### PR TITLE
Added BLOB cell value (MLDB-1213)

### DIFF
--- a/container_files/assets/www/doc/builtin/lang/Javascript.md
+++ b/container_files/assets/www/doc/builtin/lang/Javascript.md
@@ -224,6 +224,11 @@ The Stream object has the following methods:
 - `readU32BE()` reads and returns the next four bytes as an unsigned big endian integer
 - `readI32LE()` reads and returns the next four bytes as an signed little endian integer
 - `readI32BE()` reads and returns the next four bytes as an signed big endian integer
+- `readBlob(numBytes=-1,allowShortReads=false)` reads and returns the given
+  number of bytes (or all remaining bytes, if `numBytes` is -1) into a `BLOB`
+  Atom.  If EOF is reached before the required `numBytes` has been read, and
+  `numBytes` is not -1, and `allowShortReads` is `false`, then an exception will
+  be thrown.
 
 
 ### Dataset objects

--- a/container_files/assets/www/doc/builtin/sql/TypeSystem.md
+++ b/container_files/assets/www/doc/builtin/sql/TypeSystem.md
@@ -24,6 +24,11 @@ at GMT.
 internally represented as three fields expressing months, days, and seconds.
     - Time intervals can appear in queries using the `INTERVAL` keyword, for example `INTERVAL '1 month 2 days 5 minutes'`
     - See [Expressing Time Intervals](ValueExpression.md) for full details on input format.
+- A binary blob.  This
+  can be used to store or process arbitrary binary data, including that which
+  contains characters that can't be represented as a string.
+  - Binary blobs can appear in queries using the `base64_decode` function
+    with a string as its argument.
 
 These types are used in different ways, depending upon whether they are stored
 in a dataset or processed as part of an expression.

--- a/container_files/assets/www/doc/builtin/sql/ValueExpression.md
+++ b/container_files/assets/www/doc/builtin/sql/ValueExpression.md
@@ -329,6 +329,13 @@ Note that this syntax is not part of SQL, it is an MLDB extension.
   - if `x` is a string that can be converted to a number, return the number
   - otherwise, return `x` unchanged
 
+### Encoding and decoding functions
+
+- `base64_encode(blob)` returns the base-64 encoded version of the blob
+  (or string) argument as a string.
+- `base64_decode(string)` returns a blob containing the decoding of the
+  base-64 data provided in its argument.
+
 ### Numeric functions
 
 - `pow(x, y)`: returns x to the power of y.

--- a/core/function.cc
+++ b/core/function.cc
@@ -596,6 +596,13 @@ addAtomValue(const std::string & name)
 
 void
 FunctionValues::
