### PR TITLE
Added RowScope to basic row generators (MLDB-1315)

### DIFF
--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -298,7 +298,11 @@ struct JoinedDataset::Itl
     };
 
     //Easiest case with constant Where
-    void makeJoinConstantWhere(AnnotatedJoinCondition& condition, SqlExpressionMldbContext& context, BoundTableExpression& left, BoundTableExpression& right, JoinQualification qualification)
+    void makeJoinConstantWhere(AnnotatedJoinCondition& condition,
+                               SqlExpressionMldbContext& context,
+                               BoundTableExpression& left,
+                               BoundTableExpression& right,
+                               JoinQualification qualification)
     {
         bool debug = false;
         bool outerLeft = qualification == JOIN_LEFT || qualification == JOIN_FULL;
@@ -336,7 +340,14 @@ struct JoinedDataset::Itl
                 auto generator = dataset.queryBasic
                 (context, queryExpression, side.when, *sideCondition, side.orderBy,
                  0, -1, true /* allowParallel */);
-                auto rows = generator(-1);
+
+                // Because we know that our outer context is an
+                // SqlExpressionMldbContext, we know that it takes an
+                // empty rowScope with nothing that depends on the current
+                // row.
+                SqlRowScope rowScope;
+
+                auto rows = generator(-1, rowScope);
             
                 if (debug)
                     cerr << "got rows " << jsonEncode(rows) << endl;

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -1180,6 +1180,7 @@ queryBasic(const SqlBindingScope & scope,
     bool whenTrue = when.when->isConstantTrue();
 
     auto exec = [=] (ssize_t numToGenerate,
+                     SqlRowScope & rowScope,
                      const BoundParameters & params)
         {
             // Get a list of rows that we run over

--- a/sql/execution_pipeline_impl.h
+++ b/sql/execution_pipeline_impl.h
@@ -72,7 +72,7 @@ struct GenerateRowsExecutor: public ElementExecutor {
     size_t currentDone;
     bool finished;
 
-    bool generateMore();
+    bool generateMore(SqlRowScope & scope);
 
     virtual std::shared_ptr<PipelineResults> take();
 

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -1228,6 +1228,7 @@ struct BasicRowGenerator {
 
     typedef std::function<std::vector<NamedRowValue>
                           (ssize_t numToGenerate,
+                           SqlRowScope & rowScope,
                            const BoundParameters & params)> Exec;
 
     BasicRowGenerator(Exec exec = nullptr, const std::string & explain = "")
@@ -1238,9 +1239,10 @@ struct BasicRowGenerator {
 
     std::vector<NamedRowValue>
     operator () (ssize_t numToGenerate,
+                 SqlRowScope & rowScope,
                  const BoundParameters & params = BoundParameters()) const
     {
-        return exec(numToGenerate, params);
+        return exec(numToGenerate, rowScope, params);
     }
 
     Exec exec;

--- a/sql/table_expression_operations.cc
+++ b/sql/table_expression_operations.cc
@@ -411,8 +411,6 @@ getUnbound() const
 /* DATASET FUNCTION EXPRESSION                                               */
 /*****************************************************************************/
 
-/** Used when doing a select inside a FROM clause **/
-
 DatasetFunctionExpression::
 DatasetFunctionExpression(Utf8String functionName, 
                           std::vector<std::shared_ptr<TableExpression>> & args,


### PR DESCRIPTION
Interface cleanup that's necessary for correlated subqueries and row-table expressions.

Test for MLDB-1273 was already failing on master; it's not a new failure.