### PR TITLE
MLDB-1328 dont force evaluation of empty count(*) when a group by is …

### DIFF
--- a/server/bound_queries.cc
+++ b/server/bound_queries.cc
@@ -1426,7 +1426,7 @@ execute(std::function<bool (NamedRowValue & output)> aggregator,
         }
     }
 
-    if (destMap.empty() && groupContext->evaluateEmptyGroups)
+    if (destMap.empty() && groupContext->evaluateEmptyGroups && groupBy.clauses.empty())
     {
         auto pair = destMap.emplace(RowKey(), GroupMapValue());
         groupContext->initializePerThreadAggregators(pair.first->second);

--- a/testing/MLDB-1328-join_empty_dataset_test.py
+++ b/testing/MLDB-1328-join_empty_dataset_test.py
@@ -28,8 +28,8 @@ class JoinEmptyDatasetTest(unittest.TestCase):
         })
         perform('POST', '/v1/datasets/ds/commit', [], {})
         qry = "SELECT uid, count(1) AS size FROM ds GROUP BY uid"
-        perform('GET', '/v1/query', [['q', qry]])
-        # TODO: Once this query no longer fails, add the appropriate asserts
+        res = perform('GET', '/v1/query', [['q', qry]])
+        assert res['response'] == '[]'
 
 if __name__ == '__main__':
     if mldb.script.args:


### PR DESCRIPTION
…specified