### PR TITLE
Don't expose CurlWrapper in HttpRestProxy (MLDB-1200)

### DIFF
--- a/soa/service/aws.h
+++ b/soa/service/aws.h
@@ -1,9 +1,9 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* aws.h                                                           -*- C++ -*-
    Jeremy Barnes, 8 August 2013
    Copyright (c) 2013 Datacratic Inc.  All rights reserved.
 
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+   
    Amazon Web Services support code, especially signing of requests.
 */
 

--- a/soa/service/s3.cc
+++ b/soa/service/s3.cc
@@ -289,7 +289,7 @@ performSync() const
         size_t received(0);
 
         auto connection = owner->proxy.getConnection();
-        CurlWrapper::Easy & myRequest = *connection;
+        CurlWrapper::Easy & myRequest = (CurlWrapper::Easy &)(*connection);
         myRequest.reset();
 
 

--- a/soa/service/s3.h
+++ b/soa/service/s3.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* s3.h                                                            -*- C++ -*-
    Jeremy Barnes, 3 July 2012
    Copyright (c) 2012 Datacratic.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Class to deal with doing s3.
    Note: Your access key must have the listallmybuckets permission on the aws side.

--- a/utils/json_utils.h
+++ b/utils/json_utils.h
@@ -1,9 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** json_utils.h                                                   -*- C++ -*-
     Jeremy Barnes, 10 November 2013
     Copyright (c) 2013 Datacratic Inc.  All rights reserved.
 
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 */
 
 #pragma once


### PR DESCRIPTION
Simple one: we don't expose the CurlWrapper so that the HttpRestProxy can be part of our API without pulling too many extra dependencies.