### PR TITLE
Added back in try_lock to spinlock (MLDB-1218)

### DIFF
--- a/arch/arch.mk
+++ b/arch/arch.mk
@@ -19,7 +19,9 @@ LIBARCH_SOURCES := \
 	info.cc \
 	rtti_utils.cc \
 	rt.cc \
-	abort.cc
+	abort.cc \
+	spinlock.cc \
+
 
 LIBARCH_LINK := dl
 

--- a/arch/spinlock.cc
+++ b/arch/spinlock.cc
@@ -1,0 +1,22 @@
+/** spinlock.cc
+    Jeremy Barnes, 23 December 2015
+    Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+    Spinlock support functions.
+*/
+
+#include "spinlock.h"
+#include <thread>
+
+namespace ML {
+
+void
+Spinlock::
+yield()
+{
+    std::this_thread::yield();
+}
+
+} // namespace ML


### PR DESCRIPTION
This replaces #33 with a simpler implementation.  There were external plugins that were using the exposed try_lock() method, so it's been added back in.