+addBlobValue(const std::string & name)
+{
+    addValue(Utf8String(name), std::make_shared<BlobValueInfo>());
+}
+
+void
+FunctionValues::
 addNumericValue(const std::string & name)
 {
     addValue(Utf8String(name), std::make_shared<NumericValueInfo>());

--- a/core/function.h
+++ b/core/function.h
@@ -332,6 +332,9 @@ struct FunctionValues {
     /** Add a named value that is an atom (null, number, string). */
     void addAtomValue(const std::string & name);
 
+    /** Add a named value that is a blob. */
+    void addBlobValue(const std::string & name);
+
     /** Add a named value that is a floating point number. */
     void addNumericValue(const std::string & name);
 

--- a/http/http_exception.h
+++ b/http/http_exception.h
@@ -1,9 +1,9 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** http_exception.h                                               -*- C++ -*-
     Jeremy Barnes, 13 January 2015
     Copyright (c) 2015 Datacratic Inc.  All rights.
 
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+    
     Exception class to use to return HTTP exceptions.
 */
 

--- a/jml/utils/utils.mk
+++ b/jml/utils/utils.mk
@@ -9,10 +9,9 @@ LIBUTILS_SOURCES := \
 	csv.cc \
 	hex_dump.cc \
 	floating_point.cc \
-	rng.cc \
-	hash.cc
+	rng.cc
 
-LIBUTILS_LINK :=	arch cryptopp vfs
+LIBUTILS_LINK :=	arch vfs
 
 $(eval $(call library,utils,$(LIBUTILS_SOURCES),$(LIBUTILS_LINK)))
 

--- a/plugins/lang/js/js_common.cc
+++ b/plugins/lang/js/js_common.cc
@@ -122,13 +122,14 @@ void to_js(JS::JSValue & value, const CellValue & val)
     else if (val.isTimestamp()) {
         to_js(value, val.toTimestamp());
     }
-    else if (val.isTimeinterval()) {
+    else if (val.isString()) {
+        to_js(value, val.toString());
+    }
+    else {
         // Get our context so we can return a proper object
         JsPluginContext * cxt = JsContextScope::current();
         value = CellValueJS::create(val, cxt);
     }
-    else
-        to_js(value, val.toString());
 }
 
 ExpressionValue from_js(const JS::JSValue & value, ExpressionValue *)

--- a/plugins/lang/js/mldb_js.h
+++ b/plugins/lang/js/mldb_js.h
@@ -1,10 +1,10 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** mldb_js.h                                                   -*- C++ -*-
     Jeremy Barnes, 14 June 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
 
-    JS interface for mldbs.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+    JS interface for mldb.
 */
 
 #pragma once

--- a/soa/service/s3.cc
+++ b/soa/service/s3.cc
@@ -22,7 +22,7 @@
 #include "mldb/vfs/filter_streams.h"
 #include "mldb/vfs/filter_streams_registry.h"
 #include "mldb/jml/utils/ring_buffer.h"
-#include "mldb/jml/utils/hash.h"
+#include "mldb/utils/hash.h"
 #include "mldb/jml/utils/file_functions.h"
 #include "mldb/jml/utils/info.h"
 #include "mldb/jml/utils/environment.h"

--- a/soa/service/service.mk
+++ b/soa/service/service.mk
@@ -63,7 +63,7 @@ LIBCLOUD_SOURCES := \
 
 #	hdfs.cc
 
-LIBCLOUD_LINK := utils arch types value_description tinyxml2 services crypto++ ssh2 boost_filesystem archive #hdfs3
+LIBCLOUD_LINK := utils arch types value_description tinyxml2 services crypto++ ssh2 boost_filesystem archive hash #hdfs3
 
 
 $(eval $(call library,cloud,$(LIBCLOUD_SOURCES),$(LIBCLOUD_LINK)))

--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -15,6 +15,7 @@
 #include "mldb/types/vector_description.h"
 #include "mldb/ml/confidence_intervals.h"
 #include "mldb/jml/math/xdiv.h"
+#include "mldb/utils/hash.h"
 #include "mldb/base/parse_context.h"
 #include <boost/lexical_cast.hpp>
 
@@ -1483,6 +1484,51 @@ BoundFunction concat(const std::vector<BoundSqlExpression> & args)
     };
 }
 static RegisterBuiltin registerConcat(concat, "concat");
+
+BoundFunction base64_encode(const std::vector<BoundSqlExpression> & args)
+{
+    // Convert a blob into base64
+    if (args.size() != 1)
+        throw HttpReturnException(400, "base64_encode function takes 1 argument");
+    return {[=] (const std::vector<ExpressionValue> & args,
+                 const SqlRowScope & context) -> ExpressionValue
+            {
+                ExcAssertEqual(args.size(), 1);
+                Utf8String str = args[0].toUtf8String();
+                return ExpressionValue(base64Encode(str.rawData(),
+                                                    str.rawLength()),
+                                       args[0].getEffectiveTimestamp());
+            },
+            std::make_shared<StringValueInfo>()
+            };
+}
+
+static RegisterBuiltin registerBase64Encode(base64_encode, "base64_encode");
+
+BoundFunction base64_decode(const std::vector<BoundSqlExpression> & args)
+{
+    // Return an expression but with the timestamp modified to something else
+
+    if (args.size() != 1)
+        throw HttpReturnException(400, "base64_decode function takes 1 argument");
+    return {[=] (const std::vector<ExpressionValue> & args,
+                 const SqlRowScope & context) -> ExpressionValue
+            {
+                ExcAssertEqual(args.size(), 1);
+                CellValue blob = args[0].coerceToBlob();
+                return ExpressionValue(base64Decode((const char *)blob.blobData(),
+                                                    blob.blobLength()),
+                                       args[0].getEffectiveTimestamp());
+            },
+            std::make_shared<BlobValueInfo>()
+            };
+}
+
+static RegisterBuiltin registerBase64Decode(base64_decode, "base64_decode");
+
+
+
+
 
 } // namespace Builtins
 } // namespace MLDB

