### PR TITLE
Removed Parse_Context include from Date class (MLDB-1215)

### DIFF
--- a/plugins/classifier.cc
+++ b/plugins/classifier.cc
@@ -26,6 +26,7 @@
 #include "mldb/plugins/sql_config_validator.h"
 #include "mldb/plugins/sql_expression_extractors.h"
 #include "mldb/vfs/fs_utils.h"
+#include "mldb/vfs/filter_streams.h"
 #include "mldb/ml/jml/training_data.h"
 #include "mldb/ml/jml/training_index.h"
 #include "mldb/ml/jml/classifier_generator.h"
@@ -562,8 +563,8 @@ run(const ProcedureRunConfig & run,
     }
     else {
         ML::filter_istream stream(runProcConf.configurationFile.size() > 0 ?
-                                    runProcConf.configurationFile :
-                                    "/opt/bin/classifiers.json");
+                                  runProcConf.configurationFile :
+                                  "/opt/bin/classifiers.json");
         classifierConfig = jsonDecodeStream<ML::Configuration>(stream);
     }
 

--- a/plugins/csv_dataset.cc
+++ b/plugins/csv_dataset.cc
@@ -29,6 +29,7 @@
 #include "mldb/server/dataset_context.h"
 #include "mldb/server/per_thread_accumulator.h"
 #include "mldb/server/parallel_merge_sort.h"
+#include "mldb/base/parse_context.h"
 #include <mutex>
 
 using namespace std;

--- a/plugins/lang/js/mldb_js.cc
+++ b/plugins/lang/js/mldb_js.cc
@@ -20,6 +20,7 @@
 #include <boost/random/variate_generator.hpp>
 
 #include "mldb/vfs/fs_utils.h"
+#include "mldb/vfs/filter_streams.h"
 #include "mldb/utils/json_diff.h"
 #include "mldb/types/map_description.h"
 

--- a/plugins/lang/python/callback.h
+++ b/plugins/lang/python/callback.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** callback.h                                 -*- C++ -*-
     Rémi Attab, 16 Jan 2013
     Copyright (c) 2013 Datacratic.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     std::function and std::function compatible python callbacks.
 
@@ -20,12 +20,10 @@
     Not ideal, but that's life.
 */
 
-#ifndef __recoset__callback_h__
-#define __recoset__callback_h__
-
+#pragma once
 
 #include <boost/python.hpp>
-
+#include <iostream>
 
 namespace Datacratic {
 namespace Python {
@@ -115,10 +113,5 @@ private:
 
 } // namespace Python
 } // Datacratic
-
-
-#endif // __recoset__callback_h__
-
-
 
 // * I always wanted to do that.

--- a/plugins/lang/python/python_converters.cc
+++ b/plugins/lang/python/python_converters.cc
@@ -8,7 +8,7 @@
 #include "python_converters.h"
 #include "Python.h"
 #include "datetime.h"
-
+#include <iostream>
 
 using namespace std;
 

--- a/plugins/lang/python/python_plugin_context.cc
+++ b/plugins/lang/python/python_plugin_context.cc
@@ -11,6 +11,7 @@
 #include "mldb/jml/utils/string_functions.h"
 #include "mldb/plugins/for_each_line.h"
 #include "mldb/vfs/fs_utils.h"
+#include "mldb/vfs/filter_streams.h"
 #include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <memory>

--- a/plugins/nlp.cc
+++ b/plugins/nlp.cc
@@ -12,6 +12,7 @@
 #include "mldb/server/function_contexts.h"
 #include "mldb/types/any_impl.h"
 #include "mldb/sql/tokenize.h"
+#include "mldb/base/parse_context.h"
 
 using namespace std;
 

--- a/plugins/sentiwordnet.cc
+++ b/plugins/sentiwordnet.cc
@@ -13,6 +13,7 @@
 #include "mldb/types/structure_description.h"
 #include "mldb/types/any_impl.h"
 #include "mldb/vfs/fs_utils.h"
+#include "mldb/vfs/filter_streams.h"
 #include "mldb/jml/stats/distribution.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>

