### PR TITLE
Removed __int128_t from interface (MLDB-1201)

### DIFF
--- a/types/id.cc
+++ b/types/id.cc
@@ -24,6 +24,46 @@ using namespace std;
 namespace Datacratic {
 
 
+typedef __uint128_t UInt128;
+
+typedef union {
+    __uint128_t hl;
+    struct {
+        uint64_t l;
+        uint64_t h;
+    };
+} U128Repr;
+
+static inline UInt128 make128(uint64_t l, uint64_t h)
+{
+    U128Repr r;
+    r.l = l;  r.h = h;
+    return r.hl;
+}
+
+static inline uint64_t getLow(UInt128 res)
+{
+    U128Repr r;
+    r.hl = res;
+    return r.l;
+}
+
+static inline uint64_t getHigh(UInt128 res)
+{
+    U128Repr r;
+    r.hl = res;
+    return r.h;
+}
+
+static inline unsigned divmod10(UInt128 & val)
+{
+    unsigned res = val % 10;
+    val /= 10;
+    return res;
+}
+
+
+
 /*****************************************************************************/
 /* ID                                                                        */
 /*****************************************************************************/
@@ -147,7 +187,7 @@ parse(const char * value, size_t len, Type type)
 
     if ((type == UNKNOWN || type == BIGDEC) && (len == 1 && value[0] == '0')) {
         r.type = BIGDEC;
-        r.val = 0;
+        r.val1 = r.val2 = 0;
         finish();
         return;
     }
@@ -226,7 +266,7 @@ parse(const char * value, size_t len, Type type)
 
         // Google ID: --> CAESEAYra3NIxLT9C8twKrzqaA
 
-        __uint128_t res = 0;
+        auto res = make128(0, 0);
 
         auto b64Decode = [] (int c) -> int
             {
@@ -252,7 +292,8 @@ parse(const char * value, size_t len, Type type)
 
         if (!error) {
             r.type = GOOG128;
-            r.val = res;
+            r.valLow = getLow(res);
+            r.valHigh = getHigh(res);
             finish();
             return;
         }
@@ -282,17 +323,18 @@ parse(const char * value, size_t len, Type type)
                 return;
             }
             else {
-                __uint128_t res128 = res64;
+                auto res128 = make128(res64, 0);
                 for (unsigned i = maxLowLen; i < len; ++i) {
                     if (!isdigit(value[i])) {
                         error = true;
                         break;
                     }
-                    res128 = res128 * 10 + value[i] - '0';
+                    res128 = res128 * 10 + (value[i] - '0');
                 }
                 if (!error) {
                     r.type = BIGDEC;
-                    r.val = res128;
+                    r.valLow = getLow(res128);
+                    r.valHigh = getHigh(res128);
                     finish();
                     return;
                 }
@@ -316,12 +358,9 @@ parse(const char * value, size_t len, Type type)
         int64_t low  = scanRange(value + 8, 8);
 
         if (low != -1 && high != -1) {
-            __int128_t val = high;
-            val <<= 48;
-            val |= low;
-            
             r.type = BASE64_96;
-            r.val = val;
+            r.valLow = low | (high << 48);
+            r.valHigh = high >> 16;
             finish();
             return;
         }
@@ -374,7 +413,7 @@ parse(const char * value, size_t len, Type type)
     // Short string if possible
     if (len <= 16) {
         r.type = SHORTSTR;
-        val = 0;
+        val1 = val2 = 0;
         std::copy(value, value + len, r.shortStr);
         finish();
         return;
@@ -485,7 +524,7 @@ toString() const
                 throw ML::Exception("bad goog base64 char");
             };
 
-        __uint128_t v = val;
+        auto v = make128(valLow, valHigh);
         for (unsigned i = 0;  i < 21;  ++i) {
             result[25 - i] = b64Encode(v & 63);  v = v >> 6;
         }
@@ -506,11 +545,10 @@ toString() const
             }
         }
         else {
-            __uint128_t v = val;
+            auto v = make128(valLow, valHigh);
             result.reserve(32);
-            while (v) {
-                int c = v % 10;
-                v /= 10;
+            while (v != 0) {
+                int c = divmod10(v);
                 result += c + '0';
             }
         }
@@ -529,8 +567,8 @@ toString() const
                 if (i < 64) return 'a' + i - 38;
                 throw ML::Exception("bad base64 char");
             };
-
-        __uint128_t v = val;
+        
+        auto v = make128(val1, val2);
         for (unsigned i = 0;  i < 16;  ++i) {
             result[15 - i] = b64Encode(v & 63);  v = v >> 6;
         }

--- a/types/id.h
+++ b/types/id.h
@@ -17,7 +17,6 @@
 #include "mldb/types/value_description_fwd.h"
 #include <atomic>
 
-
 namespace Json {
 class Value;
 } // namespace Json
