### PR TITLE
[MLDBFB-320] force lowecase lookup on aggregates

### DIFF
--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -297,8 +297,9 @@ ExternalAggregator lookupAggregator(const Utf8String & name)
 
 ExternalAggregator tryLookupAggregator(const Utf8String & name)
 {
+    Utf8String functionNameLower(boost::algorithm::to_lower_copy(name.extractAscii()));
     std::unique_lock<std::recursive_mutex> guard(externalAggregatorsMutex);
-    auto it = externalAggregators.find(name);
+    auto it = externalAggregators.find(functionNameLower);
     if (it == externalAggregators.end())
         return nullptr;
     return it->second;

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -1393,9 +1393,7 @@ bindBuiltinFunction(SqlBindingScope & context, std::vector<BoundSqlExpression>& 
             throw HttpReturnException(400, "Builtin function " + functionName
                                    + " should not have an extract [] expression, got " + extract->print() );
 
-    Utf8String functionNameLower(boost::algorithm::to_lower_copy(functionName.extractAscii()));
-
-    bool isAggregate = tryLookupAggregator(functionNameLower) != nullptr;
+    bool isAggregate = tryLookupAggregator(functionName) != nullptr;
 
     if (isAggregate)
     {


### PR DESCRIPTION
I know that this pull request is not on master.  I will fix that before merging.

The lookup of the aggregate function was done in a case-sensitive way in some cases. This resulted in SelectExpression::findAggregator to return no aggregators when there were some. An immediate consequence is that the BoundGroupByQuery was not inserting the aggregator expression in the calc vector resulting in an out of bound lookup when evaluating the aggregators.