--- a/plugins/sql_functions.cc
+++ b/plugins/sql_functions.cc
@@ -95,8 +95,6 @@ SqlQueryFunction(MldbServer * owner,
     : Function(owner)
 {
     functionConfig = config.params.convert<SqlQueryFunctionConfig>();
-
-    SqlExpressionMldbContext context(owner);
 }
 
 Any

--- a/plugins/sql_functions.h
+++ b/plugins/sql_functions.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** sql_functions.h                                               -*- C++ -*-
     Jeremy Barnes, 6 January 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Functions to deal with datasets.
 */

--- a/plugins/tsne.cc
+++ b/plugins/tsne.cc
@@ -28,6 +28,7 @@
 #include "mldb/sql/sql_expression.h"
 #include "mldb/server/analytics.h"
 #include "mldb/vfs/fs_utils.h"
+#include "mldb/vfs/filter_streams.h"
 #include "mldb/types/jml_serialization.h"
 
 using namespace std;

--- a/plugins/word2vec.cc
+++ b/plugins/word2vec.cc
@@ -11,6 +11,7 @@
 #include "mldb/types/structure_description.h"
 #include "mldb/types/any_impl.h"
 #include "mldb/vfs/fs_utils.h"
+#include "mldb/vfs/filter_streams.h"
 #include "mldb/jml/stats/distribution.h"
 #include <boost/algorithm/string.hpp>
 

--- a/plugins/xlsx_importer.cc
+++ b/plugins/xlsx_importer.cc
@@ -13,6 +13,7 @@
 #include "mldb/types/value_description.h"
 #include "mldb/types/structure_description.h"
 #include "mldb/vfs/fs_utils.h"
+#include "mldb/vfs/filter_streams.h"
 #include "mldb/types/any_impl.h"
 #include "mldb/http/http_exception.h"
 #include "mldb/ext/tinyxml2/tinyxml2.h"

--- a/server/mldb_server.cc
+++ b/server/mldb_server.cc
@@ -26,6 +26,7 @@
 #include "mldb/server/function_collection.h"
 #include "mldb/server/dataset_context.h"
 #include "mldb/vfs/fs_utils.h"
+#include "mldb/vfs/filter_streams.h"
 #include "mldb/server/analytics.h"
 #include "mldb/types/meta_value_description.h"
 

--- a/server/script_output.h
+++ b/server/script_output.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** script_output.h                                                -*- C++ -*-
     Jeremy Barnes, 13 October 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Common definitions for the output of scripts.  Used to enforce some
     commonality over the different languages available.
@@ -13,6 +13,7 @@
 #include "mldb/types/string.h"
 #include "mldb/types/date.h"
 #include "mldb/ext/jsoncpp/json.h"
+#include "mldb/arch/exception.h"
 #include <vector>
 
 #pragma once

--- a/soa/service/archive.cc
+++ b/soa/service/archive.cc
@@ -11,6 +11,8 @@
 #include "mldb/vfs/fs_utils.h"
 #include "mldb/base/scope.h"
 #include "mldb/vfs/filter_streams_registry.h"
+#include "mldb/arch/exception.h"
+#include <sstream>
 
 // libarchive support
 #include <archive.h>

--- a/soa/service/async_event_source.cc
+++ b/soa/service/async_event_source.cc
@@ -10,6 +10,7 @@
 #include "mldb/arch/futex.h"
 #include <iostream>
 #include "message_loop.h"
+#include <cstring>
 
 
 using namespace std;

--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -16,6 +16,7 @@
 #include "mldb/types/vector_description.h"
 #include "mldb/ml/confidence_intervals.h"
 #include "mldb/jml/math/xdiv.h"
+#include "mldb/base/parse_context.h"
 
 #include <boost/regex/icu.hpp>
 

--- a/sql/cell_value.cc
+++ b/sql/cell_value.cc
@@ -14,6 +14,7 @@
 #include "mldb/types/structure_description.h"
 #include "mldb/types/enum_description.h"
 #include "cell_value_impl.h"
+#include "mldb/base/parse_context.h"
 #include "interval.h"
 
 using namespace std;

--- a/types/date.h
+++ b/types/date.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* date.h                                                          -*- C++ -*-
    Jeremy Barnes, 18 July 2010
    Copyright (c) 2010 Datacratic.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Basic class that holds and manipulates a date.  Not designed for ultimate
    accuracy, but shouldn't be too bad.
@@ -12,7 +12,7 @@
 
 #include <chrono>
 #include <string>
-#include "mldb/base/parse_context.h"
+#include <cmath>
 #include "value_description_fwd.h"
 
 namespace Json {
@@ -20,6 +20,10 @@ namespace Json {
 class Value;
 
 } // namespace Json
+
+namespace ML {
+struct Parse_Context;
+} // namespace ML
 
 namespace Datacratic {
 namespace JS {
@@ -458,8 +462,8 @@ from_js_ref(const JSValue & val, Date *)
 /* ISO8601PARSER                                                             */
 /*****************************************************************************/
 
-struct Iso8601Parser : public ML::Parse_Context
-{
+ struct Iso8601Parser {
+
     static Date parseDateTimeString(const std::string & dateTimeStr)
     {
         Iso8601Parser parser(dateTimeStr);
@@ -472,11 +476,9 @@ struct Iso8601Parser : public ML::Parse_Context
         return parser.expectTime();
     }
 
-    Iso8601Parser(const std::string & dateStr)
-        : Parse_Context(dateStr, dateStr.c_str(),
-                        dateStr.c_str() + dateStr.size())
-    {}
-
+     Iso8601Parser(const std::string & dateStr);
+     ~Iso8601Parser();
+     
     Date expectDateTime();
     bool matchDateTime(Date & date);
     Date expectDate();
@@ -507,7 +509,9 @@ private:
     bool matchSeconds(int & result);
     int expectTimeZoneMinutes();
     bool matchTimeZoneMinutes(int & result);
-};
+
+     std::unique_ptr<ML::Parse_Context> parser;
+ };
 
 PREDECLARE_VALUE_DESCRIPTION(Date);
 

--- a/types/testing/periodic_utils_test.cc
+++ b/types/testing/periodic_utils_test.cc
@@ -5,6 +5,7 @@
 
 #include "mldb/types/periodic_utils.h"
 #include <boost/test/unit_test.hpp>
+#include "mldb/arch/exception.h"
 
 using namespace std;
 using namespace ML;

--- a/types/testing/value_description_test.cc
+++ b/types/testing/value_description_test.cc
@@ -23,6 +23,7 @@
 #include "mldb/types/pointer_description.h"
 #include "mldb/types/date.h"
 #include "mldb/types/id.h"
+#include "mldb/base/parse_context.h"
 
 
 using namespace std;

--- a/vfs/filter_streams.h
+++ b/vfs/filter_streams.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* filter_streams.h                                                -*- C++ -*-
    Jeremy Barnes, 12 March 2005
    Copyright (c) 2005 Jeremy Barnes.  All rights reserved.
+   
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
    
    This file is part of "Jeremy's Machine Learning Library", copyright (c)
    1999-2015 Jeremy Barnes.

--- a/vfs/fs_utils.cc
+++ b/vfs/fs_utils.cc
@@ -105,7 +105,7 @@ Url makeUrl(const string & urlStr)
     }
     /* relative filenames */
     else {
-        char cCurDir[PATH_MAX + 1];
+        char cCurDir[65536]; // http://insanecoding.blogspot.ca/2007/11/pathmax-simply-isnt.html
         string filename(getcwd(cCurDir, sizeof(cCurDir)));
         filename += "/" + urlStr;
 

--- a/vfs/fs_utils.h
+++ b/vfs/fs_utils.h
@@ -1,9 +1,9 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* fs_utils.h                                                       -*- C++ -*-
    Wolfgang Sourdeau, February 2014
    Copyright (c) 2014 Datacratic.  All rights reserved.
 
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+   
    A set of file-system abstraction functions intended to support common
    operations among different fs types or alikes.
 */
@@ -12,11 +12,16 @@
 
 #include <string>
 #include <functional>
+#include <map>
 
+#include "mldb/ext/jsoncpp/value.h"
 #include "mldb/types/date.h"
 #include "mldb/types/url.h"
-#include "mldb/types/value_description.h"
-#include "filter_streams.h"
+#include "mldb/types/value_description_fwd.h"
+
+namespace ML {
+struct UriHandler;
+} // namespace ML
 
 namespace Datacratic {
 


### PR DESCRIPTION
Another simple change: value_description.h and parse_context.h were removed from the #includes for the Date class, and everything that broke was fixed.  Decouples the interfaces from the implementation and reduces compile times.