### PR TITLE
MLDB-1212 csv import long quoted lines

### DIFF
--- a/plugins/csv_dataset.cc
+++ b/plugins/csv_dataset.cc
@@ -1,9 +1,9 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** csv_dataset.cc
     Jeremy Barnes, 11 June 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
 
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+    
     Dataset that reads a tabular CSV file into an indexed dataset.
 */
 
@@ -408,12 +408,31 @@ parseFixedWidthCsvRow(const char * & line,
         }
         else if (c == quote) {
             // quoted string
-            static constexpr size_t STRLEN = 4096;
-            char s[STRLEN];  // holds the extracted string
+            static constexpr size_t FIXED_BUF_LEN = 4096;
+            char sbuf[FIXED_BUF_LEN];  // holds the extracted string
+            char * s = sbuf;
+            size_t buflen = FIXED_BUF_LEN;
+            std::unique_ptr<char[]> sdynamic;
             int len = 0;   // and its length
 
             bool eightBit = false;
             bool ok = false;
+
+            auto pushChar = [&] (char c)
+                {
+                    if (len == buflen) {
+                        std::unique_ptr<char[]> newBuf(new char[buflen * 2]);
+                        std::copy(s, s + len, newBuf.get());
+                        sdynamic.swap(newBuf);
+                        s = sdynamic.get();
+                        buflen *= 2;
+                    }
+
+                    
+                    ExcAssertLess(len, buflen);
+                    eightBit = eightBit || !isascii(c);
+                    s[len++] = c;
+                };
 
             for (; line < lineEnd;  ++line) {
                 c = *line;
@@ -431,8 +450,7 @@ parseFixedWidthCsvRow(const char * & line,
                     }
                     else if (*line == quote) {
                         // doubled quote; take a literal value
-                        ExcAssertLess(len, STRLEN);
-                        s[len++] = quote;
+                        pushChar(quote);
                     }
                     else {
                         // Error
@@ -440,16 +458,8 @@ parseFixedWidthCsvRow(const char * & line,
                         break;
                     }
                 }
-                else if (isascii(c)) {
-                    // Normal character set
-                    ExcAssertLess(len, STRLEN);
-                    s[len++] = c;
-                }
                 else {
-                    // Non-ascii character
-                    ExcAssertLess(len, STRLEN);
-                    eightBit = true;
-                    s[len++] = c;
+                    pushChar(c);
                 }
             }
 

--- a/testing/MLDB-1212_csv_import_long_quoted_lines.py
+++ b/testing/MLDB-1212_csv_import_long_quoted_lines.py
@@ -1,0 +1,25 @@
+
+import json, random, datetime, os
+
+    
+with open("tmp/broken_csv.csv", 'wb') as f:
+    f.write("a,b\n")
+    f.write("1,\"" + " ".join(["word " for x in xrange(50)])+"\"\n")
+    f.write("1,\"" + " ".join(["word " for x in xrange(100)])+"\"\n")
+    f.write("1,\"" + " ".join(["word " for x in xrange(1000)])+"\"\n")
+    
+result = mldb.perform("PUT", "/v1/datasets/x", [], {
+    "type": "text.csv.tabular",
+    "params": {
+        "dataFileUrl": "file://tmp/broken_csv.csv",
+        "ignoreBadLines": False
+    }
+})
+mldb.log(result)
+
+assert result["statusCode"] == 201
+jsRez = json.loads(result['response'])
+mldb.log(jsRez)
+
+mldb.script.set_return("success")
+

--- a/testing/MLDB-1212_csv_import_long_quoted_lines.py
+++ b/testing/MLDB-1212_csv_import_long_quoted_lines.py
@@ -7,6 +7,7 @@ with open("tmp/broken_csv.csv", 'wb') as f:
     f.write("1,\"" + " ".join(["word " for x in xrange(50)])+"\"\n")
     f.write("1,\"" + " ".join(["word " for x in xrange(100)])+"\"\n")
     f.write("1,\"" + " ".join(["word " for x in xrange(1000)])+"\"\n")
+    f.write("1,\"" + " ".join(["word " for x in xrange(10000)])+"\"\n")
     
 result = mldb.perform("PUT", "/v1/datasets/x", [], {
     "type": "text.csv.tabular",
@@ -20,6 +21,14 @@ mldb.log(result)
 assert result["statusCode"] == 201
 jsRez = json.loads(result['response'])
 mldb.log(jsRez)
+
+result = mldb.perform("GET", "/v1/query", [["q", "select tokenize(b, {splitchars: ' '}) as cnt from x order by rowName() ASC"]])
+jsRez = json.loads(result['response'])
+mldb.log(jsRez)
+
+answers = {2: 50, 3: 100, 4: 1000, 5: 10000}
+for row in jsRez:
+    assert answers[row["rowName"]] == row["columns"][0][1]
 
 mldb.script.set_return("success")
 

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -250,6 +250,7 @@ $(eval $(call mldb_unit_test,MLDB-1119_pooling_function.py))
 $(eval $(call mldb_unit_test,MLDB-1172_column_expr_fail.py))
 $(eval $(call mldb_unit_test,MLDB-1104-input-data-spec.py))
 $(eval $(call mldb_unit_test,MLDB-1190_segfault_sqlexpr_jseval.py))
+$(eval $(call mldb_unit_test,MLDB-1212_csv_import_long_quoted_lines.py))
 
 $(eval $(call mldb_unit_test,pytanic_plugin_test.py))
 $(eval $(call python_test,mldb_merged_dataset_test,mldb_py_runner))


### PR DESCRIPTION
Fixes issues with parsing quoted CSV fields longer than 4096 bytes.

@mailletf FYI