--- a/sql/cell_value.cc
+++ b/sql/cell_value.cc
@@ -1,9 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** cell_value.cc
     Jeremy Barnes, 24 December 2014
     Copyright (c) 2014 Datacratic Inc.  All rights reserved.
 
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 */
 
 #include "cell_value.h"
@@ -66,6 +65,24 @@ fromMonthDaySecond( int64_t months, int64_t days, double seconds)
     }
 
     return value;
+}
+
+CellValue
+CellValue::
+blob(std::string blobContents)
+{
+    CellValue result;
+    result.initBlob(blobContents.data(), blobContents.length());
+    return result;
+}
+
+CellValue
+CellValue::
+blob(const char * mem, size_t sz)
+{
+    CellValue result;
+    result.initBlob(mem, sz);
+    return result;
 }
 
 void
@@ -131,11 +148,30 @@ initString(const char * stringValue, size_t len, bool isUtf8, bool check)
     }
 }
 
+void
+CellValue::
+initBlob(const char * data, size_t len)
+{
+    strLength = len;
+    if (len <= INTERNAL_LENGTH) {
+        std::copy(data, data + len, shortString);
+        type = ST_SHORT_BLOB;
+    }
+    else {
+        void * mem = malloc(sizeof(StringRepr) + len);
+        longString = new (mem) StringRepr;
+        std::copy(data, data + len, longString->repr);
+        type = ST_LONG_BLOB;
+    }
+}
+
 CellValue::
 CellValue(const CellValue & other)
     : bits1(other.bits1), bits2(other.bits2), flags(other.flags)
 {
-    if (other.type == ST_ASCII_LONG_STRING || other.type == ST_UTF8_LONG_STRING) {
+    if (other.type == ST_ASCII_LONG_STRING
+        || other.type == ST_UTF8_LONG_STRING
+        || other.type == ST_LONG_BLOB) {
         void * mem = malloc(sizeof(StringRepr) + other.strLength + 1);
         longString = new (mem) StringRepr;
         std::copy(other.longString->repr, other.longString->repr + strLength,
@@ -213,6 +249,9 @@ cellType() const
         return TIMESTAMP;    
     case ST_TIMEINTERVAL:
         return TIMEINTERVAL;
+    case ST_SHORT_BLOB:
+    case ST_LONG_BLOB:
+        return BLOB;
     default:
         throw HttpReturnException(400, "unknown CellValue type");
     }
@@ -285,13 +324,14 @@ toString() const
     case ST_UTF8_SHORT_STRING:
     case ST_UTF8_LONG_STRING:
         throw HttpReturnException(400, "cannot call toString on utf8 string");
-    case ST_TIMESTAMP: {
+    case ST_TIMESTAMP:
         return Date::fromSecondsSinceEpoch(timestamp)
             .printIso8601(-1 /* as many digits as necessary */);
-    }
-    case ST_TIMEINTERVAL: {
+    case ST_TIMEINTERVAL:
         return printInterval();
-    }
+    case ST_SHORT_BLOB:
+    case ST_LONG_BLOB:
+        throw HttpReturnException(400, "Cannot call toString() on a blob");
     default:
         throw HttpReturnException(400, "unknown CellValue type");
     }
@@ -481,6 +521,20 @@ coerceToTimestamp() const
     return CellValue();
 }
 
+CellValue
+CellValue::
+coerceToBlob() const
+{
+    if (type == ST_EMPTY)
+        return CellValue();
+    else if (isBlob())
+        return *this;
+    else if (isString()) {
+        return CellValue::blob(toUtf8String().stealRawString());
+    }
+    return toUtf8String();
+}
+
 bool
 CellValue::
 asBool() const
@@ -551,6 +605,8 @@ isFalse() const
     case ST_ASCII_LONG_STRING:
     case ST_UTF8_SHORT_STRING:
     case ST_UTF8_LONG_STRING:
+    case ST_SHORT_BLOB:
+    case ST_LONG_BLOB:
         return !strLength;
     case ST_TIMESTAMP:
     case ST_TIMEINTERVAL:
@@ -575,9 +631,11 @@ hash() const
     switch (type) {
     case ST_ASCII_SHORT_STRING:
     case ST_UTF8_SHORT_STRING:
+    case ST_SHORT_BLOB:
         return CellValueHash(mldb_siphash24(shortString, strLength, defaultSeedStable.b));
     case ST_ASCII_LONG_STRING:
     case ST_UTF8_LONG_STRING:
+    case ST_LONG_BLOB:
         if (!longString->hash) {
             longString->hash = mldb_siphash24(longString->repr, strLength, defaultSeedStable.b);
         }
@@ -626,10 +684,12 @@ operator == (const CellValue & other) const
         return toDouble() == other.toDouble();
     case ST_ASCII_SHORT_STRING:
     case ST_UTF8_SHORT_STRING:
+    case ST_SHORT_BLOB:
         return strLength == other.strLength
             && strncmp(shortString, other.shortString, strLength) == 0;
     case ST_ASCII_LONG_STRING:
     case ST_UTF8_LONG_STRING:
+    case ST_LONG_BLOB:
         return strLength == other.strLength
             && strncmp(longString->repr, other.longString->repr, strLength) == 0;
     case ST_TIMESTAMP:
@@ -657,7 +717,7 @@ operator <  (const CellValue & other) const
     // Sort order:
     // 1.  EMPTY
     // 2.  INTEGER or FLOAT, compared numerically
-    // 3.  STRING, compared lexicographically
+    // 3.  STRING or BLOB, compared lexicographically
 
     try {
         if (JML_UNLIKELY(flags == other.flags && bits1 == other.bits1 && bits2 == other.bits2))
@@ -748,6 +808,14 @@ operator <  (const CellValue & other) const
 
                 return sign1 ? !smaller : smaller;
             }
+        case ST_SHORT_BLOB:
+        case ST_LONG_BLOB:
+            if (!isBlobType((StorageType)other.type))
+                return false;
+
+            return std::lexicographical_compare
+                (blobData(), blobData() + blobLength(),
+                 other.blobData(), other.blobData() + other.blobLength());
         default:
             throw HttpReturnException(400, "unknown CellValue type");
         }
@@ -769,6 +837,8 @@ stringChars() const
     case ST_FLOAT:
     case ST_TIMESTAMP:
     case ST_TIMEINTERVAL:
+    case ST_SHORT_BLOB:
+    case ST_LONG_BLOB:
         return nullptr;
     case ST_ASCII_SHORT_STRING:
     case ST_UTF8_SHORT_STRING:
@@ -805,6 +875,35 @@ toStringLength() const
     }
 }
 
