### PR TITLE
[MLDB-1351] run config override the config provided at creation in ma…

### DIFF
--- a/plugins/csv_export_procedure.cc
+++ b/plugins/csv_export_procedure.cc
@@ -86,20 +86,22 @@ CsvExportProcedure::
 run(const ProcedureRunConfig & run,
     const std::function<bool (const Json::Value &)> & onProgress) const
 {
+    auto runProcConf = applyRunConfOverProcConf(procedureConfig, run);
+            
     SqlExpressionMldbContext context(server);
-    ML::filter_ostream out(procedureConfig.dataFileUrl.toString());
-    CsvWriter csv(out, procedureConfig.delimiter.at(0),
-                  procedureConfig.quoteChar.at(0));
+    ML::filter_ostream out(runProcConf.dataFileUrl.toString());
+    CsvWriter csv(out, runProcConf.delimiter.at(0),
+                  runProcConf.quoteChar.at(0));
 
-    auto boundDataset = procedureConfig.exportData.stm->from->bind(context);
+    auto boundDataset = runProcConf.exportData.stm->from->bind(context);
 
     vector<shared_ptr<SqlExpression> > calc;
-    BoundSelectQuery bsq(procedureConfig.exportData.stm->select,
+    BoundSelectQuery bsq(runProcConf.exportData.stm->select,
                          *boundDataset.dataset,
                          boundDataset.asName,
-                         procedureConfig.exportData.stm->when,
-                         *procedureConfig.exportData.stm->where,
-                         procedureConfig.exportData.stm->orderBy,
+                         runProcConf.exportData.stm->when,
+                         *runProcConf.exportData.stm->where,
+                         runProcConf.exportData.stm->orderBy,
                          calc);
 
     const auto columnNames = bsq.getSelectOutputInfo()->allColumnNames();
@@ -193,15 +195,15 @@ run(const ProcedureRunConfig & run,
         return true;
     };
 
-    if (procedureConfig.headers) {
+    if (runProcConf.headers) {
         for (const auto & name: bsq.getSelectOutputInfo()->allColumnNames()) {
             csv << name.toUtf8String();
         }
         csv.endl();
     }
     bsq.execute(outputCsvLine, 
-                procedureConfig.exportData.stm->offset, 
-                procedureConfig.exportData.stm->limit,
+                runProcConf.exportData.stm->offset, 
+                runProcConf.exportData.stm->limit,
                 onProgress);
     RunOutput output;
     return output;

--- a/plugins/xlsx_importer.cc
+++ b/plugins/xlsx_importer.cc
@@ -677,6 +677,7 @@ struct XlsxImporter: public Procedure {
         Styles styles;
         std::string savedRelationships;
         bool sheetsLoaded = false;
+        auto runProcConf = applyRunConfOverProcConf(config, run);
 
         workbook.timestamp = Date::positiveInfinity();
 
@@ -733,21 +734,21 @@ struct XlsxImporter: public Procedure {
                 return true;
             };
 
-        forEachUriObject("archive+" + config.dataFileUrl.toString(),
+        forEachUriObject("archive+" + runProcConf.dataFileUrl.toString(),
                          onFile);
         
         // Create the output dataset
 
         std::shared_ptr<Dataset> output;
  
-        if (!config.output.type.empty()
-            || !config.output.id.empty()) {
-            output = obtainDataset(server, config.output);
+        if (!runProcConf.output.type.empty()
+            || !runProcConf.output.id.empty()) {
+            output = obtainDataset(server, runProcConf.output);
         }
        
         // 4.  Load the worksheets, one by one
         for (auto & sheetEntry: workbook.sheets) {
-            Utf8String filename = "archive+" + config.dataFileUrl.toString() + "#xl/" + sheetEntry.filename;
+            Utf8String filename = "archive+" + runProcConf.dataFileUrl.toString() + "#xl/" + sheetEntry.filename;
             ML::filter_istream sheetStream(filename.rawString());
             
             Sheet sheet(sheetStream.rdbuf(), workbook, strings, styles);


### PR DESCRIPTION
…ny procedures

These were the procedures that were missing the call to merge the run config with the config provided at creation:

bucketize,
word2vec,
csv.export,
xlsx.import,
ranking,
create_function (python) and
git

I've changed all of these procedures so that runs override the config provided at creation except for the python procedure which does not have anything to override.