### PR TITLE
MLDB-1313 delay resolution of wildcard ambiguity from parsing to binding

### DIFF
--- a/server/dataset_context.cc
+++ b/server/dataset_context.cc
@@ -199,7 +199,7 @@ removeQuotes(const Utf8String & variableName) const
 //by finding the dataset name that resolves first.
 Utf8String 
 SqlExpressionDatasetContext::
-resolveTableName(const Utf8String& variable) const
+resolveTableName(const Utf8String& variable, Utf8String& resolvedTableName) const
 {
     if (variable.empty())
         return Utf8String();
@@ -228,6 +228,7 @@ resolveTableName(const Utf8String& variable) const
                 if (next != variable.end()) {
                     Utf8String shortVariableName(next, variable.end());
                     shortVariableName = tableName + "." + removeQuotes(shortVariableName);
+                    resolvedTableName = std::move(tableName);
                     return shortVariableName;
                 }            
             }
@@ -248,6 +249,7 @@ resolveTableName(const Utf8String& variable) const
                 for (auto& datasetName: childaliases) {
 
                     if (tableName == datasetName) {
+                        resolvedTableName = std::move(tableName);
                         if (datasetName.find('.') != datasetName.end()) {
                             //we need to enclose it in quotes to resolve any potential ambiguity
                             Utf8String quotedVariableName(++it, variable.end());
@@ -267,6 +269,14 @@ resolveTableName(const Utf8String& variable) const
     }
 
     return variable;
+}
+
+Utf8String 
+SqlExpressionDatasetContext::
+resolveTableName(const Utf8String& variable) const
+{
+    Utf8String resolvedTableName;
+    return resolveTableName(variable, resolvedTableName);
 }
 
 VariableGetter
@@ -386,7 +396,7 @@ doGetAllColumns(const Utf8String & tableName,
         && std::find(childaliases.begin(), childaliases.end(), tableName)
             == childaliases.end()
         && tableName != alias)
-        throw HttpReturnException(400, "Unknown dataset " + tableName);    
+        throw HttpReturnException(400, "Unknown dataset " + tableName);
 
     auto columns = dataset.getMatrixView()->getColumnNames();
 
@@ -529,6 +539,21 @@ doGetColumnFunction(const Utf8String & functionName)
 
     return nullptr;
 }
+
+Utf8String 
+SqlExpressionDatasetContext::
+doResolveTableName(const Utf8String & fullVariableName, Utf8String &tableName) const
+{
+    if (!childaliases.empty()) {
+        return removeQuotes(resolveTableName(fullVariableName, tableName));
+    }
+    else {
+        Utf8String simplifiedVariableName = removeQuotes(removeTableName(fullVariableName));
+        if (simplifiedVariableName != fullVariableName)
+            tableName = alias;
+        return std::move(simplifiedVariableName);
+    }
+}   
 
 /*****************************************************************************/
 /* ROW EXPRESSION ORDER BY CONTEXT                                           */

--- a/server/dataset_context.h
+++ b/server/dataset_context.h
@@ -109,12 +109,16 @@ struct SqlExpressionDatasetContext: public SqlExpressionMldbContext {
     {
         return RowContext(row, params);
     }
+
+    virtual Utf8String 
+    doResolveTableName(const Utf8String & fullVariableName, Utf8String &tableName) const;
     
 protected:
 
     Utf8String removeTableName(const Utf8String & variableName) const;
     Utf8String removeQuotes(const Utf8String & variableName) const;
     Utf8String resolveTableName(const Utf8String& variableName) const;
+    Utf8String resolveTableName(const Utf8String& variableName, Utf8String& resolvedTableName) const;
 };
 
 

--- a/server/function_contexts.cc
+++ b/server/function_contexts.cc
@@ -282,5 +282,13 @@ doGetFunctionEntity(const Utf8String & functionName)
     return mldb->functions->getExistingEntity(functionName.rawString());
 }
 
+Utf8String 
+SqlBindingScope::
+doResolveTableName(const Utf8String & fullVariableName, Utf8String &tableName) const
+{
+    return fullVariableName;
+}
+
+
 } // namespace MLDB
 } // namespace Datacratic

--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -394,7 +394,15 @@ SqlBindingScope::
 doGetTable(const Utf8String & tableName)
 {
     throw HttpReturnException(400, "Binding context " + ML::type_name(*this)
-                              + " does not support getting tabless");
+                              + " does not support getting tables");
+}
+
+Utf8String 
+SqlBindingScope::
+doResolveTableName(const Utf8String & fullVariableName, Utf8String &tableName) const
+{
+    throw HttpReturnException(400, "Binding context " + ML::type_name(*this)
+                              + " does not support resolving table names");
 }
 
 MldbServer *
