### PR TITLE
Small cleanups in sql expression ops (MLDB-1321)

### DIFF
--- a/sql/binding_contexts.h
+++ b/sql/binding_contexts.h
@@ -199,6 +199,23 @@ struct SqlExpressionParamScope: public SqlBindingScope {
 };
 
 
+/*****************************************************************************/
+/* SQL EXPRESSION CONSTANT SCOPE                                             */
+/*****************************************************************************/
+
+/** Scope that will fail to bind anything apart from built-in function.
+    This is used to bind and evaluate constant expressions.
+*/
+
+struct SqlExpressionConstantScope: public SqlBindingScope {
+
+    static SqlRowScope getRowScope()
+    {
+        return SqlRowScope();
+    }
+};
+
+
 
 
 } // namespace MLDB

--- a/sql/builtin_dataset_functions.cc
+++ b/sql/builtin_dataset_functions.cc
@@ -133,11 +133,16 @@ BoundTableExpression sample(const SqlBindingScope & context,
                             const Utf8String& alias)
 {
     if (args.size() != 1)
-        throw HttpReturnException(500, "sample() takes 1 dataset as input, "
-                "followed by a options");
+        throw HttpReturnException(400, "sample() takes 1 dataset as input, "
+                                  "followed by a row of dataset options",
+                                  "options", options,
+                                  "alias", alias);
 
     if(!options.isRow())
-        throw ML::Exception("options should be a row");
+        throw HttpReturnException(400, "options should be a row; we got "
+                                  + jsonEncodeStr(options),
+                                  "options", options,
+                                  "alias", alias);
 
     auto ds = createSampledDatasetFn(context.getMldbServer(),
                                      args[0].dataset,

--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -1539,16 +1539,21 @@ bool
 SqlExpression::
 isConstant() const
 {
-    return false;
+    for (auto & c: getChildren()) {
+        if (!c->isConstant())
+            return false;
+    }
+    return true;
 }
 
 ExpressionValue
 SqlExpression::
 constantValue() const
 {
-    throw HttpReturnException(400, "Expression is not provably constant",
-                              "surface", surface,
-                              "ast", print());
+    SqlExpressionConstantScope scope;
+    auto bound = this->bind(scope);
+    SqlRowScope rowScope = scope.getRowScope();
+    return bound(rowScope);
 }
 
 std::map<ScopedName, UnboundVariable>

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -822,7 +822,18 @@ struct SqlExpression: public std::enable_shared_from_this<SqlExpression> {
     virtual bool isConstant() const;
 
     /** For expressions that are constant, return the result of the expression.
-        Default will throw.
+        This will be done by evaluation within a context that only has
+        builtin functions available.  If there is something that depends
+        upon something outside the context, it will be false.
+
+        Note that the isConstant() function returning true guarantees that
+        this call will succeed, but if isConstant() returns false it is
+        possible that the call succeeds anyway, due to SQL mandating lazy
+        evaluation.  Similarly for getUnbound().
+
+        Expression types that know how to rapidly evaluate a constant
+        can override to make this more efficient, eg to do so without
+        binding.
     */
     virtual ExpressionValue constantValue() const;
 

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -14,6 +14,7 @@
 #include "table_expression_operations.h"
 #include <unordered_set>
 #include "mldb/server/dataset_context.h"
+#include "mldb/base/scope.h"
 
 
 using namespace std;
@@ -1311,7 +1312,9 @@ bind(SqlBindingScope & context) const
     if (context.functionStackDepth > 100)
             throw HttpReturnException(400, "Reached a stack depth of over 100 functions while analysing query, possible infinite recursion");
 
-    context.functionStackDepth++;
+    ++context.functionStackDepth;
+    Scope_Exit(--context.functionStackDepth);
+
     std::vector<BoundSqlExpression> boundArgs;
     for (auto& arg : args)
     {
@@ -1331,7 +1334,6 @@ bind(SqlBindingScope & context) const
         //assume user
         boundOutput = bindUserFunction(context);
     }
-    context.functionStackDepth--;
     return boundOutput;
 }
 

--- a/sql/sql_expression_operations.h
+++ b/sql/sql_expression_operations.h
@@ -127,6 +127,7 @@ struct ReadVariableExpression: public SqlExpression {
     virtual std::string getType() const;
     virtual Utf8String getOperation() const;
     virtual std::vector<std::shared_ptr<SqlExpression> > getChildren() const;
+    virtual bool isConstant() const { return false; }
 
     Utf8String tableName;
     Utf8String variableName;
@@ -309,6 +310,7 @@ struct InExpression: public SqlExpression {
     virtual std::string getType() const;
     virtual Utf8String getOperation() const;
     virtual std::vector<std::shared_ptr<SqlExpression> > getChildren() const;
+    virtual bool isConstant() const { return false; } // TODO: not always
 
     std::shared_ptr<SqlExpression> expr;
     std::shared_ptr<TupleExpression> tuple;
@@ -358,9 +360,11 @@ struct BoundParameterExpression: public SqlExpression {
     virtual std::string getType() const;
     virtual Utf8String getOperation() const;
     virtual std::vector<std::shared_ptr<SqlExpression> > getChildren() const;
+    virtual bool isConstant() const { return false; }
 
     Utf8String paramName;
 };
+
 
 /*****************************************************************************/
 /* SQL ROW EXPRESSIONS                                                       */
@@ -400,6 +404,8 @@ struct WildcardExpression: public SqlRowExpression {
 
     virtual std::vector<std::shared_ptr<SqlExpression> > getChildren() const;
 
+    virtual bool isConstant() const { return false; }
+
     std::map<ScopedName, UnboundWildcard>
     wildcards() const;
 
@@ -435,7 +441,9 @@ struct ComputedVariable: public SqlRowExpression {
     virtual std::vector<std::shared_ptr<SqlExpression> > getChildren() const;
 };
 
-/** Wrapper when we dont know at parsing time if it is a user function or a builtin function */
+/** Wrapper when we dont know at parsing time if it is a user function
+    or a built-in function.
+*/
 struct FunctionCallWrapper: public SqlRowExpression {
     FunctionCallWrapper(Utf8String tableName,
                         Utf8String function,
@@ -459,6 +467,7 @@ struct FunctionCallWrapper: public SqlRowExpression {
     virtual std::string getType() const;
     virtual Utf8String getOperation() const;
     virtual std::vector<std::shared_ptr<SqlExpression> > getChildren() const;
+    virtual bool isConstant() const { return false; } // TODO: not always
 
     std::map<ScopedName, UnboundFunction> functionNames() const;
 
@@ -493,6 +502,8 @@ struct SelectColumnExpression: public SqlRowExpression {
 
     virtual std::shared_ptr<SqlExpression>
     transform(const TransformArgs & transformArgs) const;
+
+    virtual bool isConstant() const { return false; }
 
     virtual std::string getType() const
     {

--- a/sql/table_expression_operations.cc
+++ b/sql/table_expression_operations.cc
@@ -435,9 +435,8 @@ bind(SqlBindingScope & context) const
         boundArgs.push_back(arg->bind(context));
 
     ExpressionValue expValOptions;
-    if(options) {
-        BoundSqlExpression bound = options->bind(context);
-        expValOptions = bound(SqlRowScope());
+    if (options) {
+        expValOptions = options->constantValue();
     }
 
     auto fn = context.doGetDatasetFunction(functionName, boundArgs, expValOptions, asName);


### PR DESCRIPTION
- Improves the scope of SqlExpression::constantValue() allowing for it to be used in more situations
- Better error messages
- Improved accuracy in isConstant()
- Make function binding exception safer
