### PR TITLE
Mldb 1255 Fix calling dataset.rowName in N-way joins 

### DIFF
--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -283,8 +283,23 @@ struct JoinedDataset::Itl
     void recordJoinRow(const RowName & leftName, RowHash leftHash, const RowName & rightName, RowHash rightHash)
     {
         bool debug = false;
+        RowName rowName;
 
-        RowName rowName(leftName.toUtf8String() + "-" + rightName.toUtf8String());
+        if (leftName == RowName())
+        {
+            ExcAssert(rightName != RowName());
+            rowName = std::move(RowName(Utf8String("null") + "-" + rightName.toUtf8String()));
+        }
+        else if (rightName == RowName())
+        {
+            ExcAssert(leftName != RowName());
+            rowName = std::move(RowName(leftName.toUtf8String() + "-" + "null"));
+        }
+        else
+        {
+            rowName = std::move(RowName(leftName.toUtf8String() + "-" + rightName.toUtf8String()));
+        }
+
         RowHash rowHash(rowName);
 
         RowEntry entry;

--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -128,7 +128,9 @@ struct JoinedDataset::Itl
 
     /// Names of tables, so that we can correctly identify where each
     /// column came from.
-    std::vector<Utf8String> tableNames;
+    std::vector<Utf8String> sideChildNames[JOIN_SIDE_MAX]; //Sub (non -direct) tables left and right
+    Utf8String childAliases[JOIN_SIDE_MAX]; //Alias of the (direct) joined tables left and right
+    std::vector<Utf8String> tableNames; //sub tables from both side + direct childs left and right
 
     Itl(MldbServer * server, JoinedDatasetConfig joinConfig)
     {
@@ -152,11 +154,17 @@ struct JoinedDataset::Itl
         matrices.emplace_back(left.dataset->getMatrixView());
         matrices.emplace_back(right.dataset->getMatrixView());
 
+        childAliases[JOIN_SIDE_LEFT] = left.asName;
+        childAliases[JOIN_SIDE_RIGHT] = right.asName;
+
         tableNames = {left.asName, right.asName};
-       
+
         left.dataset->getChildAliases(tableNames);
         right.dataset->getChildAliases(tableNames);
 
+        left.dataset->getChildAliases(sideChildNames[JOIN_SIDE_LEFT]);
+        right.dataset->getChildAliases(sideChildNames[JOIN_SIDE_RIGHT]);
+      
         //if table aliases contains a dot '.', surround it with quotes to prevent ambiguity
         Utf8String quotedLeftName = left.asName;
         if (quotedLeftName.find('.') != quotedLeftName.end())
@@ -678,7 +686,7 @@ struct JoinedDataset::Itl
         return columnIndex.size();
     }
 
-    RowName getSubRowName(const RowName & name, JoinSide side)
+    RowName getSubRowName(const RowName & name, JoinSide side) const
     {   
         ExcAssert(side < JOIN_SIDE_MAX);
         RowHash rowHash(name);
@@ -691,9 +699,66 @@ struct JoinedDataset::Itl
         return JOIN_SIDE_LEFT == side ? entry.leftName : entry.rightName;
     };
 
+    //Query the original row name down the tree of joined datasets on that side
+    //The alternative would be to store a variable-size list of <alias,rowName> tuples for each row entry
+    RowName
+    getSubRowNameFromChildTable(const Utf8String& tableName, const RowName & name, JoinSide side) const
+    {
+        ExcAssert(side < JOIN_SIDE_MAX);
+        RowHash rowHash(name);
+        auto iter = rowIndex.find(rowHash);
+        if (iter == rowIndex.end())
+            return RowName();
+
+        int64_t index = iter->second;
+        const RowEntry& entry = rows[index];
+
+        RowName subRowName = JOIN_SIDE_LEFT == side ? entry.leftName : entry.rightName;
+
+        return datasets[side]->getOriginalRowName(tableName, subRowName);
+    }
+
+    //As getSubRowNameFromChildTable, but we dont know which side, or whether is a direct child or not.
+    RowName
+    getOriginalRowName(const Utf8String& tableName, const RowName & name) const
+    {
+        JoinSide tableSide = JOIN_SIDE_MAX;
+
+        if (tableName == getTableAlias(JOIN_SIDE_LEFT))
+            tableSide = JOIN_SIDE_LEFT;
+        else if (tableName == getTableAlias(JOIN_SIDE_RIGHT))
+            tableSide = JOIN_SIDE_RIGHT;
+
+        if (tableSide != JOIN_SIDE_MAX)
+        {
+            //its one of our childs
+            return getSubRowName(name, tableSide);
+        }
+
+        if (isChildTable(tableName, JOIN_SIDE_LEFT))
+            tableSide = JOIN_SIDE_LEFT;
+        else if (isChildTable(tableName, JOIN_SIDE_RIGHT))
+            tableSide = JOIN_SIDE_RIGHT;
+
+        if (tableSide != JOIN_SIDE_MAX)
+        {
+            //its a child of our child somewhere down this side
+            return getSubRowNameFromChildTable(tableName, name, tableSide);
+        }
+
+        return RowName();
+    }
+
+    //Alias of the direct child on that side    
     Utf8String getTableAlias(JoinSide side) const
     {
-        return tableNames[side];
+        return childAliases[side];
+    }
+
+    //Is this table alias found down the tree of joined datasets on that side
+    bool isChildTable(const Utf8String& tableName, JoinSide side) const
+    {
+        return std::find(sideChildNames[side].begin(), sideChildNames[side].end(), tableName) != sideChildNames[side].end();
     }
 };
 