@@ -673,29 +681,17 @@ static Utf8String matchIdentifier(ML::Parse_Context & context,
     }    
 
     
-    {
-        //only match the . if there is actually an identifier after
-        //for example in 'table.*' the identifier is 'table' not 'table.'
+    if (context.match_literal('.')) {
 
-        ML::Parse_Context::Revert_Token token(context);
-
-        if (context.match_literal('.')) {
-
-            Utf8String nextIdentifier = matchIdentifier(context, allowUtf8, stripQuotes);
-
-            if (!nextIdentifier.empty()) {
-                stripOuterQuotes = false;
-                result += "." + nextIdentifier;
-                token.ignore();
-            }
-        
-        }  
+          Utf8String nextIdentifier = matchIdentifier(context, allowUtf8, stripQuotes);
+          stripOuterQuotes = false;
+          result += "." + nextIdentifier;
     }  
 
-     if (stripOuterQuotes) {
+    if (stripOuterQuotes) {
         auto last = boost::prior(result.end());
         result = Utf8String(++(result.begin()), last);
-     } 
+    } 
 
     return result;
 }
@@ -1460,8 +1456,6 @@ SqlExpression::
 parse(const std::string & expression, const std::string & filename,
       int row, int col)
 {
-    //cerr << "parsing " << expression << endl;
-
     ML::Parse_Context context(filename.empty() ? expression : filename,
                               expression.c_str(),
                               expression.length(), row, col);
@@ -2014,65 +2008,6 @@ parse(ML::Parse_Context & context, bool allowUtf8)
                     auto result = std::make_shared<WildcardExpression>(tableName, prefix, prefixAs, exclusions);
                     result->surface = ML::trim(capture.captured());
                     return result;
-                }
-            }
-        }
-    }
-
-    //cerr << "offset = " << context.get_offset() << endl;
-    /* Three possibilities:
-       1.  (tablename).(prefix)*
-       2.  expression (AS label)
-       3.  label : expression
-    */
-    if (!matched) {
-
-        ML::Parse_Context::Revert_Token token(context);
-        
-        for (;;) {
-            tableName = matchIdentifier(context, allowUtf8);
-            if (tableName.empty())
-                break;
-
-            skip_whitespace(context);
-
-            if (!context.match_literal('.'))
-                break;
-
-            skip_whitespace(context);
-
-            if (matchPrefixedWildcard(prefix)) {
-
-                // Sort out ambiguity between * operator and wildcard by looking at
-                // trailing context.
-                //
-                // See MLDB-195
-                //
-                // It can only be a table name if followed by:
-                // - eof
-                // - a comma
-                // - closing paranthesis, if used as an expression
-                // - AS
-                // - EXCLUDING
-                // - a keyword
-
-                ML::Parse_Context::Revert_Token token2(context);
-
-                skip_whitespace(context);
-
-                if (context.eof()
-                    || context.match_literal(',')
-                    || context.match_literal(')')
-                    || matchKeyword(context, "AS")
-                    || matchKeyword(context, "EXCLUDING")
-                    || matchKeyword(context, "NAMED")
-                    || matchKeyword(context, "FROM") || matchKeyword(context, "WHERE")
-                    || matchKeyword(context, "GROUP BY") || matchKeyword(context, "HAVING")
-                    || matchKeyword(context, "LIMIT") || matchKeyword(context, "OFFSET")) {
-                    isWildcard = true;
-                    matched = true;
-                    token.ignore();
-                    break;
                 }
             }
         }

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -539,6 +539,12 @@ struct SqlBindingScope {
     virtual TableOperations
     doGetTable(const Utf8String & tableName);
 
+    /* Used to resolve the table name from a full identifier */
+    /* Will return value is the identifier without the table name */
+    /* Output value is the table name resolved */
+    virtual Utf8String 
+    doResolveTableName(const Utf8String & fullVariableName, Utf8String &tableName) const;
+
     /** Return the MLDB server behind this context.  Default returns a null
         pointer which means we're running outside of MLDB.
     */

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -2337,17 +2337,17 @@ BoundSqlExpression
 WildcardExpression::
 bind(SqlBindingScope & context) const
 {
-    Utf8String simplifiedprefix = prefix;
+    Utf8String simplifiedPrefix = prefix;
     Utf8String resolvedTableName = tableName;
     if (tableName.empty() && !prefix.empty())
-        simplifiedprefix = context.doResolveTableName(prefix, resolvedTableName);
+        simplifiedPrefix = context.doResolveTableName(prefix, resolvedTableName);
 
     // This function figures out the new name of the column.  If it's excluded,
     // then it returns the empty string
-    auto newColumnName = [&, simplifiedprefix] (const Utf8String & inputColumnName) -> Utf8String
+    auto newColumnName = [&, simplifiedPrefix] (const Utf8String & inputColumnName) -> Utf8String
         {
             // First, check it matches the prefix
-            if (!inputColumnName.startsWith(simplifiedprefix))
+            if (!inputColumnName.startsWith(simplifiedPrefix))
                 return Utf8String();
 
             // Second, check it doesn't match an exclusion
@@ -2366,7 +2366,7 @@ bind(SqlBindingScope & context) const
 
             // Finally, replace the prefix with the new prefix
             Utf8String result = inputColumnName;
-            result.replace(0, simplifiedprefix.length(), asPrefix);
+            result.replace(0, simplifiedPrefix.length(), asPrefix);
             return result;
         };
 

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -2330,18 +2330,24 @@ WildcardExpression(Utf8String tableName,
     : tableName(tableName), prefix(prefix), asPrefix(asPrefix),
       excluding(excluding)
 {
+
 }
 
 BoundSqlExpression
 WildcardExpression::
 bind(SqlBindingScope & context) const
 {
+    Utf8String simplifiedprefix = prefix;
+    Utf8String resolvedTableName = tableName;
+    if (tableName.empty() && !prefix.empty())
+        simplifiedprefix = context.doResolveTableName(prefix, resolvedTableName);
+
     // This function figures out the new name of the column.  If it's excluded,
     // then it returns the empty string
-    auto newColumnName = [&] (const Utf8String & inputColumnName) -> Utf8String
+    auto newColumnName = [&, simplifiedprefix] (const Utf8String & inputColumnName) -> Utf8String
         {
             // First, check it matches the prefix
-            if (!inputColumnName.startsWith(prefix))
+            if (!inputColumnName.startsWith(simplifiedprefix))
                 return Utf8String();
 
             // Second, check it doesn't match an exclusion
@@ -2360,11 +2366,11 @@ bind(SqlBindingScope & context) const
 
             // Finally, replace the prefix with the new prefix
             Utf8String result = inputColumnName;
-            result.replace(0, prefix.length(), asPrefix);
+            result.replace(0, simplifiedprefix.length(), asPrefix);
             return result;
         };
 
-    auto allColumns = context.doGetAllColumns(tableName, newColumnName);
+    auto allColumns = context.doGetAllColumns(resolvedTableName, newColumnName);
 
     auto exec = [=] (const SqlRowScope & scope,
                      ExpressionValue & storage)

--- a/testing/MLDB-835-table-aliases.py
+++ b/testing/MLDB-835-table-aliases.py
@@ -49,9 +49,9 @@ check(result, 2)
 result = mldb.get('/v1/query', q='SELECT "a."* FROM x.y')
 check(result, 2)
 
-# uncomment for MLDB-1313 test case
-#result = mldb.perform('GET', '/v1/query', [['q', 'SELECT a.* FROM x.y']])
-#Check(result, 2)
+# MLDB-1313 test case
+result2 = mldb.get('/v1/query', q='SELECT a.* FROM x.y')
+assert result.json() == result2.json()
 
 result = mldb.get('/v1/query', q='SELECT q.r.a.b FROM x.y as q.r')
 

--- a/testing/MLDB-869-select-expression.py
+++ b/testing/MLDB-869-select-expression.py
@@ -26,15 +26,9 @@ else:
     assert False, 'should not be here'
 
 #MLDB-835
-try:
-    mldb.get('/v1/query', q='SELECT x.* FROM dataset1')
-except mldb_wrapper.ResponseException as exc:
-    mldb.log(exc.response)
-else:
-    assert False, 'should not be here'
 
 result = mldb.get('/v1/query', q='SELECT x.* FROM dataset1 as x')
-mldb.log(result)
+assert result.json()[0]['columns'][0][1] == 9
 
 #MLDB-958 rowhash printing when rowhash bigger than 7FFFFFFFFFFFFFFF
 result = mldb.get('/v1/query',


### PR DESCRIPTION
If you take SELECT x.*

instead of assuming it means all column from dataset x, we will wait until binding to see if it means that or all columns that starts with "x."

Add a new method to the SqlBindingScope interface to resolve table names in identifier.