### PR TITLE
MLDB-1244 Add 'finish' and logging script to mldb service

### DIFF
--- a/container_files/init/mldb_finish.py
+++ b/container_files/init/mldb_finish.py
@@ -14,13 +14,30 @@
 import os
 import sys
 
+sigmap = { 4: "SIGILL: illegal instruction - internal error",
+           6: "SIGABRT: abort(3) called - internal error",
+           9: "SIGKILL: killed from outside, did we run out of memory (OOM killed?)",
+           11: "SIGSEGV: segfault - internal error",
+           15: "SIGTERM: regular shutdown",
+         }
+
 msg = ""
+sig = None
 if len(sys.argv) == 3:
     exit_code = sys.argv[1]
     status_code = sys.argv[2]
     if os.WIFSIGNALED(int(status_code)):
         sig = os.WTERMSIG(int(status_code))
-        msg = " Killed by signal %d." % sig
 
-print "MLDB exited.%s" % (msg)
+print  # we like space
+print
+if sig == None:
+    print "MLDB exited."
+else:
+    msg = "MLDB exited due to signal %d." % (sig)
+    if sig in sigmap:
+        msg += " " + sigmap[sig]
+    print msg
+print
+print
 

--- a/container_files/init/mldb_finish.py
+++ b/container_files/init/mldb_finish.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# Copyright Datacratic 2016
+# Author: Jean Raby <jean@datacratic.com>
+
+# This script is called by runsv when the mldb service exits.
+# See http://smarden.org/runit/runsv.8.html for more details.
+# Two arguments are given to ./finish:
+# The first one is ./run's exit code, or -1 if ./run didn't exit normally.
+# The second one is the least significant byte of the exit status as
+# determined by waitpid(2); for instance it is 0 if ./run exited normally,
+# and the signal number if ./run was terminated by a signal.
+# If runsv cannot start ./run for some reason, the exit code is 111 and the status is 0.
+
+import os
+import sys
+
+msg = ""
+if len(sys.argv) == 3:
+    exit_code = sys.argv[1]
+    status_code = sys.argv[2]
+    if os.WIFSIGNALED(int(status_code)):
+        sig = os.WTERMSIG(int(status_code))
+        msg = " Killed by signal %d." % sig
+
+print "MLDB exited.%s" % (msg)
+

--- a/container_files/init/mldb_finish.py
+++ b/container_files/init/mldb_finish.py
@@ -14,10 +14,11 @@
 import os
 import sys
 