+const unsigned char *
+CellValue::
+blobData() const
+{
+    switch (type) {
+    case ST_SHORT_BLOB:
+        return (const unsigned char *)shortString;
+    case ST_LONG_BLOB:
+        return (const unsigned char *)longString->repr;
+    default:
+        throw HttpReturnException(400, "CellValue is not a blob",
+                                  "value", *this);
+    }
+}
+
+uint32_t
+CellValue::
+blobLength() const
+{
+    switch (type) {
+    case ST_SHORT_BLOB:
+    case ST_LONG_BLOB:
+        return strLength;
+    default:
+        throw HttpReturnException(400, "CellValue is not a blob",
+                                  "value", *this);
+    }
+}
+
 bool
 CellValue::
 isExactDouble() const
@@ -817,6 +916,8 @@ isExactDouble() const
     case ST_ASCII_LONG_STRING:
     case ST_UTF8_SHORT_STRING:
     case ST_UTF8_LONG_STRING:
+    case ST_SHORT_BLOB:
+    case ST_LONG_BLOB:
         return false;
     case ST_INTEGER:
         return int64_t(toDouble()) == toInt();
@@ -962,6 +1063,34 @@ struct CellValueDescription: public ValueDescriptionT<CellValue> {
                 expect_interval(context, months, days, seconds);
                 *val = CellValue::fromMonthDaySecond(months, days, seconds);
             }            
