### PR TITLE
Fix a segfault in rest_collection

### DIFF
--- a/rest/poly_collection.cc
+++ b/rest/poly_collection.cc
@@ -92,6 +92,12 @@ PolyCollectionBase(const Utf8String & nounSingular,
 {
 }
 
+PolyCollectionBase::
+~PolyCollectionBase()
+{
+    shutdown();
+}
+
 void
 PolyCollectionBase::
 initRoutes(RouteManager & manager)

--- a/rest/poly_collection.h
+++ b/rest/poly_collection.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** poly_collection.h                                              -*- C++ -*-
     Jeremy Barnes, 22 December 2014
     Copyright (c) 2014 Datacratic Inc.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Collection of polymorphic objects.
 */
@@ -32,6 +32,7 @@ struct PolyCollectionBase
     PolyCollectionBase(const Utf8String & nounSingular,
                        const Utf8String & nounPlural,
                        RestDirectory * server);
+    virtual ~PolyCollectionBase();
     
     RestDirectory * server;
         
@@ -73,6 +74,8 @@ struct PolyCollection: public PolyCollectionBase {
     PolyCollection(const Utf8String & nounSingular,
                    const Utf8String & nounPlural,
                    RestDirectory * server);
+
+    virtual ~PolyCollection();
 
     virtual std::shared_ptr<PolyConfig>
     getConfig(Utf8String key, const PolyEntity & value) const;

--- a/rest/poly_collection_impl.h
+++ b/rest/poly_collection_impl.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** poly_collection_impl.h                                         -*- C++ -*-
     Jeremy Barnes, 22 December 2014
     Copyright (c) 2014 Datacratic Inc.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Implementation of polymorphic collections.
 */
@@ -26,6 +26,13 @@ PolyCollection(const Utf8String & nounSingular,
                RestDirectory * server)
     : PolyCollectionBase(nounSingular, nounPlural, server)
 {
+}
+
+template<typename Entity>
+PolyCollection<Entity>::
+~PolyCollection()
+{
+    this->shutdown();
 }
 
 template<typename Entity>

--- a/rest/rest_collection.cc
+++ b/rest/rest_collection.cc
@@ -650,6 +650,14 @@ BackgroundTaskBase()
 {
 }
 
+BackgroundTaskBase::
+~BackgroundTaskBase()
+{
+    if (!cancelled) {
+        cancel();
+    }
+}
+
 Json::Value
 BackgroundTaskBase::
 getProgress() const
@@ -663,10 +671,9 @@ BackgroundTaskBase::
 cancel()
 {
     bool wasCancelled = this->cancelled.exchange(true);
-    if (wasCancelled)
-        return;
-
-    cancelledWatches.trigger(true);
+    if (!wasCancelled) {
+        cancelledWatches.trigger(true);
+    }
 
 #if 0
     // Give it one second to stop
@@ -686,7 +693,7 @@ cancel()
     //thread->join();
 
     while (!error && !finished) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
     }
 }
 


### PR DESCRIPTION
It occurrs when the object is destroyed before threads have finished
running. I added a counter and a condition variable to have the dtor
wait for them before dtoring.