### PR TITLE
Allows usage of make x x_ARGS for mldb_unit_test

### DIFF
--- a/mldb_macros.mk
+++ b/mldb_macros.mk
@@ -31,7 +31,7 @@ $(TESTS)/$(1).passed:	$$(BIN)/mldb_runner  $(CWD)/$(1)
 	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "                 $(COLOR_GREEN)$(1) passed $(COLOR_RESET)$(COLOR_DARK_GRAY)[" `cat $(TESTS)/$(1).timing | awk 'FNR == 1 { start = $$$$1; } FNR == 2 { end = $$$$1; } END { printf("%.1fs", 1.0 * end - 1.0 * start) }'` "]$(COLOR_RESET)")
 
 # If ARGS
-TEST_$(1)_ARGS := $$(if $$(findstring $($(1)_ARGS), $($(1)_ARGS),), --script-args $($(1)_ARGS), )
+TEST_$(1)_ARGS := $$(if $$(findstring $(ARGS), $(ARGS)), $(ARGS), )
 
 $(1):	$$(BIN)/mldb_runner  $(CWD)/$(1)  $$(foreach plugin,$(2),mldb_plugin_$$(plugin))
 	$$(TEST_$(1)_SETUP) $$(TEST_$(1)_RAW_COMMAND) $$(TEST_$(1)_ARGS)

--- a/mldb_macros.mk
+++ b/mldb_macros.mk
@@ -30,8 +30,11 @@ $(TESTS)/$(1).passed:	$$(BIN)/mldb_runner  $(CWD)/$(1)
 	@date -u +%s.%N >> $(TESTS)/$(1).timing
 	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "                 $(COLOR_GREEN)$(1) passed $(COLOR_RESET)$(COLOR_DARK_GRAY)[" `cat $(TESTS)/$(1).timing | awk 'FNR == 1 { start = $$$$1; } FNR == 2 { end = $$$$1; } END { printf("%.1fs", 1.0 * end - 1.0 * start) }'` "]$(COLOR_RESET)")
 
+# If ARGS
+TEST_$(1)_ARGS := $$(if $$(findstring $($(1)_ARGS), $($(1)_ARGS),), --script-args $($(1)_ARGS), )
+
 $(1):	$$(BIN)/mldb_runner  $(CWD)/$(1)  $$(foreach plugin,$(2),mldb_plugin_$$(plugin))
-	$$(TEST_$(1)_SETUP) $$(TEST_$(1)_RAW_COMMAND)
+	$$(TEST_$(1)_SETUP) $$(TEST_$(1)_RAW_COMMAND) $$(TEST_$(1)_ARGS)
 
 .PHONY: $(1)
 mldb_unit_tests: $(1)


### PR DESCRIPTION
To run all the tests (as before)
```
make -j28 MLDB-1155_csv_line_endings.py
```

To run a single test (new)
```
make -j28 MLDB-1155_csv_line_endings.py MLDB-1155_csv_line_endings.py_ARGS="'[\"CsvLineEndingsCsvGz.test_empty_csv\"]'"
```