+            else if (v.isMember("blob")) {
+                std::string contents;
+
+                if (!v["blob"].isNull()) {
+                    if (!v["blob"].type() == Json::arrayValue) {
+                        throw HttpReturnException(400, "JSON blob is not an array: '" + v.toStringNoNewLine() + "'");
+                    }
+                    for (auto & v2: v["blob"]) {
+                        if (v2.isUInt() || v2.isInt()) {
+                            uint64_t val = v2.asUInt();
+                            if (val > 255)
+                                context.exception("Invalid byte value " + to_string(val) + " reading blob data (must be 0-255)");
+                            contents += val;
+                        }
+                        else if (v2.isString()) {
+                            std::string part = v2.asString();
+                            contents += part;
+                        }
+                        else context.exception
+                                 ("Can't deal with unknown array entry '"
+                                  + v2.toStringNoNewLine()
+                                  + "' reading blob data");
+
+                    }
+                }
+
+                *val = CellValue::blob(std::move(contents));
+            }
             else {
                 throw HttpReturnException(400, "Unknown JSON CellValue '" + v.toStringNoNewLine() + "'");
             }
@@ -1023,6 +1152,40 @@ struct CellValueDescription: public ValueDescriptionT<CellValue> {
             v2["interval"] = val->toString();
             context.writeJson(v2);
             return;         
+        }
+        case CellValue::BLOB: {
+            context.startObject();
+            context.startMember("blob");
+            context.startArray();
+            
+            // Chunks of ASCII are written as a string; non-ASCII is
+            // as integers.
+            const unsigned char * p = val->blobData();
+            const unsigned char * e = p + val->blobLength();
+
+            while (p < e) {
+                const unsigned char * s = p;
+                while (p < e && *p >= ' ' && *p < 127 && isascii(*p))
+                    ++p;
+                size_t len = p - s;
+                //cerr << "len = " << len << endl;
+                if (len == 1) {
+                    context.newArrayElement();
+                    context.writeInt(*s);
+                }
+                else if (len >= 2) {
+                    context.newArrayElement();
+                    context.writeString(string(s, p));
+                }
+                
+                while (p < e && (*p <= ' ' || *p >= 127 || !isascii(*p))) {
+                    context.newArrayElement();
+                    context.writeInt(*p++);
+                }
+            }
+            context.endArray();
+            context.endObject();
+            return;
         }
         default:
             throw HttpReturnException(400, "unknown cell type");

--- a/sql/cell_value_impl.h
+++ b/sql/cell_value_impl.h
@@ -1,9 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
-/** cell_value.h                                                   -*- C++ -*-
+/** cell_value_impl.h                                              -*- C++ -*-
     Jeremy Barnes, 24 December 2014
     Copyright (c) 2014 Datacratic Inc.  All rights reserved.
 
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 */
 
 #pragma once
@@ -126,6 +125,13 @@ CellValue::
 isStringType(StorageType type)
 {
     return type == ST_ASCII_SHORT_STRING || type == ST_ASCII_LONG_STRING || type == ST_UTF8_SHORT_STRING || type == ST_UTF8_LONG_STRING;
+}
+
+bool
+CellValue::
+isBlobType(StorageType type)
+{
+    return type == ST_SHORT_BLOB || type == ST_LONG_BLOB;
 }
 
 

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -1782,6 +1782,15 @@ coerceToTimestamp() const
     return cell_.coerceToTimestamp();
 }
 
+CellValue
+ExpressionValue::
+coerceToBlob() const
+{
+    if (type_ != ATOM)
+        return CellValue();
+    return cell_.coerceToBlob();
+}
+
 void
 ExpressionValue::
 setAtom(CellValue value, Date ts)
@@ -2182,6 +2191,7 @@ template class ExpressionValueInfoT<double>;
 template class ExpressionValueInfoT<CellValue>;
 template class ExpressionValueInfoT<std::string>;
 template class ExpressionValueInfoT<Utf8String>;
+template class ExpressionValueInfoT<std::vector<unsigned char> >;
 template class ExpressionValueInfoT<int64_t>;
 template class ExpressionValueInfoT<uint64_t>;
 template class ExpressionValueInfoT<char>;
@@ -2191,6 +2201,7 @@ template class ScalarExpressionValueInfoT<double>;
 template class ScalarExpressionValueInfoT<CellValue>;
 template class ScalarExpressionValueInfoT<std::string>;
 template class ScalarExpressionValueInfoT<Utf8String>;
