### PR TITLE
Mldb 1226 persist model

### DIFF
--- a/container_files/assets/www/doc/builtin/functions/Tfidf.md
+++ b/container_files/assets/www/doc/builtin/functions/Tfidf.md
@@ -30,10 +30,10 @@ The types of IDF weighting schemes are:
 | *weighting scheme* | *description* | *IDF weight*  |
 |--------------------|---------------|--------------|
 | `unary` | unary IDF score, i.e. don't use IDF | \\( 1 \\) |
-| `inverse` | the logarithm of the number of documents in the corpus divided by the number of documents the term appears in | \\( \log \left( \frac {N}{1 + n_t } \right) \\) |
-| `inverseSmooth` | similar to `inverse` but with logarithmic terms above 1 | \\( \log \left( 1 + \frac {N}{1 + n_t } \right) \\) |
+| `inverse` | the logarithm of the number of documents in the corpus divided by the number of documents the term appears in (this will lead to negative scores for terms appearing in all documents in the corpus) | \\( \log \left( \frac {N}{1 + n_t } \right) \\) |
+| `inverseSmooth` | similar to `inverse` but with 1 added to the logarithmic term (this ensures that the score will never be negative) | \\( \log \left( 1 + \frac {N}{1 + n_t } \right) \\) |
 | `inverseMax` | similar to `inverseSmooth` but using the maximum term frequency | \\( \log \left(1 + \frac {\max_{\{t' \in d\}} n_{t'}} {1 + n_t}\right)  \\)
-| `probabilisticInverse` | similar to `inverse` but substracting the number of documents the term appears in from the total number of documents | \\(  \log \left( \frac {N - n_t} {1 + n_t} \right) \\)
+| `probabilisticInverse` | similar to `inverse` but substracting the number of documents the term appears in from the total number of documents in the training corpus (this can leads to positive and negative scores) | \\(  \log \left( \frac {N - n_t} {1 + n_t} \right) \\)
 
 
 ## Input and Output Values

--- a/container_files/assets/www/doc/builtin/functions/Tfidf.md
+++ b/container_files/assets/www/doc/builtin/functions/Tfidf.md
@@ -33,7 +33,7 @@ The types of IDF weighting schemes are:
 | `inverse` | the logarithm of the number of documents in the corpus divided by the number of documents the term appears in (this will lead to negative scores for terms appearing in all documents in the corpus) | \\( \log \left( \frac {N}{1 + n_t } \right) \\) |
 | `inverseSmooth` | similar to `inverse` but with 1 added to the logarithmic term (this ensures that the score will never be negative) | \\( \log \left( 1 + \frac {N}{1 + n_t } \right) \\) |
 | `inverseMax` | similar to `inverseSmooth` but using the maximum term frequency | \\( \log \left(1 + \frac {\max_{\{t' \in d\}} n_{t'}} {1 + n_t}\right)  \\)
-| `probabilisticInverse` | similar to `inverse` but substracting the number of documents the term appears in from the total number of documents in the training corpus (this can leads to positive and negative scores) | \\(  \log \left( \frac {N - n_t} {1 + n_t} \right) \\)
+| `probabilisticInverse` | similar to `inverse` but substracting the number of documents the term appears in from the total number of documents in the training corpus (this can lead to positive and negative scores) | \\(  \log \left( \frac {N - n_t} {1 + n_t} \right) \\)
 
 
 ## Input and Output Values

--- a/ml/kmeans.h
+++ b/ml/kmeans.h
@@ -1,10 +1,9 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 // -*- C++ -*-
 // kmeans.h
 // Simon Lemieux - 20 Jun 2013
 // Copyright (c) 2013 Datacratic. All rights reserved.
 // 
+// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
 #pragma once
 

--- a/plugins/classifier.cc
+++ b/plugins/classifier.cc
@@ -158,9 +158,9 @@ run(const ProcedureRunConfig & run,
     ClassifierConfig runProcConf =
         applyRunConfOverProcConf(procedureConfig, run);
 
-
-    if(runProcConf.modelFileUrl.toString().empty()) {
-        throw ML::Exception("modelFileUrl cannot be empty");
+    // this includes being empty
+    if(!runProcConf.modelFileUrl.valid()) {
+        throw ML::Exception("modelFileUrl is not valid");
     }
 
     // 1.  Get the input dataset

--- a/plugins/kmeans.h
+++ b/plugins/kmeans.h
@@ -29,14 +29,14 @@ struct KmeansConfig : public ProcedureConfig {
           maxIterations(100),
           metric(METRIC_COSINE)
     {
-        centroids.withType("embedding");
     }
 
     InputQuery trainingData;
+    Url modelFileUrl;
     Optional<PolyConfigT<Dataset> > output;
+    Optional<PolyConfigT<Dataset> > centroids;
     static constexpr char const * defaultOutputDatasetType = "embedding";
 
-    PolyConfigT<Dataset> centroids;
     int numInputDimensions;
     int numClusters;
     int maxIterations;
@@ -73,14 +73,8 @@ struct KmeansProcedure: public Procedure {
 /*****************************************************************************/
 
 struct KmeansFunctionConfig {
-    KmeansFunctionConfig()
-        : metric(METRIC_COSINE)
-    {
-    }
     
-    PolyConfigT<Dataset> centroids;       ///< Dataset containing the centroids
-    MetricSpace metric;                   ///< Actual metric
-    InputQuery inputData;                 ///< What to select from dataset
+    Url modelFileUrl;
 };
 
 DECLARE_STRUCTURE_DESCRIPTION(KmeansFunctionConfig);
@@ -99,14 +93,12 @@ struct KmeansFunction: public Function {
     virtual FunctionInfo getFunctionInfo() const;
     
     KmeansFunctionConfig functionConfig;
-    std::vector<ColumnName> columnNames;
 
-    struct Cluster {
-        CellValue clusterName;
-        ML::distribution<float> centroid;
-    };
+    // holds the dimension of the embedding space
+    size_t dimension;
 
-    std::vector<Cluster> clusters;
+    struct Impl;
+    std::unique_ptr<Impl> impl;
 };
 
 } // namespace MLDB

--- a/plugins/tfidf.cc
+++ b/plugins/tfidf.cc
@@ -353,21 +353,21 @@ apply(const FunctionApplier & applier,
     }
 
     // the different possible IDF scores
-    auto idf_unary = [=] (uint64_t numberOfRelevantDoc) {
+    auto idf_unary = [=] (double numberOfRelevantDoc) {
         return 1.0f;
     };
 
-    auto idf_inverse = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log((double) corpusSize / (1 + numberOfRelevantDoc));
+    auto idf_inverse = [=] (double numberOfRelevantDoc) {
+        return std::log(corpusSize / (1 + numberOfRelevantDoc));
     };
-    auto idf_inverseSmooth = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log(1 + ((double) corpusSize / (1 + numberOfRelevantDoc)));
+    auto idf_inverseSmooth = [=] (double numberOfRelevantDoc) {
+        return std::log(1 + (corpusSize / (1 + numberOfRelevantDoc)));
     };
-    auto idf_inverseMax = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log(1 + (double) (maxNt) / (1 +  numberOfRelevantDoc));
+    auto idf_inverseMax = [=] (double numberOfRelevantDoc) {
+        return std::log(1 + (maxNt) / (1 +  numberOfRelevantDoc));
     };
-    auto idf_probabilistic_inverse = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log((double) (corpusSize - numberOfRelevantDoc) / (1 + numberOfRelevantDoc));
+    auto idf_probabilistic_inverse = [=] (double numberOfRelevantDoc) {
+        return std::log((corpusSize - numberOfRelevantDoc) / (1 + numberOfRelevantDoc));
     };
 
     std::function<double(double)> idf_fct = idf_unary;

--- a/plugins/tfidf.cc
+++ b/plugins/tfidf.cc
@@ -358,16 +358,16 @@ apply(const FunctionApplier & applier,
     };
 
     auto idf_inverse = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log(corpusSize / (1 + numberOfRelevantDoc));
+        return std::log((double) corpusSize / (1 + numberOfRelevantDoc));
     };
     auto idf_inverseSmooth = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log(1 + (corpusSize / (1 + numberOfRelevantDoc)));
+        return std::log(1 + ((double) corpusSize / (1 + numberOfRelevantDoc)));
     };
     auto idf_inverseMax = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log(1 + (maxNt)/ (1 +  numberOfRelevantDoc));
+        return std::log(1 + (double) (maxNt) / (1 +  numberOfRelevantDoc));
     };
     auto idf_probabilistic_inverse = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log((corpusSize - numberOfRelevantDoc) / (1 + numberOfRelevantDoc));
+        return std::log((double) (corpusSize - numberOfRelevantDoc) / (1 + numberOfRelevantDoc));
     };
 
     std::function<double(double)> idf_fct = idf_unary;
@@ -394,16 +394,19 @@ apply(const FunctionApplier & applier,
     Date ts = inputVal.getEffectiveTimestamp();
 
     // Compute the score for every word in the input
+    //cerr << "corpus size " << corpusSize << " document size " << documentSize << endl;
+
     for (auto& col : inputVal.getRow() ) {
         Utf8String term = std::get<0>(col).toUtf8String(); // the term is the columnName
+        double frequency = (double) std::get<1>(col).getAtom().toUInt() / documentSize;
 
-        double frequency = std::get<1>(col).getAtom().toUInt() / documentSize;
         double tf = tf_fct(frequency);
         const auto docFrequency = dfs.find(term);
         double idf = (docFrequency != dfs.end() 
                       ? idf_fct(docFrequency->second) 
                       : idf_fct(0)); 
 
+        //cerr << term << " tf " << tf << " idf " << idf << endl;
         values.emplace_back(std::get<0>(col),
                             tf*idf,
                             ts);

--- a/plugins/tfidf.cc
+++ b/plugins/tfidf.cc
@@ -292,20 +292,20 @@ apply(const FunctionApplier & applier,
     }
 
     // the different possible IDF scores
-    auto idf_unary = [=] (unsigned long long numberOfRelevantDoc) {
+    auto idf_unary = [=] (uint64_t numberOfRelevantDoc) {
         return 1.0f;
     };
-    auto idf_inverse = [=] (unsigned long long numberOfRelevantDoc) {
-        return std::log(N / std::max(1ULL, numberOfRelevantDoc));
+    auto idf_inverse = [=] (uint64_t numberOfRelevantDoc) {
+        return std::log(N / (1 + numberOfRelevantDoc));
     };
-    auto idf_inverseSmooth = [=] (unsigned long long numberOfRelevantDoc) {
-        return std::log(1 + (N / std::max(1ULL, numberOfRelevantDoc)));
+    auto idf_inverseSmooth = [=] (uint64_t numberOfRelevantDoc) {
+        return std::log(1 + (N / (1 + numberOfRelevantDoc)));
     };
-    auto idf_inverseMax = [=] (unsigned long long numberOfRelevantDoc) {
-        return std::log(1 + (maxNt)/ std::max(1ULL, numberOfRelevantDoc));
+    auto idf_inverseMax = [=] (uint64_t numberOfRelevantDoc) {
+        return std::log(1 + (maxNt)/ (1 +  numberOfRelevantDoc));
     };
-    auto idf_probabilistic_inverse = [=] (unsigned long long numberOfRelevantDoc) {
-        return std::log((N - numberOfRelevantDoc) / std::max(1ULL, numberOfRelevantDoc));
+    auto idf_probabilistic_inverse = [=] (uint64_t numberOfRelevantDoc) {
+        return std::log((N - numberOfRelevantDoc) / (1 + numberOfRelevantDoc));
     };
 
     std::function<double(double)> idf_fct = idf_unary;

--- a/plugins/tfidf.cc
+++ b/plugins/tfidf.cc
@@ -1,9 +1,9 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** tfidf.cc
     Mathieu Marquis Bolduc, November 27th, 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
 
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+    
     Implementation of TF-IDF algorithm
 */
 
@@ -12,7 +12,6 @@
 #include "mldb/server/mldb_server.h"
 #include "mldb/core/dataset.h"
 #include "mldb/jml/stats/distribution.h"
-#include <boost/multi_array.hpp>
 #include "mldb/jml/utils/guard.h"
 #include "mldb/jml/utils/worker_task.h"
 #include "mldb/jml/utils/pair_utils.h"
@@ -23,9 +22,73 @@
 #include "mldb/server/analytics.h"
 #include "mldb/types/any_impl.h"
 #include "mldb/types/optional_description.h"
+#include "mldb/vfs/filter_streams.h"
 
 using namespace std;
 
+namespace {
+void
+serialize(ML::DB::Store_Writer & store, 
+          uint64_t corpusSize, 
+          const std::unordered_map<Datacratic::Utf8String, uint64_t> & dfs)
+{
+    std::string name = "tfidf";
+    int version = 0;
+    store << name << version;
+    store << corpusSize;
+    for (auto & df : dfs) {
+        store << df.first.rawString();
+        store << df.second;
+    }
+}
+
+void
+reconstitute(ML::DB::Store_Reader & store, 
+             uint64_t & corpusSize,
+             std::unordered_map<Datacratic::Utf8String, uint64_t> & dfs)
+{
+    std::string name;
+    store >> name;
+    if (name != "tfidf")
+        throw ML::Exception("invalid name when loading a tf-idf object");
+
+    int version;
+    store >> version;
+    if (version != 0)
+        throw ML::Exception("invalid tf-idf version");
+
+    store >> corpusSize;
+    dfs.clear();
+    dfs.reserve(corpusSize);
+    for (int i=0; i < corpusSize; ++i) {
+        std::string term;
+        uint64_t df;
+        store >> term;
+        store >> df;
+        dfs[term] = df;
+    }
+}
+
+void
+save(const std::string & filename,
+     uint64_t corpusSize, 
+     const std::unordered_map<Datacratic::Utf8String, uint64_t> & dfs)
+{
+    ML::filter_ostream stream(filename);
+    ML::DB::Store_Writer store(stream);
+    serialize(store, corpusSize, dfs);
+}
+
+void
+load(const std::string & filename,
+     uint64_t & corpusSize, 
+     std::unordered_map<Datacratic::Utf8String, uint64_t> & dfs)
+{
+    ML::filter_istream stream(filename);
+    ML::DB::Store_Reader store(stream);
+    reconstitute(store, corpusSize, dfs);
+}
+}
 
 namespace Datacratic {
 namespace MLDB {
@@ -38,7 +101,7 @@ TFTypeDescription()
 {
     addValue("raw", TF_raw, "Use raw TF score, the frequency the term appears in the document.");
     addValue("log", TF_log, "Use logarithmic TF score, the logarithm of the frequency the term appears in the document.");
-    addValue("augmented", TF_augmented, "Use augmented TF Score, the half-frequency the term appears in the document divided by the maximum frequency of any term in the document.");
+    addValue("augmented", TF_augmented, "Use augmented TF score, the half-frequency the term appears in the document divided by the maximum frequency of any term in the document.");
 }
 
 IDFTypeDescription::
@@ -61,15 +124,38 @@ TfidfConfigDescription()
                      withType(TfidfConfig::defaultOutputDatasetType));
     
     addField("trainingData", &TfidfConfig::trainingData,
-             "An SQL query to provided for input to the tfidf procedure."
-             "Returns the list of terms for each document.");
+             "An SQL query to provide for input to the tfidf procedure."
+             "Each row represents the terms in a given document.  Note that "
+             "the procedure will not modify the terms in any ways. "
+             "As an example, terms with different capitalization 'Montreal', "
+             "'montreal' or with accented characters 'Montréal' "
+             "will all be considered as different terms.");
+    addField("modelFileUrl", &TfidfConfig::modelFileUrl,
+             "URL where the model file (with extension '.idf') should be saved. "
+             "This file can be loaded by a function of type 'tfidf' to compute "
+             "the tf-idf of a given term. "
+             "If someone is only interested in the number of documents the "
+             "terms in the training input appear in then the parameter can be "
+             "omitted and the outputDataset param can be provided instead.");
     addField("outputDataset", &TfidfConfig::output,
              "Output dataset.  This dataset will contain a single row "
-             "containing the number of documents each term appears in");
+             "containing the number of documents each term appears in.",
+             optional);
     addField("functionName", &TfidfConfig::functionName,
              "If specified, a function of this name will be created using "
-             "the training result.");
+             "the training model.  Note that the 'modelFileUrl' must "
+             "also be provided.");
     addParent<ProcedureConfig>();
+
+    onPostValidate = [] (TfidfConfig * cfg, 
+                         JsonParsingContext & context) {
+        // to create a function we need access to a model
+        if(!cfg->modelFileUrl.valid() && !cfg->functionName.empty()) {
+            throw ML::Exception("modelFileUrl \"" + cfg->modelFileUrl.toString() 
+                                + "\" is not valid.  A valid modelFileUrl parameter "
+                                + "is required to create a function.");
+        }
+    };
 }
 
 
@@ -105,13 +191,13 @@ run(const ProcedureRunConfig & run,
     auto boundDataset = runProcConf.trainingData.stm->from->bind(context);
 
     //This will cummulate the number of documents each word is in 
-    std::unordered_map<Utf8String, int> bagOfWords;
+    std::unordered_map<Utf8String, uint64_t> dfs;
 
     auto aggregator = [&] (const MatrixNamedRow & row)
         {
-            for (auto& col : row.columns) {                
+            for (auto& col : row.columns) {            
                 Utf8String word = get<0>(col).toUtf8String();
-                bagOfWords[word] += 1;               
+                dfs[word] += 1;               
             }
 
             return true;
@@ -126,33 +212,48 @@ run(const ProcedureRunConfig & run,
                    runProcConf.trainingData.stm->limit,
                    onProgress);     
 
-    PolyConfigT<Dataset> outputDataset = runProcConf.output;
-    if (outputDataset.type.empty())
-        outputDataset.type = TfidfConfig::defaultOutputDatasetType;
-
-    auto output = createDataset(server, outputDataset, onProgress, true /*overwrite*/);
-
-    Date applyDate = Date::now();
-
-    std::vector<std::tuple<ColumnName, CellValue, Date> > row;
-    row.reserve(bagOfWords.size());
-
-    for (auto& val : bagOfWords) {
-        row.emplace_back(ColumnName(val.first), val.second/* / (float)count*/, applyDate);
+    bool saved = false;
+    if (!runProcConf.modelFileUrl.empty()) {
+        save(runProcConf.modelFileUrl.toString(), dfs.size(), dfs);
+        saved = true;
     }
 
-    output->recordRow(RowName("Number of Documents with Word"), row);        
-    output->commit();
+    if (runProcConf.output) {
+        PolyConfigT<Dataset> outputDataset = *runProcConf.output;
+        if (outputDataset.type.empty())
+            outputDataset.type = TfidfConfig::defaultOutputDatasetType;
+
+        auto output = createDataset(server, outputDataset, onProgress, true /*overwrite*/);
+
+        Date applyDate = Date::now();
+
+        std::vector<std::tuple<ColumnName, CellValue, Date> > row;
+        row.reserve(dfs.size());
+
+        for (auto& df : dfs) {
+            row.emplace_back(ColumnName(df.first), df.second/*(float)count*/, applyDate);
+        }
+
+        output->recordRow(RowName("Number of Documents with Word"), row);        
+        output->commit();
+    }
 
     if(!runProcConf.functionName.empty()) {
+        if (saved) {
+            TfidfFunctionConfig tfidfFunctionConf;
+            tfidfFunctionConf.modelFileUrl = runProcConf.modelFileUrl;
+            
+            PolyConfig tfidfFuncPC;
+            tfidfFuncPC.type = "tfidf";
+            tfidfFuncPC.id = runProcConf.functionName;
+            tfidfFuncPC.params = tfidfFunctionConf;
 
-        PolyConfig tfidfFuncPC;
-        tfidfFuncPC.type = "tfidf";
-        tfidfFuncPC.id = runProcConf.functionName;
-        tfidfFuncPC.params = TfidfFunctionConfig(runProcConf.output,
-                boundDataset.dataset->getMatrixView()->getRowCount());
-
-        obtainFunction(server, tfidfFuncPC, onProgress);
+            obtainFunction(server, tfidfFuncPC, onProgress);
+        } else {
+            throw ML::Exception("Can't create tfidf function " +
+                                runProcConf.functionName.rawString() + 
+                                " Have you provided a valid modelFileUrl?");
+        }
     }
 
     return Any();
@@ -163,15 +264,21 @@ DEFINE_STRUCTURE_DESCRIPTION(TfidfFunctionConfig);
 TfidfFunctionConfigDescription::
 TfidfFunctionConfigDescription()
 {
-    addField("dataset", &TfidfFunctionConfig::dataset,
-             "Dataset describing the number of document each term appears in. "
-             "It is generated using the tfidf.train procedure.");
-    addField("sizeOfCorpus", &TfidfFunctionConfig::N,
-             "Number of documents in the corpus");
+    addField("modelFileUrl", &TfidfFunctionConfig::modelFileUrl,
+             "An URL to a model file previously created with a 'tfidf.train' procedure.");
     addField("tfType", &TfidfFunctionConfig::tf_type,
              "Type of TF scoring", TF_log);
     addField("idfType", &TfidfFunctionConfig::idf_type,
              "Type of IDF scoring", IDF_inverse);
+
+    onPostValidate = [] (TfidfFunctionConfig * cfg, 
+                         JsonParsingContext & context) {
+        // this includes empty url
+        if(!cfg->modelFileUrl.valid()) {
+            throw ML::Exception("modelFileUrl \"" + cfg->modelFileUrl.toString() 
+                                + "\" is not valid");
+        }
+    };
 }
 
 
@@ -186,7 +293,7 @@ TfidfFunction(MldbServer * owner,
     : Function(owner)
 {
     functionConfig = config.params.convert<TfidfFunctionConfig>();
-    dataset = obtainDataset(server, functionConfig.dataset, onProgress);
+    load(functionConfig.modelFileUrl.toString(), corpusSize, dfs);
 }
 
 Any
@@ -206,65 +313,19 @@ apply(const FunctionApplier & applier,
     ExpressionValue storage;
     const ExpressionValue & inputVal = context.get("input", storage);
 
-    SelectExpression select;
-    size_t documentCount = 0;
-    double maxFrequency = 0;
-
-    select.clauses.reserve(inputVal.getRow().size());
+    uint64_t maxFrequency = 0; // max term frequency for the current document
+    uint64_t documentSize = 0; // number of terms in the document
+    uint64_t maxNt = 0;        // max document frequency for terms in the current doc
 
     for (auto& col : inputVal.getRow() ) {
-
-        Utf8String colName = std::get<0>(col).toUtf8String();
-        int64_t value = std::get<1>(col).toInt();
-        maxFrequency = std::max((double)value, maxFrequency);
-        documentCount += value;
-        auto expr = std::make_shared<ReadVariableExpression>("", colName);
-        auto variableExpr = std::make_shared<ComputedVariable>(colName, expr);
-        select.clauses.push_back(variableExpr);
+        Utf8String term = std::get<0>(col).toUtf8String();
+        uint64_t value = std::get<1>(col).getAtom().toUInt();
+        maxFrequency = std::max(value, maxFrequency);
+        documentSize += value;
+        const auto termFrequency = dfs.find(term);
+        if (termFrequency != dfs.end())
+            maxNt = std::max(maxNt, termFrequency->second); 
     }
-
-    maxFrequency /= documentCount;
-
-     auto onProgress = [&] (const Json::Value & progress)
-        {
-            return true;
-        };
-
-    int64_t maxNt = 0;
-
-    // Get values from the corpus dataset only for the words in the input
-    // i.e. a subset of the dataset.
-    std::unordered_map<Utf8String, int64_t> bagOfWords;
-
-     //Check values in the corpus
-     auto aggregator = [&] (const MatrixNamedRow & row)
-        {
-            for (auto& col : row.columns) {         
-
-                Utf8String word = get<0>(col).toUtf8String();
-                const CellValue& cell = get<1>(col);
-                // if the value is not set it is because the term
-                // was never seen in the corpus
-                int64_t value = cell.isInteger() ? cell.toInt() : 0;
-                maxNt = std::max(maxNt, value);
-                bagOfWords[word] = value;               
-            }
-
-            return true;
-        };
-
-    iterateDataset(select, *dataset, "", 
-                   WhenExpression::parse("true"),
-                   SqlExpression::parse("true"),
-                   aggregator,
-                   ORDER_BY_NOTHING,
-                   0,
-                   -1,
-                   onProgress);     
-
-    RowValue values;
-    Date ts = inputVal.getEffectiveTimestamp();
-    double N = functionConfig.N;
 
     // the different possible TF scores
     auto tf_raw = [=] (double frequency) {
@@ -274,7 +335,7 @@ apply(const FunctionApplier & applier,
         return (std::log(1.0f + frequency));
     };
     auto tf_augmented = [=] (double frequency) {
-        return 0.5f + (0.5f * frequency) / maxFrequency;
+        return 0.5f + (0.5f * frequency * documentSize) / maxFrequency;
     };
 
     std::function<double(double)> tf_fct = tf_raw;
@@ -295,17 +356,18 @@ apply(const FunctionApplier & applier,
     auto idf_unary = [=] (uint64_t numberOfRelevantDoc) {
         return 1.0f;
     };
+
     auto idf_inverse = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log(N / (1 + numberOfRelevantDoc));
+        return std::log(corpusSize / (1 + numberOfRelevantDoc));
     };
     auto idf_inverseSmooth = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log(1 + (N / (1 + numberOfRelevantDoc)));
+        return std::log(1 + (corpusSize / (1 + numberOfRelevantDoc)));
     };
     auto idf_inverseMax = [=] (uint64_t numberOfRelevantDoc) {
         return std::log(1 + (maxNt)/ (1 +  numberOfRelevantDoc));
     };
     auto idf_probabilistic_inverse = [=] (uint64_t numberOfRelevantDoc) {
-        return std::log((N - numberOfRelevantDoc) / (1 + numberOfRelevantDoc));
+        return std::log((corpusSize - numberOfRelevantDoc) / (1 + numberOfRelevantDoc));
     };
 
     std::function<double(double)> idf_fct = idf_unary;
@@ -328,14 +390,19 @@ apply(const FunctionApplier & applier,
         break;
     }
 
+    RowValue values;
+    Date ts = inputVal.getEffectiveTimestamp();
+
     // Compute the score for every word in the input
     for (auto& col : inputVal.getRow() ) {
-        Utf8String colName = std::get<0>(col).toUtf8String();
-     
+        Utf8String term = std::get<0>(col).toUtf8String(); // the term is the columnName
 
-        double frequency = std::get<1>(col).toDouble() / documentCount;
+        double frequency = std::get<1>(col).getAtom().toUInt() / documentSize;
         double tf = tf_fct(frequency);
-        double idf = idf_fct(bagOfWords[colName]);
+        const auto docFrequency = dfs.find(term);
+        double idf = (docFrequency != dfs.end() 
+                      ? idf_fct(docFrequency->second) 
+                      : idf_fct(0)); 
 
         values.emplace_back(std::get<0>(col),
                             tf*idf,

--- a/plugins/tfidf.h
+++ b/plugins/tfidf.h
@@ -40,7 +40,8 @@ DECLARE_ENUM_DESCRIPTION(IDFType);
 struct TfidfConfig : public ProcedureConfig {
 
     InputQuery trainingData;
-    PolyConfigT<Dataset> output;
+    Url modelFileUrl;
+    Optional<PolyConfigT<Dataset> > output;
     static constexpr char const * defaultOutputDatasetType = "sparse.mutable";
 
     Utf8String functionName;
@@ -74,24 +75,13 @@ struct TfidfProcedure: public Procedure {
 /*****************************************************************************/
 
 struct TfidfFunctionConfig {
-    TfidfFunctionConfig(PolyConfigT<Dataset> dataset, int sizeOfCorpus = 1)
-        : dataset(dataset),         
-          N(sizeOfCorpus),
-          tf_type(TF_log),
-          idf_type(IDF_inverse)
-
-    {
-    }
-
     TfidfFunctionConfig()
-        : N(1),
-          tf_type(TF_log),
+        : tf_type(TF_log),
           idf_type(IDF_inverse)
     {
     }
-    
-    PolyConfigT<Dataset> dataset;       
-    int N;
+
+    Url modelFileUrl;
     TFType tf_type;
     IDFType idf_type;
 };
@@ -111,8 +101,10 @@ struct TfidfFunction: public Function {
     /** Describe what the input and output is for this function. */
     virtual FunctionInfo getFunctionInfo() const;
     
-    std::shared_ptr<Dataset> dataset;
     TfidfFunctionConfig functionConfig;
+    // document frequencies for terms
+    std::unordered_map<Utf8String, uint64_t> dfs;
+    uint64_t corpusSize;
 };
 
 } // namespace MLDB

--- a/plugins/tfidf.h
+++ b/plugins/tfidf.h
@@ -76,8 +76,8 @@ struct TfidfProcedure: public Procedure {
 
 struct TfidfFunctionConfig {
     TfidfFunctionConfig()
-        : tf_type(TF_log),
-          idf_type(IDF_inverse)
+        : tf_type(TF_raw),
+          idf_type(IDF_inverseSmooth)
     {
     }
 

--- a/testing/MLDB-1025-output-dataset-serialization-test.cc
+++ b/testing/MLDB-1025-output-dataset-serialization-test.cc
@@ -67,7 +67,6 @@ BOOST_AUTO_TEST_CASE( test_output_dataset_defaults )
 {
     std::vector<std::pair<PolyConfigT<Dataset>, std::string> > expectedDatasetType = {
         { createConfig<BucketizeProcedureConfig>("outputDataset").outputDataset, "sparse.mutable" },
-        { createConfig<KmeansConfig>("centroidsDataset").centroids, "embedding" },
         { createConfig<StatsTableProcedureConfig>("outputDataset").output, "sparse.mutable" },
         { createConfig<TransformDatasetConfig>("outputDataset").outputDataset, "sparse.mutable" },
         { createConfig<TsneConfig>("rowOutputDataset").output, "embedding" }

--- a/testing/MLDB-1101-tf-idf.py
+++ b/testing/MLDB-1101-tf-idf.py
@@ -61,6 +61,7 @@ tf_idf_conf = {
     "type": "tfidf.train",
     "params": {
         "trainingData": "select * from bag_of_words",
+        "modelFileUrl": "file://tmp/MLDB-1101.idf",
         "outputDataset": {
             "id": "tf_idf",
             "type": "sparse.mutable"

--- a/testing/MLDB-1101-tf-idf.py
+++ b/testing/MLDB-1101-tf-idf.py
@@ -29,7 +29,7 @@ dataset = mldb.create_dataset(dataset_config)
 #this is our corpus
 dataset.record_row("row1", [ ["test", "peanut butter jelly peanut butter jelly", 0]])
 dataset.record_row("row2", [ ["test", "peanut butter jelly time peanut butter jelly time", 0]])
-dataset.record_row("row3", [ ["test", "this is the song", 0]])
+dataset.record_row("row3", [ ["test", "this is the jelly song", 0]])
 
 dataset.commit()
 

--- a/testing/MLDB-1101-tf-idf.py
+++ b/testing/MLDB-1101-tf-idf.py
@@ -84,7 +84,7 @@ mldb.log(rez)
 rez = mldb.perform("GET", "/v1/query", [["q", "select tokenize('jelly time', {' ' as splitchars}) as input from tf_idf order by rowName() ASC"]])
 mldb.log(rez)
 
-rez = mldb.perform("GET", "/v1/query", [["q", "select tfidffunction({tokenize('jelly time', {' ' as splitchars}) as input}) as * from tf_idf order by rowName() ASC"]])
+rez = mldb.perform("GET", "/v1/query", [["q", "select tfidffunction({tokenize('jelly time butter bristol', {' ' as splitchars}) as input}) as * from tf_idf order by rowName() ASC"]])
 mldb.log(rez)
 
 #'time' should be more relevant than 'jelly' because its rarer in the corpus

--- a/testing/MLDB-1101-tf-idf.py
+++ b/testing/MLDB-1101-tf-idf.py
@@ -2,24 +2,22 @@
 
 import json
 
-def get_column(result, column):
-	assert(result['statusCode'] == 200)
-	response = json.loads(result['response'])
-	numRow = len(response)
-	found = False
-	for rowIndex in range (0, numRow):
-		row = response[rowIndex]['columns']
-		numCol = len(row)
-		for colIndex in range (0, numCol):
-			if row[colIndex][0] == column:				
-				found = True
-				return row[colIndex][1];
-				break
-		if (found):
-			break
-	assert found
+def get_column(result, column, row_index = 0):
+    response = json.loads(result['response'])
+    for col in response[row_index]['columns']:
+        if col[0] == column:				
+            return col[1]
+
+    assert("could not find column %s on row %d" % (column, row_index))
 
 	
+def assert_success(call, response):
+    if 400 > response['statusCode'] >= 200:
+        mldb.log(call + " - succeeded")
+        return
+       
+    mldb.log(response)
+    assert false, call + " - failed"
 
 dataset_config = {
     'type'    : 'sparse.mutable',
@@ -44,14 +42,11 @@ baggify_conf = {
             "id": "bag_of_words",
             "type": "sparse.mutable"
         },
-        
+        "runOnCreation": True
     }
 }
 baggify_output = mldb.perform("PUT", "/v1/procedures/baggify", [], baggify_conf)
-mldb.log(baggify_output)
-
-run_output = mldb.perform("POST", "/v1/procedures/baggify/runs")
-mldb.log(run_output)
+assert_success("tokenize the sentences into bag of words", baggify_output)
 
 rez = mldb.perform("GET", "/v1/query", [["q", "select * from bag_of_words order by rowName() ASC"]])
 mldb.log(rez)
@@ -66,43 +61,51 @@ tf_idf_conf = {
             "id": "tf_idf",
             "type": "sparse.mutable"
         },
-        "functionName" : "tfidffunction"
+        "functionName": "tfidffunction",
+        "runOnCreation": True
     }
 }
 
 baggify_output = mldb.perform("PUT", "/v1/procedures/tf_idf_proc", [], tf_idf_conf)
-mldb.log(baggify_output)
-
-run_output = mldb.perform("POST", "/v1/procedures/tf_idf_proc/runs")
-mldb.log(run_output)
+assert_success("training of the tf-idf procedure", baggify_output)
 
 rez = mldb.perform("GET", "/v1/query", [["q", "select * from tf_idf order by rowName() ASC"]])
 mldb.log(rez)
+assert get_column(rez, "peanut") == 2, "expected doc frequency of 2 for 'peanut' in corpus" 
+assert get_column(rez, "time") == 1, "expected doc frequency of 1 for 'time' in corpus" 
 
 rez = mldb.perform("GET", "/v1/query", [["q", "select tfidffunction({{*} as input}) as * from tf_idf order by rowName() ASC"]])
+assert_success("applying tf-idf on training data", baggify_output)
 mldb.log(rez)
+assert get_column(rez, "output.time") > 0, "expected positive tf-idf for 'time'" 
 
-rez = mldb.perform("GET", "/v1/query", [["q", "select tokenize('jelly time', {' ' as splitchars}) as input from tf_idf order by rowName() ASC"]])
-mldb.log(rez)
+def test_relative_values(f_name):
+    query = "select %s({tokenize('jelly time butter butter bristol', {' ' as splitchars}) as input}) as * from tf_idf" % f_name
+    rez = mldb.perform("GET", "/v1/query", [["q", query]])
+    assert_success("applying tf-idf on new data with function " + f_name, baggify_output)
+    mldb.log(rez)
+    assert get_column(rez, "output.bristol") > get_column(rez, 'output.jelly'),  \
+        "'bristol' is more relevant than 'jelly' because it shows only in this document"
+    assert get_column(rez, "output.butter") >= get_column(rez, 'output.jelly'), \
+        "'butter' more relevant than 'jelly' because it occurs moreoften"
+    assert get_column(rez, 'output.time') > get_column(rez, 'output.jelly'), \
+        "'time' should be more relevant than 'jelly' because its rarer in the corpus"
 
-rez = mldb.perform("GET", "/v1/query", [["q", "select tfidffunction({tokenize('jelly time butter bristol', {' ' as splitchars}) as input}) as * from tf_idf order by rowName() ASC"]])
-mldb.log(rez)
-
-#'time' should be more relevant than 'jelly' because its rarer in the corpus
-assert get_column(rez, 'output.time') > get_column(rez, 'output.jelly')
+test_relative_values("tfidffunction")
 
 func_conf = {
     "type": "tfidf",
     "params": {
-        "dataset": "tf_idf",
-        "sizeOfCorpus" : 3,
+        "modelFileUrl": "file://tmp/MLDB-1101.idf",
         "tfType" : "augmented",
         "idfType" : "inverseMax",       
     }
 }
 
 output = mldb.perform("PUT", "/v1/functions/tfidffunction2", [], func_conf)
-mldb.log(output)
+assert_success("creation of tfidf function", output)
+
+test_relative_values("tfidffunction2")
 
 rez = mldb.perform("GET", "/v1/query", [["q", "select tfidffunction2({tokenize('jelly time', {' ' as splitchars}) as input}) as * from tf_idf order by rowName() ASC"]])
 mldb.log(rez)

--- a/testing/MLDB-926_auto_functions_for_procs.py
+++ b/testing/MLDB-926_auto_functions_for_procs.py
@@ -70,6 +70,7 @@ conf = {
     "type": "kmeans.train",
     "params": {
         "trainingData": "select * excluding(label) from toy",
+        "modelFileUrl": "file://tmp/MLDB-926.mks",
         "centroidsDataset": {"id": "kmean_out", "type": "sparse.mutable" },
         "functionName": "kmeans_func"
     }


### PR DESCRIPTION
- modified the kmeans procedure to persist the centroids as a model file - that model is necessary to create a kmeans function
- similarly modified tf-idf procedure to persist the document frequencies of the terms in the corpus along with the corpus size - that model is also necessary when creating a kmeans function
- adapted and augmented the test coverage of the kmeans and tf-idf functions