### PR TITLE
filter_stream can return object info (MLDB-1218)

### DIFF
--- a/soa/service/archive.cc
+++ b/soa/service/archive.cc
@@ -87,20 +87,20 @@ bool iterateArchive(std::streambuf * archive,
 
             switch (filetype) {
             case AE_IFREG: {
-                FsObjectInfo info;
-                info.size
+                auto info = std::make_shared<FsObjectInfo>();
+                info->size
                     = archive_entry_size_is_set(entry) ?
                     archive_entry_size(entry) : -1;
-                info.exists = true;
+                info->exists = true;
                 if (archive_entry_mtime_is_set(entry)) {
-                    info.lastModified = Date::fromSecondsSinceEpoch(archive_entry_mtime(entry) + 0.000000001 * archive_entry_mtime_nsec(entry));
+                    info->lastModified = Date::fromSecondsSinceEpoch(archive_entry_mtime(entry) + 0.000000001 * archive_entry_mtime_nsec(entry));
                 }
-                else info.lastModified = Date::notADate();
+                else info->lastModified = Date::notADate();
 
-                info.ownerId = std::to_string(archive_entry_uid(entry));
+                info->ownerId = std::to_string(archive_entry_uid(entry));
                 const char * gname = archive_entry_gname(entry);
                 if (gname)
-                    info.ownerName = gname;
+                    info->ownerName = gname;
                 //info.permissions = archive_entry_strmode(entry);
 
                 auto open = [=] (const std::map<std::string, std::string> & options)
@@ -127,10 +127,10 @@ bool iterateArchive(std::streambuf * archive,
 
                         std::shared_ptr<std::istream> result
                         (new std::istringstream(stream.str()));
-                        return ML::UriHandler(result->rdbuf(), result);
+                        return ML::UriHandler(result->rdbuf(), result, info);
                     };
 
-                return onObject(filename, info, open, 1 /* depth */);
+                return onObject(filename, *info, open, 1 /* depth */);
             }
             case AE_IFDIR: 
                 //cerr << "*** got directory " << filename << endl;

--- a/soa/service/sftp.h
+++ b/soa/service/sftp.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* sftp.h                                                          -*- C++ -*-
    Jeremy Barnes, 21 June 2012
    Copyright (c) 2012 Datacratic.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Sftp functionality.
 */

--- a/vfs/filter_streams.h
+++ b/vfs/filter_streams.h
@@ -18,8 +18,11 @@
 #include <memory>
 #include <map>
 
-namespace ML {
+namespace Datacratic {
+struct FsObjectInfo;  // Structure for file system or URL metadata; in fs_utils.h
+} // namespace Datacratic
 
+namespace ML {
 
 /*****************************************************************************/
 /* BASE STRUCTURES                                                           */
@@ -61,15 +64,23 @@ struct UriHandler {
 
     UriHandler(std::streambuf * buf,
                std::shared_ptr<void> bufOwnership,
+               std::shared_ptr<Datacratic::FsObjectInfo> info = nullptr,
                UriHandlerOptions options = UriHandlerOptions())
         : buf(buf),
           bufOwnership(std::move(bufOwnership)),
+          info(std::move(info)),
           options(std::move(options))
     {
     }
                      
+    UriHandler(std::streambuf * buf,
+               std::shared_ptr<void> bufOwnership,
+               const Datacratic::FsObjectInfo & info,
+               UriHandlerOptions options = UriHandlerOptions());
+    
     std::streambuf * buf;                ///< Streambuf to operate on
     std::shared_ptr<void> bufOwnership;  ///< Ownership of the stream buffer
+    std::shared_ptr<Datacratic::FsObjectInfo> info;  ///< Known information/metadata
     UriHandlerOptions options;
 };    
 
@@ -275,6 +286,11 @@ public:
     */
     std::pair<const char *, size_t>
     mapped() const;
+
+    /** Return the information and metadata about the underlying object,
+        for example last modified date, etc.
+    */
+    Datacratic::FsObjectInfo info() const;
     
 private:
     std::unique_ptr<std::istream> stream;
@@ -283,6 +299,7 @@ private:
     std::shared_ptr<void> sink;            ///< Ownership of streambuf
     std::atomic<bool> deferredFailure;
     std::string resource;
+    std::shared_ptr<Datacratic::FsObjectInfo> info_;
 };
 
 

--- a/vfs/fs_utils.cc
+++ b/vfs/fs_utils.cc
@@ -346,8 +346,9 @@ struct LocalUrlFsHandler : public UrlFsHandler {
                         if (!options.empty())
                             throw ML::Exception("Options not accepted by S3");
 
-                        std::shared_ptr<std::istream> result(new ML::filter_istream(filename));
-                        return ML::UriHandler(result->rdbuf(), std::move(result));
+                        std::shared_ptr<std::istream> result(new ML::filter_istream(filename, options));
+                        return ML::UriHandler(result->rdbuf(), std::move(result),
+                                              getInfo(Url(filename)));
                     };
                     
                     result = onObject(filename,

--- a/vfs/testing/filter_streams_test.cc
+++ b/vfs/testing/filter_streams_test.cc
@@ -14,6 +14,7 @@
 
 #include "mldb/jml/utils/file_functions.h"
 #include "mldb/vfs/filter_streams.h"
+#include "mldb/vfs/fs_utils.h"
 #include "mldb/vfs/filter_streams_registry.h"
 #include "mldb/arch/exception.h"
 #include "mldb/arch/exception_handler.h"
@@ -447,8 +448,9 @@ struct RegisterExcHandlers {
         handler.reset(new boost::iostreams::stream_buffer<ExceptionSource>
                       (ExceptionSource(onException, throwType),
                        1));
-
-        return UriHandler(handler.get(), handler);
+        Datacratic::FsObjectInfo info;
+        info.exists = true;
+        return UriHandler(handler.get(), handler, info);
     }
 
     static UriHandler


### PR DESCRIPTION
Provides access to information and metadata (etag, permissions, size, etc) that is already known for most implementations without requiring a separate, non-atomic call to getUriObjectInfo.