+template class ScalarExpressionValueInfoT<std::vector<unsigned char> >;
 template class ScalarExpressionValueInfoT<int64_t>;
 template class ScalarExpressionValueInfoT<uint64_t>;
 template class ScalarExpressionValueInfoT<char>;

--- a/sql/sql.mk
+++ b/sql/sql.mk
@@ -18,5 +18,5 @@ SQL_EXPRESSION_SOURCES := \
 	sql_utils.cc \
 
 # NOTE: the SQL library should NOT depend on MLDB.  See the comment in testing/testing.mk
-$(eval $(call library,sql_expression,$(SQL_EXPRESSION_SOURCES),types utils value_description any ml services_base json_diff siphash))
+$(eval $(call library,sql_expression,$(SQL_EXPRESSION_SOURCES),types utils value_description any ml services_base json_diff siphash hash))
 

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -3,6 +3,8 @@
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
 
     This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+    Base SQL expression support.
 */
 
 #pragma once
@@ -16,7 +18,8 @@
 #include <set>
 
 // NOTE TO MLDB DEVELOPERS: This is an API header file.  No includes
-// should be added, especially value_description.h.
+// should be added, especially value_description.h.  Only
+// value_expression_fwd.h is OK.
 
 
 namespace ML {

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -2176,6 +2176,18 @@ bind(SqlBindingScope & context) const
                 this,
                 std::make_shared<BooleanValueInfo>()};
     }
+    else if (type == "blob") {
+        return {[=] (const SqlRowScope & row,
+                     ExpressionValue & storage) -> const ExpressionValue &
+                {
+                    ExpressionValue valStorage;
+                    const ExpressionValue & val = boundExpr(row, valStorage);
+                    return storage = std::move(ExpressionValue(val.coerceToBlob(),
+                                                               val.getEffectiveTimestamp()));
+                },
+                this,
+                    std::make_shared<BooleanValueInfo>()};
+    }
     else throw HttpReturnException(400, "Unknown type '" + type
                                    + "' for CAST (" + expr->surface
                                    + " AS " + type + ")");

--- a/testing/MLDB-1213-blob-support.js
+++ b/testing/MLDB-1213-blob-support.js
@@ -1,0 +1,33 @@
+// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+function assertEqual(expr, val)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    mldb.log(expr, 'IS NOT EQUAL TO', val);
+
+    throw "Assertion failure";
+}
+
+
+function testQuery(query, expected) {
+    mldb.log("testing query", query);
+
+    var resp = mldb.get('/v1/query', {q: query, format: 'table'});
+
+    mldb.log("received", resp.json);
+    mldb.log("expected", expected);
+    
+    assertEqual(resp.responseCode, 200);
+    assertEqual(resp.json, expected);
+}
+
+assertEqual(mldb.query("SELECT base64_encode('hello123') AS x")[0].columns[0][1], "aGVsbG8xMjM=");
+assertEqual(mldb.query("SELECT base64_decode(base64_encode('hello')) AS x")[0].columns[0][1], "hello");
+
+"success"
+
+

--- a/testing/cell_value_test.cc
+++ b/testing/cell_value_test.cc
@@ -162,3 +162,36 @@ BOOST_AUTO_TEST_CASE( test_date )
     BOOST_CHECK_EQUAL(jsonEncodeStr(CellValue(jsonDecodeStr<Date>(string("\"2015-10-06T20:52:18.842Z\"")))),
                       "{\"ts\":\"2015-10-06T20:52:18.842Z\"}");
 }
