### PR TITLE
[MLDBFB-320] related to MLDB-957, built-in function names should be c…

### DIFF
--- a/server/bound_queries.cc
+++ b/server/bound_queries.cc
@@ -1124,11 +1124,10 @@ struct GroupContext: public SqlExpressionDatasetContext {
         }
 
         //check aggregators
-        Utf8String functionNameLower(boost::algorithm::to_lower_copy(functionName.extractAscii()));
-        auto aggFn = SqlBindingScope::doGetAggregator(functionNameLower, args);
+        auto aggFn = SqlBindingScope::doGetAggregator(functionName, args);
         if (aggFn)
         {
-            if (functionNameLower == "count")
+            if (functionName == "count")
             {
                 //count is *special*
                 evaluateEmptyGroups = true;

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -1393,9 +1393,7 @@ bindBuiltinFunction(SqlBindingScope & context, std::vector<BoundSqlExpression>& 
             throw HttpReturnException(400, "Builtin function " + functionName
                                    + " should not have an extract [] expression, got " + extract->print() );
 
-    Utf8String functionNameLower(boost::algorithm::to_lower_copy(functionName.extractAscii()));
-
-    bool isAggregate = tryLookupAggregator(functionNameLower) != nullptr;
+    bool isAggregate = tryLookupAggregator(functionName) != nullptr;
 
     if (isAggregate)
     {


### PR DESCRIPTION
…ase-sensitive

This was causing some instability since part of the code was interpreting a function as being an aggregator when some other parts were not!