### PR TITLE
MLDB-1362 workaround for boost::date_time MT issue

### DIFF
--- a/server/mldb_server.cc
+++ b/server/mldb_server.cc
@@ -113,9 +113,19 @@ init(std::string configurationPath,
 {
     auto server = std::make_shared<StandalonePeerServer>();
 
+    preInit();
     initServer(server);
     initRoutes();
     initCollections(configurationPath, staticFilesPath, staticDocPath, hideInternalEntities);
+}
+
+void
+MldbServer::
+preInit()
+{
+    //Because of a multithread issue in boost, we need to call this to force boost::date_time to initialize in single thread
+    //better do it as early as possible
+    Date::now().weekday();
 }
 
 void

--- a/server/mldb_server.h
+++ b/server/mldb_server.h
@@ -130,6 +130,7 @@ struct MldbServer: public ServicePeer, public EventRecorder {
     std::string getCacheDirectory() const;
 
 private:
+    void preInit();
     void initRoutes();
     void initCollections(std::string configurationPath,
                          std::string staticFilesPath,


### PR DESCRIPTION
Workaround for the issue that @mailletf encountered when calling date_part in MT