+
+BOOST_AUTO_TEST_CASE(test_blob)
+{
+    char blobData[] = "\1\1\2\3\4\5\0";
+    string blobContents(blobData, blobData + 7);
+
+    BOOST_CHECK_EQUAL(blobContents.size(), 7);
+
+    CellValue blob = CellValue::blob(blobContents);
+    
+    BOOST_CHECK_EQUAL(blob.cellType(), CellValue::BLOB);
+    BOOST_CHECK(blob.isBlob());
+    BOOST_CHECK_EQUAL(blob, blob);
+    BOOST_CHECK(!(blob != blob));
+    BOOST_CHECK(!(blob < blob));
+    
+    BOOST_CHECK_EQUAL(blob.blobLength(), blobContents.size());
+    BOOST_CHECK_EQUAL(string(blob.blobData(), blob.blobData() + blob.blobLength()),
+                      blobContents);
+
+    BOOST_CHECK_EQUAL(jsonEncodeStr(blob), "{\"blob\":[1,1,2,3,4,5,0]}");
+    BOOST_CHECK_EQUAL(jsonEncodeStr(CellValue::blob("")),
+                      "{\"blob\":[]}");
+    BOOST_CHECK_EQUAL(jsonEncodeStr(jsonDecode<CellValue>(jsonEncode(CellValue::blob("")))),
+                      jsonEncodeStr(CellValue::blob("")));
+    BOOST_CHECK_EQUAL(jsonEncodeStr(CellValue::blob("hello\1")),
+                      "{\"blob\":[\"hello\",1]}");
+    BOOST_CHECK_EQUAL(jsonEncodeStr(jsonDecode<CellValue>(jsonEncode(CellValue::blob("hello\1")))),
+                      jsonEncodeStr(CellValue::blob("hello\1")));
+
+    BOOST_CHECK_EQUAL(jsonEncodeStr(jsonDecodeStr<CellValue>(jsonEncodeStr(blob))),
+                      jsonEncodeStr(blob));
+}

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -24,7 +24,7 @@ $(eval $(call test,svd_utils_test,mldb,boost))
 #$(eval $(call test,mldb_sql_test,mldb,boost))  # plugin is disabled
 $(eval $(call test,mldb_mnist_test,mldb,boost))
 $(eval $(call test,mldb_reddit_test,mldb,boost))
-$(eval $(call test,cell_value_test,mldb,boost))
+$(eval $(call test,cell_value_test,sql_expression,boost))
 
 # NOTE: sql_expression_test should NOT depend on the MLDB library.  If you
 # are tempted to add it, you have coupled them together and broken
@@ -310,4 +310,4 @@ $(eval $(call mldb_unit_test,MLDBFB-308-where-outer-join-test.py,,manual))
 $(eval $(call mldb_unit_test,MLDB-1267-bucketize-ts-test.py))
 $(eval $(call mldb_unit_test,MLDB-1319-new-executor-function-binding.js))
 $(eval $(call mldb_unit_test,MLDB-1328-join_empty_dataset_test.py,,manual)) # Issue
-
+$(eval $(call mldb_unit_test,MLDB-1213-blob-support.js))

--- a/types/string.h
+++ b/types/string.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* string.h                                                          -*- C++ -*-
    Sunil Rottoo, 27 April 2012
    Copyright (c) 20102 Datacratic.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Basic classes for dealing with string including internationalisation
 */

--- a/utils/hash.cc
+++ b/utils/hash.cc
@@ -1,23 +1,57 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* md5.cc
    Jeremy Barnes, 25 October 2012
    Copyright (c) 2012 Datacratic.  All rights reserved.
 
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 */
 
 #include "hash.h"
-#include "string_functions.h"
+#include "mldb/arch/format.h"
 
 #define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
 #include "crypto++/sha.h"
 #include "crypto++/md5.h"
 #include "crypto++/hmac.h"
 #include "crypto++/base64.h"
+#include "crypto++/filters.h"
 
 using namespace std;
 
