### PR TITLE
Don't stack overflow on JSON encoding long strings (MLDB-1238)

### DIFF
--- a/types/json_parsing.h
+++ b/types/json_parsing.h
@@ -1,9 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* json_parsing.h                                                  -*- C++ -*-
    Jeremy Barnes, 22 February 2013
    Copyright (c) 2013 Datacratic Inc.  All rights reserved.
 
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 */
 
 #pragma once

--- a/types/testing/json_handling_test.cc
+++ b/types/testing/json_handling_test.cc
@@ -74,3 +74,28 @@ BOOST_AUTO_TEST_CASE(test_utf8_bad_string)
     StreamingJsonParsingContext context(payload, start, start + payload.size());
     BOOST_CHECK_THROW(context.expectStringUtf8(), ML::Parse_Context::Exception);
 }
+
+BOOST_AUTO_TEST_CASE(test_json_encode_decode_long_strings)
+{
+    string needsEscaping;
+    string needsNoEscaping;
+    for (unsigned i = 0;  i < 10000000;  ++i) {
+        needsEscaping += (' ' + (i % 90));
+        needsNoEscaping += 'A' + (i % 26);
+    }
+
+    string result1 = jsonEscape(needsEscaping);
+
+    BOOST_CHECK_GT(result1.length(), needsEscaping.length());
+
+    string result2 = jsonEscape(needsNoEscaping);
+
+    BOOST_CHECK_EQUAL(result2.length(), needsNoEscaping.length());
+    BOOST_CHECK(result2 == needsNoEscaping);
+
+
+    const std::string payload = "\"http\\u00253A\\u00252F\\u";
+    const char* start = payload.c_str();                                        
+    StreamingJsonParsingContext context(payload, start, start + payload.size());
+    BOOST_CHECK_THROW(context.expectStringUtf8(), ML::Parse_Context::Exception);
+}


### PR DESCRIPTION
@wsourdeau FYI.  The MLDB versions are a little different and we took the opportunity to avoid making a character by character copy of the string passed in if it doesn't need escaping.
