### PR TITLE
upgrade jdcal version to 1.0.1

### DIFF
--- a/python_constraints.txt
+++ b/python_constraints.txt
@@ -62,7 +62,7 @@ ipykernel==4.0.3
 ipython-genutils==0.1.0
 ipywidgets==4.0.2
 itsdangerous==0.24
-jdcal==1.0
+jdcal==1.0.1
 jsonschema==2.5.1
 jupyter-client==4.0.0
 jupyter-console==4.0.2


### PR DESCRIPTION
The version 1.0 no longer exists and cannot be installed on pypi.
https://github.com/phn/jdcal/issues/5