### PR TITLE
MLDB-1233 small fix for bucket number in group by

### DIFF
--- a/server/bound_queries.cc
+++ b/server/bound_queries.cc
@@ -271,8 +271,8 @@ struct UnorderedExecutor: public BoundSelectQuery::Executor {
             selectOutput.mergeToRowDestructive(outputRow.columns);
         }
 
-        int bucketNumber = numBuckets > 0 ? rowNum/numPerBucket : -1;
-        
+        int bucketNumber = numBuckets > 0 ? std::min(rowNum/numPerBucket, numBuckets-1) : -1;
+
         /* Finally, pass to the terminator to continue. */
         return aggregator(outputRow, calcd, bucketNumber);
     }


### PR DESCRIPTION
Fix (for now) a small issue where some rows could report a bucket index == bucketnumber.