### PR TITLE
Mldb 12550 3 way outer join

### DIFF
--- a/builtin/filtered_dataset.cc
+++ b/builtin/filtered_dataset.cc
@@ -242,10 +242,11 @@ getKnownColumnInfo(const ColumnName & columnName) const
 
 BoundFunction
 FilteredDataset::
-overrideFunction(const Utf8String & functionName,
-                     SqlBindingScope & context) const
+overrideFunction(const Utf8String & tableName,
+                 const Utf8String & functionName,
+                 SqlBindingScope & context) const
 {
-    return dataset.overrideFunction(functionName, context);
+    return dataset.overrideFunction(tableName, functionName, context);
 }
 
 std::shared_ptr<MatrixView>

--- a/builtin/filtered_dataset.h
+++ b/builtin/filtered_dataset.h
@@ -44,7 +44,8 @@ struct FilteredDataset : public Dataset {
 
     // these methods have been overriden by the dataset specialized classes - implement redirect
     virtual KnownColumn getKnownColumnInfo(const ColumnName & columnName) const;
-    virtual BoundFunction overrideFunction(const Utf8String & functionName,
+    virtual BoundFunction overrideFunction(const Utf8String & tableName,
+                                           const Utf8String & functionName,
                                            SqlBindingScope & context) const;
 
     virtual std::shared_ptr<MatrixView> getMatrixView() const;

--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -145,7 +145,11 @@ struct JoinedDataset::Itl
         matrices.emplace_back(left.dataset->getMatrixView());
         matrices.emplace_back(right.dataset->getMatrixView());
 
+        cerr << "table names: " << left.asName << "," << right.asName << endl;
+
         tableNames = {left.asName, right.asName};
+        left.dataset->getChildAliases(tableNames);
+        right.dataset->getChildAliases(tableNames);
 
         //if table aliases contains a dot '.', surround it with quotes to prevent ambiguity
         Utf8String quotedLeftName = left.asName;

--- a/builtin/joined_dataset.h
+++ b/builtin/joined_dataset.h
@@ -56,6 +56,8 @@ struct JoinedDataset: public Dataset {
 
     virtual void getChildAliases(std::vector<Utf8String>&) const;
 
+    virtual BoundFunction overrideFunction(const Utf8String & tableName, const Utf8String & functionName, SqlBindingScope & context) const;
+
 private:
     JoinedDatasetConfig datasetConfig;
     struct Itl;

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -1348,7 +1348,8 @@ commit()
 
 BoundFunction
 Dataset::
-overrideFunction(const Utf8String & functionName,
+overrideFunction(const Datacratic::Utf8String&,
+                 const Utf8String & functionName,
                  SqlBindingScope & context) const
 {
     return BoundFunction();

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -305,7 +305,8 @@ struct Dataset: public MldbEntity {
         Default implementation returns a null function.
     */
     virtual BoundFunction
-    overrideFunction(const Utf8String & functionName,
+    overrideFunction(const Utf8String & tableName,
+                     const Utf8String & functionName,
                      SqlBindingScope & context) const;
 
     /** Allow the dataset to override the generation of row IDs for a

--- a/plugins/embedding.cc
+++ b/plugins/embedding.cc
@@ -1017,7 +1017,8 @@ getRowStream() const
 
 BoundFunction
 EmbeddingDataset::
-overrideFunction(const Utf8String & functionName,
+overrideFunction(const Utf8String & tableName,
+                 const Utf8String & functionName,
                  SqlBindingScope & context) const
 {
     if (functionName == "distance") {

--- a/plugins/embedding.h
+++ b/plugins/embedding.h
@@ -60,7 +60,8 @@ struct EmbeddingDataset: public Dataset {
     virtual std::shared_ptr<RowStream> getRowStream() const;
 
     virtual BoundFunction
-    overrideFunction(const Utf8String & functionName,
+    overrideFunction(const Utf8String & tableName,
+                     const Utf8String & functionName,
                      SqlBindingScope & context) const;
 
     virtual RestRequestMatchResult

--- a/server/dataset_context.cc
+++ b/server/dataset_context.cc
@@ -307,7 +307,7 @@ doGetFunction(const Utf8String & tableName,
 {
     // First, let the dataset either override or implement the function
     // itself.
-    auto fnoverride = dataset.overrideFunction(functionName, *this);
+    auto fnoverride = dataset.overrideFunction(tableName, functionName, *this);
     if (fnoverride)
         return fnoverride;
 

--- a/server/forwarded_dataset.cc
+++ b/server/forwarded_dataset.cc
@@ -167,11 +167,12 @@ getColumnNames(ssize_t offset, ssize_t limit) const
 
 BoundFunction
 ForwardedDataset::
-overrideFunction(const Utf8String & functionName,
+overrideFunction(const Utf8String & tableName, 
+                 const Utf8String & functionName,
                  SqlBindingScope & context) const
 {
     ExcAssert(underlying);
-    return underlying->overrideFunction(functionName, context);
+    return underlying->overrideFunction(tableName, functionName, context);
 }
 
 GenerateRowsWhereFunction

--- a/server/forwarded_dataset.h
+++ b/server/forwarded_dataset.h
@@ -81,7 +81,8 @@ struct ForwardedDataset: public Dataset {
     getColumnNames(ssize_t offset = 0, ssize_t limit = -1) const;
 
     virtual BoundFunction
-    overrideFunction(const Utf8String & functionName,
+    overrideFunction(const Utf8String & tableName, 
+                     const Utf8String & functionName,
                      SqlBindingScope & context) const;
 
     virtual GenerateRowsWhereFunction

--- a/sql/join_utils.cc
+++ b/sql/join_utils.cc
@@ -132,9 +132,6 @@ removeTableName(const SqlExpression & expr, const Utf8String & tableName, const 
                         name.replace(0, std::get<2>(prefixt), Utf8String());
                         ExcAssert(!name.empty());
                         ExcAssert(!name.startsWith("."));
-
-                        cerr << "removed table name in var : " << var->variableName << " is now " << name << " from table " << std::get<0>(prefixt) << endl;
-
                         return std::make_shared<ReadVariableExpression>(std::get<0>(prefixt), name);
                     }
                 }               
@@ -153,9 +150,6 @@ removeTableName(const SqlExpression & expr, const Utf8String & tableName, const 
                         for (auto & a: func->args) {
                             newArgs.emplace_back(std::move(doArg(a)));
                         }
-
-                        cerr << "removed table name in function : " << func->functionName << " is now " << name << " from table " << std::get<0>(prefixt) << endl;
-
                         return std::make_shared<FunctionCallWrapper>(std::get<0>(prefixt), name, std::move(newArgs), func->extract);
                     }
                 }
@@ -227,11 +221,7 @@ AnnotatedClause(std::shared_ptr<SqlExpression> c,
         }
 
         Utf8String tableName(v.begin(), dotIt);
-
-        cerr << "func " << v << " with table name " << tableName << endl;
-
         if (leftTables.count(tableName)) {
-            cerr << "left" << endl;
             v.replace(0, tableName.length() + 1,
                       Utf8String(""));
             ExcAssert(!v.empty());
@@ -239,7 +229,6 @@ AnnotatedClause(std::shared_ptr<SqlExpression> c,
             leftFuncs.emplace_back(std::move(v));
         }
         else if (rightTables.count(tableName)) {
-            cerr << "right" << endl;
             v.replace(0, tableName.length() + 1,
                       Utf8String(""));
             ExcAssert(!v.empty());
@@ -463,13 +452,7 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
             // expression locally to the table, not in the context of the
             // join.
 
-            for (auto& n : side.table->getTableNames())
-            {
-                cerr << "table name in do side: " << n << endl;
-            }
-
             auto localExpr = removeTableName(*side.equalExpression, side.table->getAs(), side.table->getTableNames());
-
             side.selectExpression = localExpr;
 
             // Construct the select expression.  It's simply the value of
@@ -484,9 +467,7 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
             side.orderBy.clauses.emplace_back(localExpr, ASC);
         };
 
-    cerr << "do left side" << endl;
     doSide(left);
-    cerr << "do right side" << endl;
     doSide(right);
 }
 

--- a/sql/join_utils.cc
+++ b/sql/join_utils.cc
@@ -28,7 +28,8 @@ generateWhereExpression(const std::vector<AnnotatedClause> & clause,
     std::shared_ptr<SqlExpression> result;
 
     for (auto & c: clause) {
-        auto tableClause = removeTableName(*c.expr, tableName);
+        set<Utf8String> aliases;
+        auto tableClause = removeTableName(*c.expr, tableName, aliases);
         if (!result)
             result = tableClause;
         else result = std::make_shared<BooleanOperatorExpression>(result, tableClause, "AND");
@@ -86,12 +87,34 @@ extractTableName(Utf8String & variableName, const std::set<Utf8String> & tables)
 // Replace all variable names like "table.x" with "x" to be run
 // in the context of a table
 std::shared_ptr<SqlExpression>
-removeTableName(const SqlExpression & expr, const Utf8String & tableName)
+removeTableName(const SqlExpression & expr, const Utf8String & tableName, const std::set<Utf8String>& childAliases)
 {
+    //prefixes to look for in variable names
+    //variable names use only the table name not the child aliases
+    //because the child columns will have been flattened
+    // i.e. if child table x has a column y, the dataset will have a x.y column
     Utf8String prefixToFind = tableName + ".";
     size_t prefixLength = prefixToFind.length();
     Utf8String prefixToFind2 = "\"" + tableName + "\"" + ".";
     size_t prefixLength2 = prefixToFind2.length();
+
+    std::vector<std::tuple<Utf8String, Utf8String, size_t> >  variablePrefixes = 
+            {(std::make_tuple(tableName, std::move(prefixToFind), prefixLength)), 
+             (std::make_tuple(tableName, std::move(prefixToFind2), prefixLength2)) };
+
+    //build list of prefixes to look for in function names
+    //with a tuple of table-name, prefix, prefix length
+    std::vector<std::tuple<Utf8String, Utf8String, size_t> > functionprefixes;
+    for (const Utf8String& alias : childAliases)
+    {
+        Utf8String prefixToFind = alias + ".";
+        size_t length = prefixToFind.length();
+        functionprefixes.push_back(std::make_tuple(alias, std::move(prefixToFind), length));
+
+        Utf8String prefixToFind2 = "\"" + alias + "\"" + ".";
+        length = prefixToFind.length();
+        functionprefixes.push_back(std::make_tuple(alias, std::move(prefixToFind2), length));
+    }
 
     // If an expression refers to a variable, then remove the table name
     // from it.  Otherwise return the same expression.
@@ -102,38 +125,39 @@ removeTableName(const SqlExpression & expr, const Utf8String & tableName)
             auto var = std::dynamic_pointer_cast<ReadVariableExpression>(a);
             if (var) {
 
-                if (var->variableName.startsWith(prefixToFind)) {
-                    Utf8String name(var->variableName);
-                    name.replace(0, prefixLength, Utf8String());
-                    ExcAssert(!name.empty());
-                    ExcAssert(!name.startsWith("."));
-
-                    return std::make_shared<ReadVariableExpression>(tableName, name);
-                }
-                else if (var->variableName.startsWith(prefixToFind2))
+                for (auto& prefixt : variablePrefixes)
                 {
-                    Utf8String name(var->variableName);
-                    name.replace(0, prefixLength2, Utf8String());
-                    ExcAssert(!name.empty());
-                    ExcAssert(!name.startsWith("."));
+                     if (var->variableName.startsWith(std::get<1>(prefixt))) {
+                        Utf8String name(var->variableName);
+                        name.replace(0, std::get<2>(prefixt), Utf8String());
+                        ExcAssert(!name.empty());
+                        ExcAssert(!name.startsWith("."));
 
-                    return std::make_shared<ReadVariableExpression>(tableName, name);
-                }
+                        cerr << "removed table name in var : " << var->variableName << " is now " << name << " from table " << std::get<0>(prefixt) << endl;
+
+                        return std::make_shared<ReadVariableExpression>(std::get<0>(prefixt), name);
+                    }
+                }               
             }
             auto func = std::dynamic_pointer_cast<FunctionCallWrapper>(a);
             if (func) {
-                if (func->functionName.startsWith(prefixToFind)) {
-                    Utf8String name(func->functionName);
-                    name.replace(0, prefixLength, Utf8String());
-                    ExcAssert(!name.empty());
-                    ExcAssert(!name.startsWith("."));
+                for (auto& prefixt : functionprefixes)
+                {
+                    if (func->functionName.startsWith(std::get<1>(prefixt))) {
+                        Utf8String name(func->functionName);
+                        name.replace(0, std::get<2>(prefixt), Utf8String());
+                        ExcAssert(!name.empty());
+                        ExcAssert(!name.startsWith("."));
 
-                    vector<std::shared_ptr<SqlExpression> > newArgs;
-                    for (auto & a: func->args) {
-                        newArgs.emplace_back(std::move(doArg(a)));
+                        vector<std::shared_ptr<SqlExpression> > newArgs;
+                        for (auto & a: func->args) {
+                            newArgs.emplace_back(std::move(doArg(a)));
+                        }
+
+                        cerr << "removed table name in function : " << func->functionName << " is now " << name << " from table " << std::get<0>(prefixt) << endl;
+
+                        return std::make_shared<FunctionCallWrapper>(std::get<0>(prefixt), name, std::move(newArgs), func->extract);
                     }
-
-                    return std::make_shared<FunctionCallWrapper>(tableName, name, std::move(newArgs), func->extract);
                 }
             }
 
@@ -204,7 +228,10 @@ AnnotatedClause(std::shared_ptr<SqlExpression> c,
 
         Utf8String tableName(v.begin(), dotIt);
 
+        cerr << "func " << v << " with table name " << tableName << endl;
+
         if (leftTables.count(tableName)) {
+            cerr << "left" << endl;
             v.replace(0, tableName.length() + 1,
                       Utf8String(""));
             ExcAssert(!v.empty());
@@ -212,6 +239,7 @@ AnnotatedClause(std::shared_ptr<SqlExpression> c,
             leftFuncs.emplace_back(std::move(v));
         }
         else if (rightTables.count(tableName)) {
+            cerr << "right" << endl;
             v.replace(0, tableName.length() + 1,
                       Utf8String(""));
             ExcAssert(!v.empty());
@@ -434,8 +462,13 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
             // Remove the "table." from "table.var" as we are running the
             // expression locally to the table, not in the context of the
             // join.
-            auto localExpr = removeTableName(*side.equalExpression,
-                                             side.table->getAs());
+
+            for (auto& n : side.table->getTableNames())
+            {
+                cerr << "table name in do side: " << n << endl;
+            }
+
+            auto localExpr = removeTableName(*side.equalExpression, side.table->getAs(), side.table->getTableNames());
 
             side.selectExpression = localExpr;
 
@@ -451,7 +484,9 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
             side.orderBy.clauses.emplace_back(localExpr, ASC);
         };
 
+    cerr << "do left side" << endl;
     doSide(left);
+    cerr << "do right side" << endl;
     doSide(right);
 }
 

--- a/sql/join_utils.h
+++ b/sql/join_utils.h
@@ -14,7 +14,7 @@ namespace Datacratic {
 namespace MLDB {
 
 std::shared_ptr<SqlExpression>
-removeTableName(const SqlExpression & expr, const Utf8String & tableName);
+removeTableName(const SqlExpression & expr, const Utf8String & tableName, const std::set<Utf8String>& aliases);
 
 
 /*****************************************************************************/

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -214,6 +214,7 @@ struct TableOperations {
     /// Get a function bound to the given dataset
     std::function<BoundFunction (SqlBindingScope & context,
                                  const Utf8String &,
+                                 const Utf8String &,
                                  const std::vector<std::shared_ptr<ExpressionValueInfo> > & args)>
     getFunction;
 

--- a/sql/table_expression_operations.cc
+++ b/sql/table_expression_operations.cc
@@ -29,11 +29,12 @@ bindDataset(std::shared_ptr<Dataset> dataset, Utf8String asName)
 
     // Allow the dataset to override functions
     result.table.getFunction = [=] (SqlBindingScope & context,
+                                    const Utf8String & tableName,
                                     const Utf8String & functionName,
                                     const std::vector<std::shared_ptr<ExpressionValueInfo> > & args)
         -> BoundFunction 
         {
-            return dataset->overrideFunction(functionName, context);
+            return dataset->overrideFunction(tableName, functionName, context);
         };
 
     // Allow the dataset to run queries


### PR DESCRIPTION
This fixes calling dataset.rowName() in 3 way joins by allowing the joinDataset to override the getFunction with the table name in order to check what was the original rowName from that dataset in the joined row.

Does *not* fix it for N-way joins yet, that will be next, I want to pull this to unblock some users.