### PR TITLE
Reduced ExpressionValue useless padding (MLDB-1363)

### DIFF
--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -778,8 +778,6 @@ swap(ExpressionValue & other) noexcept
     std::swap(type_,    other.type_);
     std::swap(storage_[0], other.storage_[0]);
     std::swap(storage_[1], other.storage_[1]);
-    std::swap(storage_[2], other.storage_[2]);
-    std::swap(storage_[3], other.storage_[3]);
     std::swap(ts_, other.ts_);
 }
 

--- a/sql/expression_value.h
+++ b/sql/expression_value.h
@@ -737,7 +737,7 @@ private:
 
     /// This is where the underlying values are actually stored
     union {
-        uint64_t storage_[4];
+        uint64_t storage_[2];
         CellValue cell_;
         std::shared_ptr<const Row> row_;
         std::shared_ptr<const Struct> struct_;

--- a/testing/sql_expression_test.cc
+++ b/testing/sql_expression_test.cc
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** sql_expression_test.cc
     Jeremy Barnes, 25 January 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Test of row expressions.
 */
@@ -1245,4 +1245,12 @@ BOOST_AUTO_TEST_CASE(test_colon_as)
     cerr << "alignof(CellValue) = " << alignof(CellValue) << endl;
     cerr << "sizeof(ExpressionValue) = " << sizeof(ExpressionValue) << endl;
     cerr << "alignof(ExpressionValue) = " << alignof(ExpressionValue) << endl;
+    cerr << "sizeof(Id) = " << sizeof(Id) << endl;
+    cerr << "alignof(Id) = " << alignof(Id) << endl;
+    cerr << "sizeof(Utf8String) = " << sizeof(Utf8String) << endl;
+    cerr << "alignof(Utf8String) = " << alignof(Utf8String) << endl;
+    cerr << "sizeof(std::string) = " << sizeof(std::string) << endl;
+    cerr << "alignof(std::string) = " << alignof(std::string) << endl;
+
+    BOOST_CHECK_EQUAL(sizeof(ExpressionValue), 32);
 }


### PR DESCRIPTION
Removes some useless padding in the ExpressionValue class, which should reduce overall memory usage somewhat in queries.

Very trivial.