-namespace ML {
+namespace Datacratic {
+
+std::string base64Encode(const std::string & str)
+{
+    return base64Encode(str.c_str(), str.length());
+}
+
+std::string base64Encode(const char * buf, size_t nBytes)
+{
+    std::string result;
+    result.reserve(nBytes * 8 / 6 + 4);
+    CryptoPP::Base64Encoder baseEncoder(nullptr, false /* insert line breaks */);
+    baseEncoder.Attach(new CryptoPP::StringSink(result));
+    baseEncoder.Put((const byte *)buf, nBytes);
+    baseEncoder.MessageEnd();
+
+    return result;
+}
+
+std::string base64Decode(const std::string & str)
+{
+    return base64Decode(str.c_str(), str.length());
+}
+
+std::string base64Decode(const char * buf, size_t nBytes)
+{
+    std::string result;
+    result.reserve(nBytes * 6 / 8);
+    CryptoPP::Base64Decoder baseDecoder;
+    baseDecoder.Attach(new CryptoPP::StringSink(result));
+    baseDecoder.Put((const byte *)buf, nBytes);
+    baseDecoder.MessageEnd();
+
+    return result;
+}
 
 std::string md5HashToHex(const std::string & str)
 {
@@ -56,7 +90,7 @@ std::string md5HashToBase64(const char * buf, size_t nBytes)
     // base64
     char outBuf[256];
 
-    CryptoPP::Base64Encoder baseEncoder;
+    CryptoPP::Base64Encoder baseEncoder(nullptr, false /* add line endings */);
     baseEncoder.Put(digest, digestLen);
     baseEncoder.MessageEnd();
     size_t got = baseEncoder.Get((byte *)outBuf, 256);
@@ -64,7 +98,7 @@ std::string md5HashToBase64(const char * buf, size_t nBytes)
 
     //cerr << "got " << got << " characters" << endl;
 
-    return ML::trim(std::string(outBuf));
+    return std::string(outBuf);
 }
 
 std::string hmacSha1Base64(const std::string & stringToSign,
@@ -82,7 +116,7 @@ std::string hmacSha1Base64(const std::string & stringToSign,
     // base64
     char outBuf[256];
 
-    CryptoPP::Base64Encoder baseEncoder;
+    CryptoPP::Base64Encoder baseEncoder(nullptr, false /* add line endings */);
     baseEncoder.Put(digest, digestLen);
     baseEncoder.MessageEnd();
     size_t got = baseEncoder.Get((byte *)outBuf, 256);
@@ -106,7 +140,7 @@ std::string hmacSha256Base64(const std::string & stringToSign,
     // base64
     char outBuf[256];
 
-    CryptoPP::Base64Encoder baseEncoder;
+    CryptoPP::Base64Encoder baseEncoder(nullptr, false /* add line endings */);
     baseEncoder.Put(digest, digestLen);
     baseEncoder.MessageEnd();
     size_t got = baseEncoder.Get((byte *)outBuf, 256);
@@ -115,6 +149,4 @@ std::string hmacSha256Base64(const std::string & stringToSign,
         return base64digest;
 }
 
-                             
-
-} // namespace ML
+} // namespace Datacratic

--- a/utils/hash.h
+++ b/utils/hash.h
@@ -1,21 +1,23 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
-/* md5.h                                                           -*- C++ -*-
+/* hash.h                                                           -*- C++ -*-
    Jeremy Barnes, 25 October 2012
    Copyright (c) 2012 Datacratic.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Md5 hash functions.
 */
 
-#ifndef __jml__utils__md5_h__
-#define __jml__utils__md5_h__
+#pragma once
 
 #include <string>
 
-namespace ML {
+namespace Datacratic {
 
 std::string base64Encode(const std::string & str);
 std::string base64Encode(const char * buf, size_t nBytes);
+
+std::string base64Decode(const std::string & str);
+std::string base64Decode(const char * buf, size_t nBytes);
 
 std::string md5HashToHex(const std::string & str);
 std::string md5HashToHex(const char * buf, size_t nBytes);
@@ -28,8 +30,4 @@ std::string hmacSha1Base64(const std::string & stringToSign,
 std::string hmacSha256Base64(const std::string & stringToSign,
                              const std::string & privateKey);
 
-
-
 } // namespace ML
-
-#endif /* __jml__utils__md5_h__ */

--- a/utils/utils.mk
+++ b/utils/utils.mk
@@ -1,7 +1,10 @@
 # This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
-# RTB simulator makefile
-# Jeremy Barnes, 16 January 2010
+# gcc 4.7
+$(eval $(call set_compile_option,hash.cc,-fpermissive))
+
+$(eval $(call library,hash,hash.cc,cryptopp))
+
 
 $(eval $(call library,json_diff,json_diff.cc json_utils.cc,jsoncpp value_description types utils siphash))
 


### PR DESCRIPTION
This adds basic support for binary blobs in the SQL query cells, as well as functions in
Javascript to manipulate them, facilities for encoding and decoding in base64,
documentation and basic tests.

As part of the change, some of the old JML hash functionality was moved into MLDB
proper.