-sigmap = { 4: "SIGILL: illegal instruction - internal error",
-           6: "SIGABRT: abort(3) called - internal error",
-           9: "SIGKILL: killed from outside, did we run out of memory (OOM killed?)",
-           11: "SIGSEGV: segfault - internal error",
+sigmap = { 4:  "SIGILL: illegal instruction (internal error)",
+           6:  "SIGABRT: abort(3) called (internal error)",
+           8:  "SIGFPE: divide-by-zero (internal error)",
+           9:  "SIGKILL: killed from outside (external cause, maybe the OOM Killer)",
+           11: "SIGSEGV: segmentation fault (internal error)",
            15: "SIGTERM: regular shutdown",
          }
 
@@ -32,9 +33,9 @@ if len(sys.argv) == 3:
 print  # we like space
 print
 if sig == None:
-    print "MLDB exited."
+    print "MLDB exited due to unknown signal"
 else:
-    msg = "MLDB exited due to signal %d." % (sig)
+    msg = "MLDB exited due to signal %d" % (sig)
     if sig in sigmap:
         msg += " " + sigmap[sig]
     print msg

--- a/container_files/init/mldb_logger.py
+++ b/container_files/init/mldb_logger.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# Copyright Datacratic 2016
+# Author: Jean Raby <jean@datacratic.com>
+
+# Wrapper around tee -a
+# Read from stdin and write to logfile and to stdout
+
+import os
+tee = "/usr/bin/tee"
+os.execv(tee,[tee, '-a', '{{MLDB_LOGFILE}}'])
+

--- a/container_files/init/mldb_runner.sh
+++ b/container_files/init/mldb_runner.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
+
+exec 2>&1  # stderr to stdout for logging purposes
+
 cd {{MLDB_DATA_DIR}}
-BIN=/opt/bin REMOTE_CREDENTIAL_PROVIDER=http://127.0.0.1:{{CREDENTIALSD_LISTEN_PORT}} /sbin/setuser _mldb /opt/bin/mldb_runner --http-listen-port {{MLDB_RUNNER_LISTEN_PORT}} --configuration-path {{MLDB_CONFIGURATION_PATH}} --static-doc-path {{MLDB_STATIC_ASSETS_PATH}}/www/doc/builtin --cache-dir {{MLDB_SSD_CACHE_PATH}} --plugin-directory {{MLDB_GLOBAL_PLUGINS_PATH}} --plugin-directory {{MLDB_LOCAL_PLUGINS_PATH}} {{MLDB_EXTRA_FLAGS}} 2>&1 | tee -a /var/log/mldb_runner.log
+BIN=/opt/bin REMOTE_CREDENTIAL_PROVIDER=http://127.0.0.1:{{CREDENTIALSD_LISTEN_PORT}} exec /sbin/setuser _mldb /opt/bin/mldb_runner --http-listen-port {{MLDB_RUNNER_LISTEN_PORT}} --configuration-path {{MLDB_CONFIGURATION_PATH}} --static-doc-path {{MLDB_STATIC_ASSETS_PATH}}/www/doc/builtin --cache-dir {{MLDB_SSD_CACHE_PATH}} --plugin-directory {{MLDB_GLOBAL_PLUGINS_PATH}} --plugin-directory {{MLDB_LOCAL_PLUGINS_PATH}} {{MLDB_EXTRA_FLAGS}}
+

--- a/container_files/template_vars.mk
+++ b/container_files/template_vars.mk
@@ -22,5 +22,6 @@ export MLDB_SSD_CACHE_PATH = /ssd_cache
 export MLDB_EXTRA_FLAGS =  # these flags will be passed as-is to the mldb_runner executable
 export MLDB_GLOBAL_PLUGINS_PATH = file:///opt/mldb/plugins
 export MLDB_LOCAL_PLUGINS_PATH = file:///mldb_data/plugins/autoload
+export MLDB_LOGFILE = /var/log/mldb_runner.log
 
 

--- a/release.mk
+++ b/release.mk
@@ -33,6 +33,8 @@ $(eval $(call mldb_install_templated_file,mldb/container_files/version.json,$(AL
 
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/05-mldb-id-mapping.sh,$(ETC)/my_init.d/05-mldb-id-mapping.sh,555))
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/mldb_runner.sh,$(ETC)/service/mldb_runner/run,555))
+$(eval $(call mldb_install_templated_file,mldb/container_files/init/mldb_logger.py,$(ETC)/service/mldb_runner/log/run,555))
+$(eval $(call mldb_install_templated_file,mldb/container_files/init/mldb_finish.py,$(ETC)/service/mldb_runner/finish,555))
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/nginx_runner.sh,$(ETC)/service/nginx/run,555))
 $(eval $(call mldb_install_templated_file,mldb/container_files/mldb_nginx_site.conf,$(ETC)/nginx/sites-enabled/mldb))
 $(eval $(call mldb_install_templated_file,mldb/container_files/nginx.conf,$(ETC)/nginx/nginx.conf))


### PR DESCRIPTION
The docker init system (based on runsvdir) will call
/etc/service/mldb_runner/finish when mldb_runner exits.
The finish script will print a message with the signal number that killed the
process if it is available.

The 'run' script has been tweaked to 'exec' mldb_runner instead of forking it.
This is required for the finish script to properly get the signal code when
mldb_runner exits.

Since we now 'exec', we cannot use a pipeline to redirect stderr to stdout and
stdout to tee.  Instead, we use a logging script, which is a simple wrapper
around tee. runsv will arrange to wire up the file descriptor correctly
(mldb_runner's stdout to the logger's stdin).