@@ -769,6 +834,11 @@ overrideFunction(const Utf8String & tableName,
 {
     if (functionName == "rowName") {
 
+        if (tableName.empty())
+            return BoundFunction();
+
+        //we do as much "side-checking" as we can at binding time
+
         JoinedDataset::Itl::JoinSide tableSide = JoinedDataset::Itl::JOIN_SIDE_MAX;
 
         if (tableName == itl->getTableAlias(JoinedDataset::Itl::JOIN_SIDE_LEFT))
@@ -786,11 +856,36 @@ overrideFunction(const Utf8String & tableName,
                 },
                 std::make_shared<Utf8StringValueInfo>()
             };
-        }        
+        }
+
+        if (itl->isChildTable(tableName, JoinedDataset::Itl::JOIN_SIDE_LEFT))
+            tableSide = JoinedDataset::Itl::JOIN_SIDE_LEFT;
+        else if (itl->isChildTable(tableName, JoinedDataset::Itl::JOIN_SIDE_RIGHT))
+            tableSide = JoinedDataset::Itl::JOIN_SIDE_RIGHT;
+
+        if (tableSide != JoinedDataset::Itl::JOIN_SIDE_MAX)
+        {
+            return {[&, tableName, tableSide] (const std::vector<ExpressionValue> & args,
+                     const SqlRowScope & context)
+                {
+                    auto & row = static_cast<const SqlExpressionDatasetContext::RowContext &>(context);
+                    return ExpressionValue(itl->getSubRowNameFromChildTable(tableName, row.row.rowName, tableSide).toUtf8String(), Date::negativeInfinity());
+                },
+                std::make_shared<Utf8StringValueInfo>()
+            };
+        }
     }
 
     return BoundFunction();
 }
