### PR TITLE
Cosmetic changes to graceful shutdown code

### DIFF
--- a/container_files/init/mldb_finish.py
+++ b/container_files/init/mldb_finish.py
@@ -12,6 +12,7 @@
 # If runsv cannot start ./run for some reason, the exit code is 111 and the status is 0.
 
 import os
+import signal
 import sys
 
 sigmap = { 4:  "SIGILL: illegal instruction (internal error)",
@@ -33,8 +34,8 @@ if len(sys.argv) == 3:
 print  # we like space
 print
 if sig == None:
-    print "MLDB exited"
-    os.kill(1,15)
+    print "MLDB exited, shutting down container."
+    os.kill(1, signal.SIGTERM)  # Tell init to terminate every process.
 else:
     msg = "MLDB exited due to signal %d" % (sig)
     if sig in sigmap:


### PR DESCRIPTION
 - Use constant instead of magic number
 - Let the operator know mldb that the container is being shut down