### PR TITLE
Update services to use 'exec' and drop tee -a log

### DIFF
--- a/container_files/init/credentialsd_runner.sh
+++ b/container_files/init/credentialsd_runner.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-/sbin/setuser _mldb /opt/bin/credentialsd --listen-port {{CREDENTIALSD_LISTEN_PORT}} --listen-host {{CREDENTIALSD_LISTEN_ADDR}} --credentials-path {{MLDB_CREDENTIALS_PATH}} 2>&1 | tee /var/log/credentialsd.log
+exec 2>&1  # stderr to stdout for logging purposes
+
+exec /sbin/setuser _mldb /opt/bin/credentialsd --listen-port {{CREDENTIALSD_LISTEN_PORT}} --listen-host {{CREDENTIALSD_LISTEN_ADDR}} --credentials-path {{MLDB_CREDENTIALS_PATH}}
 

--- a/container_files/init/ipython_notebook_runner.sh
+++ b/container_files/init/ipython_notebook_runner.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+exec 2>&1  # stderr to stdout for logging purposes
+
 cd {{IPYTHON_NB_DIR}}
 
 /sbin/setuser _mldb mkdir -p {{IPYTHON_NB_DIR}}/_demos
@@ -18,5 +20,5 @@ if [ ! -e {{IPYTHON_DIR}}/profile_default ] ; then
     /sbin/setuser _mldb cp {{IPYTHON_DIR}}/custom.css {{IPYTHON_DIR}}/profile_default/static/custom/custom.css
 fi
 
-IPYTHONDIR={{IPYTHON_DIR}} /sbin/setuser _mldb /usr/local/bin/ipython notebook --log-level=ERROR --config={{IPYTHON_DIR}}/ipython_extra_config.py 2>&1 | tee /var/log/ipython_notebook.log
+IPYTHONDIR={{IPYTHON_DIR}} exec /sbin/setuser _mldb /usr/local/bin/ipython notebook --log-level=ERROR --config={{IPYTHON_DIR}}/ipython_extra_config.py
  

--- a/container_files/init/nginx_runner.sh
+++ b/container_files/init/nginx_runner.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-/usr/sbin/nginx -g 'daemon off;'  
+exec 2>&1  # stderr to stdout for logging purposes
+
+exec /usr/sbin/nginx -g 'daemon off;'

--- a/container_files/init/uwsgi_validator_runner.sh
+++ b/container_files/init/uwsgi_validator_runner.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+exec 2>&1  # stderr to stdout for logging purposes
+
 install -o _mldb -d -m 750 /var/log/validator_api
 
 install -d -o _mldb -g _mldb {{MLDB_VALIDATOR_DIR}}
 export CONFIG=/etc/validator_api_config.json
-/sbin/setuser _mldb /usr/local/bin/uwsgi \
+exec /sbin/setuser _mldb /usr/local/bin/uwsgi \
     --socket 127.0.0.1:{{UWSGI_VALIDATOR_PORT}} \
     --master \
+    --die-on-term \
     --processes 8 \
     --logto=/var/log/validator_api/validator_api.log \
     --chdir=/opt/bin \


### PR DESCRIPTION
Allows all services to be properly controlled by sv {status,start,stop} service

The in-container log file for all services will not be generated anymore.
If we ever need those, we can use a 'log' script like mldb_runner does.