@@ -232,7 +231,7 @@ struct Id {
         if (type != other.type) return false;
         if (type == NONE || type == NULLID) return true;
         if (JML_UNLIKELY(type >= STR)) return complexEqual(other);
-        return val == other.val;  // works for SHORTSTR too
+        return val1 == other.val1 && val2 == other.val2;  // works for SHORTSTR too
     }
 
     bool operator != (const Id & other) const
@@ -247,7 +246,8 @@ struct Id {
         if (type < other.type) return true;
         if (other.type < type) return false;
         if (JML_UNLIKELY(type > STR)) return complexLess(other);
-        return val < other.val;
+        return (valHigh < other.valHigh
+                || (valHigh == other.valHigh && valLow < other.valLow));
     }
 
     bool operator > (const Id & other) const
@@ -279,16 +279,19 @@ struct Id {
     union {
         // 128 byte integer
         struct {
-            uint64_t val1;
-            uint64_t val2;
+            uint64_t val1;  // low order bits
+            uint64_t val2;  // high order bits
+        };
+
+        struct {
+            uint64_t valLow;
+            uint64_t valHigh;
         };
 
         struct {
             uint32_t v1h, v1l;
             uint32_t v2h, v2l;
         };
-
-        __uint128_t val;
 
         // uuid
         struct {

--- a/types/jml_serialization.h
+++ b/types/jml_serialization.h
@@ -142,7 +142,7 @@ inline ML::DB::Store_Reader & operator >> (ML::DB::Store_Reader & store, Id & id
         store >> s;
         if (s.length() <= 16) {
             r.type = Id::SHORTSTR;
-            r.val = 0;
+            r.val1 = r.val2 = 0;
             std::copy(s.c_str(), s.c_str() + s.length(), r.shortStr);
         }
         else {

--- a/types/testing/id_test.cc
+++ b/types/testing/id_test.cc
@@ -81,19 +81,6 @@ BOOST_AUTO_TEST_CASE( test_goog64_id )
     checkSerializeReconstitute(id);
 }
 
-/* ensures that the upper 64 bits of val are equal to val2 and the lower ones
- * to val1 */
-BOOST_AUTO_TEST_CASE( test_int128_64_union_alignment )
-{
-    Id id;
-
-    id.val = 0x0123456789abcdefLL;
-    id.val <<= 64;
-    id.val |= 0x1122334455667788;
-    BOOST_CHECK_EQUAL(id.val1, 0x1122334455667788);
-    BOOST_CHECK_EQUAL(id.val2, 0x0123456789abcdef);
-}
-
 BOOST_AUTO_TEST_CASE( test_bigdec_id )
 {
     string s = "999999999999";
@@ -192,19 +179,22 @@ BOOST_AUTO_TEST_CASE( test_id_basics )
 {
     Id id1("++++++++++++++++");
     BOOST_CHECK_EQUAL(id1.type, Id::BASE64_96);
-    BOOST_CHECK(id1.val == 0);
+    BOOST_CHECK(id1.val1 == 0);
+    BOOST_CHECK(id1.val2 == 0);
 
     Id id2("+++++++++++++++/");
     BOOST_CHECK_EQUAL(id2.type, Id::BASE64_96);
-    BOOST_CHECK(id2.val == 1);
+    BOOST_CHECK(id2.val1 == 1);
+    BOOST_CHECK(id1.val2 == 0);
 
     Id id3("+++++++++++++++0");
     BOOST_CHECK_EQUAL(id3.type, Id::BASE64_96);
-    BOOST_CHECK(id3.val == 2);
+    BOOST_CHECK(id3.val1 == 2);
+    BOOST_CHECK(id1.val2 == 0);
 
     Id id4("++++/+++++++++++");
     BOOST_CHECK_EQUAL(id4.type, Id::BASE64_96);
-    BOOST_CHECK(id4.val == __uint128_t(1) << (11 * 6));
+    BOOST_CHECK(id4.val2 == 1ULL << (11 * 6 - 64));
     BOOST_CHECK_LT(id3, id4);
 
     BOOST_CHECK_EQUAL(id1.toString().size(), id1.toStringLength());

--- a/utils/json_utils.h
+++ b/utils/json_utils.h
@@ -19,13 +19,10 @@ std::string jsonPrintAbbreviated(const Json::Value & val,
                                  int maxCharsPerItem = 100,
                                  int maxCharsOverall = -1);
 
-typedef __int128_t int128_t;
-
 /** Type used for the seed of a hash. */
 union HashSeed {
     char b[16];
     int64_t i64[2];
-    __int128_t i128;
 };
 
 /** Hash seed used by default for hashes that need to be stable over


### PR DESCRIPTION
This hoists the non-standard type (which is also not available on 32 bit machines or some compilers) out of the header files, and into implementation files.