+
+RowName
+JoinedDataset::
+getOriginalRowName(const Utf8String& tableName, const RowName & name) const
+{
+    return itl->getOriginalRowName(tableName, name);
+}
+
 
 static RegisterDatasetType<JoinedDataset, JoinedDatasetConfig> 
 regJoined(builtinPackage(),

--- a/builtin/joined_dataset.h
+++ b/builtin/joined_dataset.h
@@ -58,6 +58,8 @@ struct JoinedDataset: public Dataset {
 
     virtual BoundFunction overrideFunction(const Utf8String & tableName, const Utf8String & functionName, SqlBindingScope & context) const;
 
+    virtual RowName getOriginalRowName(const Utf8String& tableName, const RowName & name) const;
+
 private:
     JoinedDatasetConfig datasetConfig;
     struct Itl;

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -1355,6 +1355,13 @@ overrideFunction(const Datacratic::Utf8String&,
     return BoundFunction();
 }
 
+RowName 
+Dataset::
+getOriginalRowName(const Utf8String& tableName, const RowName & name) const
+{
+    return name;
+}
+
 } // namespace MLDB
 } // namespace Datacratic
 

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -401,6 +401,10 @@ struct Dataset: public MldbEntity {
         the query is inappropriate.
     */
     virtual Date quantizeTimestamp(Date timestamp) const;
+
+    /* In the case of a dataset with rows composed from other datasets (i.e., joins)
+       This will return the name that the row has in the table with this alias*/
+    virtual RowName getOriginalRowName(const Utf8String& tableName, const RowName & name) const;
 };
 
 

