### PR TITLE
MLDB-1267 bucketize latest timestamp

### DIFF
--- a/plugins/csv_dataset.cc
+++ b/plugins/csv_dataset.cc
@@ -123,6 +123,7 @@ struct SqlCsvScope: public SqlExpressionMldbContext {
     SqlCsvScope(MldbServer * server, const std::vector<ColumnName> & columnNames,
                 Date fileTimestamp, Utf8String dataFileUrl)
         : SqlExpressionMldbContext(server), columnNames(columnNames),
+          fileTimestamp(fileTimestamp),
           dataFileUrl(std::move(dataFileUrl))
     {
         columnsUsed.resize(columnNames.size(), false);
@@ -570,10 +571,12 @@ struct CsvDataset::Itl: public TabularDataStore {
         config = conf;
         filename = config.dataFileUrl.toString();
         
-        Date ts = getUriObjectInfo(filename).lastModified;
-
         // Ask for a memory mappable stream if possible
         ML::filter_istream stream(filename, { { "mapped", "true" } });
+
+        // Get the file timestamp out
+        Date ts = stream.info().lastModified;
+
 
         string header;
 

--- a/testing/MLDB-1043-bucketize-procedure.js
+++ b/testing/MLDB-1043-bucketize-procedure.js
@@ -62,6 +62,11 @@ function runTest(testNumber, buckets, goldStandard) {
     assertEqual(res['responseCode'], 200);
     checkResults(res, goldStandard);
 
+    res = mldb.get("/v1/query", {q: "SELECT *, when({*}) FROM " + datasetName,
+                                 format: "full"});
+
+    // MLDB-1267
+    assertEqual(res.json[0].columns[1][1].ts, "2015-12-22T14:26:51Z");
 }
 
 // Create base dataset --------------------------------------------------------


### PR DESCRIPTION
Causes the latest timestamp for the order by column to be used by the bucketize procedure.

Also fixes a bug in CSV timestamps that caused the test to fail originally.

@FinchPowers FYI