### PR TITLE
MLDB-1307 FunctionExpressionContext is no longer readthrough

### DIFF
--- a/core/function.cc
+++ b/core/function.cc
@@ -684,21 +684,12 @@ toRowInfo() const
 /* FUNCTION INFO                                                             */
 /*****************************************************************************/
 
-/*****************************************************************************/
-/* FUNCTION APPLIER                                                          */
-/*                                                                           */
-/* 'outer' is the original row scope in which the function is evaluated      */
-/* as needed by FunctionExpressionContext                                    */
-/* or any binding scope inherited from ReadThroughBindingContext             */
-/* in order to evaluate sub-select expressions in the expression             */                                     
-/*****************************************************************************/
-
 FunctionOutput
 FunctionApplier::
-apply(const SqlRowScope & outer, const FunctionContext & input) const
+apply(const FunctionContext & input) const
 { 
     ExcAssert(function);
-    return function->applyOuter(outer, *this, input);
+    return function->apply(*this, input);
 }
 
 

--- a/core/function.h
+++ b/core/function.h
@@ -300,11 +300,10 @@ DECLARE_STRUCTURE_DESCRIPTION(FunctionValueInfo);
 */
 
 struct FunctionValues {
+
     std::map<ValueMapKey, FunctionValueInfo> values;
 
-    FunctionValues()
-    {
-    }
+    FunctionValues(){}
 
     /** Construct from the value info of something that returns a row. */
     FunctionValues(const ExpressionValueInfo & rowInfo);
@@ -408,7 +407,7 @@ struct FunctionApplier {
     FunctionInfo info;       ///< Information about the input and output of the applier
 
     /// Apply the function to the given context
-    FunctionOutput apply(const SqlRowScope & outer, const FunctionContext & input) const;
+    FunctionOutput apply(const FunctionContext & input) const;
 };
 
 
@@ -485,11 +484,6 @@ protected:
         access to the information put in the applier by the bind()
         method.
     */
-
-    //if sub class doesnt override this version we ignore the "outer"    
-    virtual FunctionOutput applyOuter(const SqlRowScope & outer, const FunctionApplier & applier, const FunctionContext & context) const {
-        return apply(applier, context); 
-    }
 
     virtual FunctionOutput apply(const FunctionApplier & applier, const FunctionContext & context) const = 0;
 

--- a/plugins/sql_functions.cc
+++ b/plugins/sql_functions.cc
@@ -224,7 +224,7 @@ SqlExpressionFunction::
 SqlExpressionFunction(MldbServer * owner,
                       PolyConfig config,
                       const std::function<bool (const Json::Value &)> & onProgress)
-    : Function(owner), outerScope(owner), innerScope(outerScope)
+    : Function(owner), outerScope(owner), innerScope(owner)
 {
     functionConfig = config.params.convert<SqlExpressionFunctionConfig>();
 
@@ -259,7 +259,7 @@ struct SqlExpressionFunctionApplier: public FunctionApplier {
                                  const FunctionValues & input)
         : FunctionApplier(function),
           function(function),
-          innerScope(outerScope, input)
+          innerScope(outerScope.getMldbServer(), input, outerScope.functionStackDepth)
     {
         if (!function->functionConfig.prepared) {
             // Specialize to this input
@@ -276,20 +276,15 @@ struct SqlExpressionFunctionApplier: public FunctionApplier {
     {
     }
 
-    FunctionOutput apply(const SqlRowScope& outerRowScope,
-                         const FunctionContext & context) const
+    FunctionOutput apply(const FunctionContext & context) const
     {
         if (function->functionConfig.prepared) {
-            // Use the pre-bound version.    Note that we ignore the outer
-            // row scope, which wasn't available when we prepared the
-            // expression.
-            SqlRowScope emptyOuterRowScope;
-            return function->bound(function->innerScope.getRowContext(emptyOuterRowScope, context));
+            // Use the pre-bound version.   
+            return function->bound(function->innerScope.getRowContext(context));
         }
         else {
-            // Use the specialized version.  The outer row scope is available
-            // from the expression.
-            return bound(this->innerScope.getRowContext(outerRowScope, context));
+            // Use the specialized version. 
+            return bound(this->innerScope.getRowContext(context));
         }
     }
 
@@ -312,22 +307,13 @@ bind(SqlBindingScope & outerContext,
     return std::move(result);
 }
 
-FunctionOutput 
-SqlExpressionFunction::
-applyOuter(const SqlRowScope& outer, const FunctionApplier & applier,
-                              const FunctionContext & context) const
-{
-  return static_cast<const SqlExpressionFunctionApplier &>(applier)
-        .apply(outer, context);
-}
-
 FunctionOutput
 SqlExpressionFunction::
 apply(const FunctionApplier & applier,
       const FunctionContext & context) const
 {
-    //applyOuter should get called instead 
-    ExcAssert(false);
+    return static_cast<const SqlExpressionFunctionApplier &>(applier)
+           .apply(context);
 }
 
 FunctionInfo
@@ -340,12 +326,10 @@ getFunctionInfo() const
 
     FunctionInfo result;
 
-    // 0.  We want the pure function information, so we assume there is
-    //     no context for it apart from MLDB itself.
-    SqlExpressionMldbContext outerContext(MldbEntity::getOwner(this->server));
-
     // 1.  Create a binding context to see what this function takes
-    FunctionExpressionContext context(outerContext);
+    //     We want the pure function information, so we assume there is
+    //     no context for it apart from MLDB itself.
+    FunctionExpressionContext context(MldbEntity::getOwner(this->server));
 
     // 2.  Bind the expression in.  That will tell us what it is expecting
     //     as an input.

--- a/plugins/sql_functions.h
+++ b/plugins/sql_functions.h
@@ -88,9 +88,6 @@ struct SqlExpressionFunction: public Function {
     bind(SqlBindingScope & outerContext,
          const FunctionValues & inputInfo) const;
 
-    virtual FunctionOutput applyOuter(const SqlRowScope& outer, const FunctionApplier & applier,
-                              const FunctionContext & context) const;
-
     virtual FunctionOutput apply(const FunctionApplier & applier,
                               const FunctionContext & context) const;
 

--- a/server/function_collection.cc
+++ b/server/function_collection.cc
@@ -124,8 +124,7 @@ call(const std::map<Utf8String, ExpressionValue> & input) const
 
     auto applier = this->bind(outerContext, info.input);
     
-    SqlRowScope outer; //we dont have a row in this case, use an empty scope
-    return applier->apply(outer, inputContext);
+    return applier->apply(inputContext);
 }
 
 /*****************************************************************************/

--- a/server/function_contexts.cc
+++ b/server/function_contexts.cc
@@ -11,7 +11,8 @@
 #include "mldb/server/function_contexts.h"
 #include "mldb/core/dataset.h"
 #include "mldb/types/basic_value_descriptions.h"
-
+#include "mldb/server/mldb_server.h"
+#include "mldb/server/function_collection.h"
 
 using namespace std;
 
@@ -152,15 +153,18 @@ getMldbServer() const
 /*****************************************************************************/
 
 FunctionExpressionContext::
-FunctionExpressionContext(SqlBindingScope & context)
-    : ReadThroughBindingContext(context), knownInput(false)
-{
+FunctionExpressionContext(const MldbServer * mldb)
+    : knownInput(false), mldb(const_cast<MldbServer *>(mldb))
+{    
+    ExcAssert(mldb != nullptr);
 }
 
 FunctionExpressionContext::
-FunctionExpressionContext(SqlBindingScope & context, FunctionValues input)
-    : ReadThroughBindingContext(context), input(std::move(input)), knownInput(true)
+FunctionExpressionContext(const MldbServer * mldb, FunctionValues input, size_t outerFunctionStackDepth)
+    : input(std::move(input)), knownInput(true), mldb(const_cast<MldbServer *>(mldb))
 {
+    functionStackDepth = outerFunctionStackDepth;
+    ExcAssert(mldb != nullptr);
 }
 
 VariableGetter
@@ -269,6 +273,13 @@ doGetAllColumns(const Utf8String & tableName,
         };
 
     return getAllColumnsFromFunctionImpl(tableName, keep, input, getValue);
+}
+
+std::shared_ptr<Function>
+FunctionExpressionContext::
+doGetFunctionEntity(const Utf8String & functionName)
+{
+    return mldb->functions->getExistingEntity(functionName.rawString());
 }
 
 } // namespace MLDB

--- a/server/function_contexts.h
+++ b/server/function_contexts.h
@@ -63,12 +63,13 @@ struct ExtractContext: public SqlBindingScope {
 /*****************************************************************************/
 
 /** Used to run an expression in a purely function context. */
+/** Only input values and server functions will be available in this context */
 
-struct FunctionExpressionContext: public ReadThroughBindingContext {
+struct FunctionExpressionContext : public SqlBindingScope{
 
-    struct RowContext: public ReadThroughBindingContext::RowContext {
-        RowContext(const SqlRowScope& outer, const FunctionContext & input)
-            : ReadThroughBindingContext::RowContext(outer), input(input)
+    struct RowContext : public SqlRowScope{
+        RowContext(const FunctionContext & input)
+            : input(input)
         {
         }
 
@@ -76,11 +77,12 @@ struct FunctionExpressionContext: public ReadThroughBindingContext {
     };
 
     /// Initialize.  The info will be inferred from the function itself.
-    FunctionExpressionContext(SqlBindingScope & context);
+    FunctionExpressionContext(const MldbServer * mldb);
     
     /// Initialize with known input input.
-    FunctionExpressionContext(SqlBindingScope & context,
-                              FunctionValues input);
+    FunctionExpressionContext(const MldbServer * mldb,
+                              FunctionValues input,
+                              size_t functionStackDepth);
     
     /** Information for input values goes here. */
     FunctionValues input;
@@ -97,14 +99,24 @@ struct FunctionExpressionContext: public ReadThroughBindingContext {
     doGetAllColumns(const Utf8String & tableName,
                     std::function<Utf8String (const Utf8String &)> keep);
 
-    RowContext getRowContext(const SqlRowScope& outer, const FunctionContext & input) const
+    RowContext getRowContext(const FunctionContext & input) const
     {
-        return RowContext(outer, input);
+        return RowContext(input);
+    }
+
+    virtual std::shared_ptr<Function> doGetFunctionEntity(const Utf8String & functionName);
+
+    MldbServer *
+    getMldbServer() const
+    {
+        return mldb;
     }
 
 private:
 
     bool findVariableRecursive(const Utf8String& variableName, std::shared_ptr<ExpressionValueInfo>& valueInfo, SchemaCompleteness& schemaCompleteness) const;
+
+    MldbServer * mldb;
 };
 
 } // namespace MLDB

--- a/server/sql_expression_function_operations.cc
+++ b/server/sql_expression_function_operations.cc
@@ -31,7 +31,6 @@ bindApplyFunctionExpression(const Utf8String & functionName,
                             SqlBindingScope & context)
 {
     // Ask what our function needs
-
     std::shared_ptr<Function> function = context.doGetFunctionEntity(functionName);
 
     auto boundWith = with.bind(context);
@@ -59,7 +58,7 @@ bindApplyFunctionExpression(const Utf8String & functionName,
                 context.update(std::move(withOutput));
 
                 if (function) {
-                    FunctionOutput functionOutput = applier->apply(row, context);
+                    FunctionOutput functionOutput = applier->apply(context);
                     //cerr << "functionoutput = " << jsonEncode(functionOutput) << endl;
                     context.update(std::move(functionOutput));
                 }
@@ -133,7 +132,7 @@ bindSelectApplyFunctionExpression(const Utf8String & functionName,
                 context.update(std::move(withOutput));
 
                 if (function) {
-                    FunctionOutput functionOutput = applier->apply(row, context);
+                    FunctionOutput functionOutput = applier->apply(context);
                     //cerr << "functionoutput = " << jsonEncode(functionOutput) << endl;
                     context.update(std::move(functionOutput));
                 }

--- a/sql/binding_contexts.cc
+++ b/sql/binding_contexts.cc
@@ -66,6 +66,7 @@ doGetFunction(const Utf8String & tableName,
     result.exec = [=] (const std::vector<ExpressionValue> & args,
                        const SqlRowScope & context)
         {
+            //ExcAssert(dynamic_cast<const RowContext *>(&context) != nullptr);
             auto & row = static_cast<const RowContext &>(context);
             //cerr << "rebinding to apply function " << functionName
             //<< ": context type is "


### PR DESCRIPTION
The only things that FunctionExpressionContext now makes available are:

-The input values
-Functions (from the server)
-Function stack depth for recursion detection