--- a/testing/MLDB-180-basic-join.js
+++ b/testing/MLDB-180-basic-join.js
@@ -279,12 +279,12 @@ testQuery('SELECT * FROM test1 INNER JOIN test2 ON test1.x = 1',
           expected);
 
 expected = [
-   [ "_rowName", "test1.x", "test1.y", "test2.x", "test2.z", "test1.z" ],
-   [ "ex1-ex4", 1, 2, 1, 2, null ],
-   [ "ex1-ex6", 1, 2, null, 3, null ],
-   [ "ex2-", 2, null, null, null, 4 ],
-   [ "ex3-", null, null, null, null, 3 ],
-   [ "ex1-ex5", 1, 2, 2, 2, null ]
+   [ "_rowName", "test1.x", "test1.z", "test1.y", "test2.x", "test2.z" ],
+   [ "ex3-null", null, 3, null, null, null ],
+   [ "ex1-ex4", 1, null, 2, 1, 2 ],
+   [ "ex1-ex6", 1, null, 2, null, 3 ],
+   [ "ex1-ex5", 1, null, 2, 2, 2 ],
+   [ "ex2-null", 2, 4, null, null, null ]
 ];
 
 testQuery('SELECT * FROM test1 LEFT JOIN test2 ON test1.x = 1',
@@ -301,24 +301,24 @@ testQuery('SELECT * FROM test1 RIGHT JOIN test2 ON test1.x = 1',
           expected);
 
 expected = [
-   [ "_rowName", "test1.x", "test1.y", "test2.x", "test2.z", "test1.z" ],
+ [ "_rowName", "test2.x", "test2.z", "test1.x", "test1.y", "test1.z" ],
+   [ "null-ex6", null, 3, null, null, null ],
    [ "ex1-ex4", 1, 2, 1, 2, null ],
-   [ "ex2-ex4", 2, null, 1, 2, 4 ],
-   [ "-ex5", null, null, 2, 2, null ],
-   [ "-ex6", null, null, null, 3, null ],
-   [ "ex3-ex4", null, null, 1, 2, 3 ]
+   [ "ex2-ex4", 1, 2, 2, null, 4 ],
+   [ "null-ex5", 2, 2, null, null, null ],
+   [ "ex3-ex4", 1, 2, null, null, 3 ]
 ];
 
 testQuery('SELECT * FROM test1 RIGHT JOIN test2 ON test2.x = 1',
           expected);
 
 expected = [
-[ "_rowName", "test1.x", "test1.y", "test2.x", "test2.z", "test1.z" ],
-   [ "ex1-ex4", 1, 2, 1, 2, null ],
-   [ "ex2-", 2, null, null, null, 4 ],
-   [ "-ex5", null, null, 2, 2, null ],
-   [ "ex3-", null, null, null, null, 3 ],
-   [ "-ex6", null, null, null, 3, null ]
+[ "_rowName", "test2.x", "test2.z", "test1.x", "test1.z", "test1.y" ],
+   [ "null-ex6", null, 3, null, null, null ],
+   [ "ex3-null", null, null, null, 3, null ],
+   [ "ex1-ex4", 1, 2, 1, null, 2 ],
+   [ "null-ex5", 2, 2, null, null, null ],
+   [ "ex2-null", null, null, 2, 4, null ]
 ];
 
 testQuery('SELECT * FROM test1 FULL JOIN test2 ON test1.x = 1 AND test2.x = 1',
@@ -331,33 +331,33 @@ testQuery('SELECT * FROM test1 FULL OUTER JOIN test2 ON test1.x = 1 AND test2.x 
           expected);
 
 expected = [
-   [ "_rowName", "test1.x", "test1.y", "test2.x", "test2.z", "test1.z" ],
-   [ "ex1-ex4", 1, 2, 1, 2, null ],
-   [ "ex3-", null, null, null, null, 3 ],
-   [ "-ex6", null, null, null, 3, null ],
-   [ "ex2-ex5", 2, null, 2, 2, 4 ]
+   [ "_rowName", "test2.x", "test2.z", "test1.x", "test1.z", "test1.y" ],
+   [ "null-ex6", null, 3, null, null, null ],
+   [ "ex3-null", null, null, null, 3, null ],
+   [ "ex1-ex4", 1, 2, 1, null, 2 ],
+   [ "ex2-ex5", 2, 2, 2, 4, null ]
 ];
 
 testQuery('SELECT * FROM test1 FULL JOIN test2 ON test1.x = test2.x',
           expected);
 
 expected = [
-   [ "_rowName", "test1.x", "test1.y", "test2.x", "test2.z", "test1.z" ],
-   [ "ex1-ex4", 1, 2, 1, 2, null ],
-   [ "ex2-", 2, null, null, null, 4 ],
-   [ "-ex5", null, null, 2, 2, null ],
-   [ "ex3-", null, null, null, null, 3 ],
-   [ "-ex6", null, null, null, 3, null ]
+   [ "_rowName", "test2.x", "test2.z", "test1.x", "test1.z", "test1.y" ],
+   [ "null-ex6", null, 3, null, null, null ],
+   [ "ex3-null", null, null, null, 3, null ],
+   [ "ex1-ex4", 1, 2, 1, null, 2 ],
+   [ "null-ex5", 2, 2, null, null, null ],
+   [ "ex2-null", null, null, 2, 4, null ]
 ];
 
 testQuery('SELECT * FROM test1 FULL JOIN test2 ON (test1.x = test2.x) AND (test2.x != 2)',
           expected);
 
 expected = [
-   [ "_rowName", "test1.x", "test1.y", "test2.x", "test2.z", "test1.z" ],
-   [ "ex1-ex4", 1, 2, 1, 2, null ],
-   [ "ex2-", 2, null, null, null, 4 ],
-   [ "ex3-", null, null, null, null, 3 ]
+   [ "_rowName", "test1.x", "test1.z", "test1.y", "test2.x", "test2.z" ],
+   [ "ex3-null", null, 3, null, null, null ],
+   [ "ex1-ex4", 1, null, 2, 1, 2 ],
+   [ "ex2-null", 2, 4, null, null, null ]
 ];
 
 testQuery('SELECT * FROM test1 LEFT JOIN test2 ON test1.x = test2.x AND test2.x != 2',
@@ -367,10 +367,10 @@ testQuery('SELECT * FROM test1 LEFT OUTER JOIN test2 ON test1.x = test2.x AND te
           expected);
 
 expected = [
-   [ "_rowName", "test1.x", "test1.y", "test2.x", "test2.z" ],
+   [ "_rowName", "test2.x", "test2.z", "test1.x", "test1.y" ],
+   [ "null-ex6", null, 3, null, null ],
    [ "ex1-ex4", 1, 2, 1, 2 ],
-   [ "-ex5", null, null, 2, 2 ],
-   [ "-ex6", null, null, null, 3 ]
+   [ "null-ex5", 2, 2, null, null ]
 ];
 
 testQuery('SELECT * FROM test1 RIGHT JOIN test2 ON test1.x = test2.x AND test2.x != 2',
@@ -406,26 +406,26 @@ dataset4.commit()
 dataset5.commit()
 
 expected = [
-   [ "_rowName", "test3.x", "test3.y", "test3.z", "test4.x", "test4.z" ],
-   [ "ex1-", 1, 2, null, null, null ],
-   [ "ex2-", 2, null, 4, null, null ],
-   [ "-ex5", null, null, null, null, 3 ],
-   [ "ex3-ex3", null, null, 3, 1, 2 ],
-   [ "-ex4", null, null, null, 2, 2 ]
+   [ "_rowName", "test4.x", "test4.z", "test3.x", "test3.z", "test3.y" ],
+   [ "null-ex5", null, 3, null, null, null ],
+   [ "null-ex4", 2, 2, null, null, null ],
+   [ "ex3-ex3", 1, 2, null, 3, null ],
+   [ "ex2-null", null, null, 2, 4, null ],
+   [ "ex1-null", null, null, 1, null, 2 ]
 ];
 
 testQuery('SELECT * FROM test3 OUTER JOIN test4 ON test3.rowName() = test4.rowName()',
           expected);
 
 expected = [
-   [ "_rowName", "test4.x", "test4.z", "test5.x", "test5.z", "test3.x", "test3.z", "test3.y" ],
-   [ "-ex5-", null, 3, null, null, null, null, null ],
-   [ "-ex4-", 2, 2, null, null, null, null, null ],
-   [ "-ex5", null, null, 1, 2, null, null, null ],
-   [ "ex2--", null, null, null, null, 2, 4, null ],
-   [ "ex3-ex3-", 1, 2, null, null, null, 3, null ],
-   [ "-ex6", null, null, 2, 2, null, null, null ],
-   [ "ex1--ex1", null, null, null, 3, 1, null, 2 ]
+   [ "_rowName", "test3.x", "test3.y", "test5.x", "test5.z", "test3.z", "test4.x", "test4.z" ],
+   [ "ex1-null-ex1", 1, 2, null, 3, null, null, null ],
+   [ "null-ex6", null, null, 2, 2, null, null, null ],
+   [ "null-ex5", null, null, 1, 2, null, null, null ],
+   [ "ex2-null-null", 2, null, null, null, 4, null, null ],
+   [ "null-ex5-null", null, null, null, null, null, null, 3 ],
+   [ "null-ex4-null", null, null, null, null, null, 2, 2 ],
+   [ "ex3-ex3-null", null, null, null, null, 3, 1, 2 ]
 ];
 
 testQuery('SELECT * FROM test3 OUTER JOIN test4 ON test3.rowName() = test4.rowName() OUTER JOIN test5 on test3.rowName() = test5.rowName()',
@@ -439,16 +439,16 @@ dataset6.recordRow("ex6", [ [ "x", null, ts ], ["z", 3, ts] ]);
 dataset6.commit()
 
 expected = [
-   [  "_rowName", "test3.x", "test3.z", "test4.x", "test4.z", "test6.x", "test6.z", "test3.y", "test5.x", "test5.z" ],
-   [ "ex3-ex3--ex3", null, 3, 1, 2, 1, 2, null, null, null ],
-   [ "ex1--ex1-", 1, null, null, null, null, null, 2, null, 3 ],
-   [ "-ex4--", null, null, 2, 2, null, null, null, null, null ],
-   [ "-ex5-", null, null, null, null, null, null, null, 1, 2 ],
-   [ "ex2---", 2, 4, null, null, null, null, null, null, null ],
-   [ "-ex6-", null, null, null, null, null, null, null, 2, 2 ],
-   [ "-ex6", null, null, null, null, null, 3, null, null, null ],
-   [ "-ex4", null, null, null, null, 2, 2, null, null, null ],
-   [ "-ex5--", null, null, null, 3, null, null, null, null, null ]
+   [ "_rowName", "test6.x", "test6.z", "test5.x", "test5.z", "test3.x", "test3.y", "test3.z", "test4.x", "test4.z" ],
+   [ "null-ex6", null, 3, null, null, null, null, null, null, null ],
+   [ "null-ex5-null", null, null, 1, 2, null, null, null, null, null ],
+   [ "ex1-null-ex1-null", null, null, null, 3, 1, 2, null, null, null ],
+   [ "null-ex4", 2, 2, null, null, null, null, null, null, null ],
+   [ "null-ex6-null", null, null, 2, 2, null, null, null, null, null ],
+   [ "ex2-null-null-null", null, null, null, null, 2, null, 4, null, null ],
+   [ "null-ex4-null-null", null, null, null, null, null, null, null, 2, 2 ],
+   [ "null-ex5-null-null", null, null, null, null, null, null, null, null, 3 ],
+   [ "ex3-ex3-null-ex3", 1, 2, null, null, null, null, 3, 1, 2 ]
 ];
 
 

--- a/testing/MLDB-180-basic-join.js
+++ b/testing/MLDB-180-basic-join.js
@@ -431,4 +431,28 @@ expected = [
 testQuery('SELECT * FROM test3 OUTER JOIN test4 ON test3.rowName() = test4.rowName() OUTER JOIN test5 on test3.rowName() = test5.rowName()',
           expected);
 
+var dataset6 = mldb.createDataset({type:'sparse.mutable',id:'test6'});
+dataset6.recordRow("ex3", [ [ "x", 1, ts ], ["z", 2, ts] ]);
+dataset6.recordRow("ex4", [ [ "x", 2, ts ], ["z", 2, ts] ]);
+dataset6.recordRow("ex6", [ [ "x", null, ts ], ["z", 3, ts] ]);
+
+dataset6.commit()
+
+expected = [
+   [  "_rowName", "test3.x", "test3.z", "test4.x", "test4.z", "test6.x", "test6.z", "test3.y", "test5.x", "test5.z" ],
+   [ "ex3-ex3--ex3", null, 3, 1, 2, 1, 2, null, null, null ],
+   [ "ex1--ex1-", 1, null, null, null, null, null, 2, null, 3 ],
+   [ "-ex4--", null, null, 2, 2, null, null, null, null, null ],
+   [ "-ex5-", null, null, null, null, null, null, null, 1, 2 ],
+   [ "ex2---", 2, 4, null, null, null, null, null, null, null ],
+   [ "-ex6-", null, null, null, null, null, null, null, 2, 2 ],
+   [ "-ex6", null, null, null, null, null, 3, null, null, null ],
+   [ "-ex4", null, null, null, null, 2, 2, null, null, null ],
+   [ "-ex5--", null, null, null, 3, null, null, null, null, null ]
+];
+
+
+testQuery('SELECT * FROM test3 OUTER JOIN test4 ON test3.rowName() = test4.rowName() OUTER JOIN test5 on test3.rowName() = test5.rowName() OUTER JOIN test6 on test3.rowName() = test6.rowName()',
+          expected);
+
 "success"


### PR DESCRIPTION
And also replace empty rowname entries with "null" in outer joins.

I wasnt sure is getOriginalRowName should be part of the dataset interface or the MatrixView interface - I picked the dataset interface because I thought MatrixView and ColumnIndex were mainly meant as pure interfaces, while getOriginalRowName should only be overriden by the JoinDataset. But Im open to suggestions.