### PR TITLE
Allow memory to be returned to OS (MLDBFB-329)

### DIFF
--- a/container_files/assets/www/doc/builtin/Running.md
+++ b/container_files/assets/www/doc/builtin/Running.md
@@ -242,3 +242,18 @@ Inside the virtual machine, MLDB runs as a Docker container (see above) controll
 To upgrade MLDB to the latest version, you will need to launch a new AMI.
 
 
+## Environment Variables (advanced usage)
+
+The following environment variables control MLDB:
+- `RETURN_OS_MEMORY` (0 or 1, default 1): if this is set (which it is by
+  default), the whole set of deallocated memory will be returned to the
+  OS whenever a dataset is destroyed.  If you observe long pauses after
+  a dataset is destroyed and have a dedicated machine or a container
+  with dedicated memory, you can set this to 0 to disable that behavior.
+- `PRINT_OS_MEMORY` (0 or 1, default 0): if this is set (it is *not* set
+  by default), then each time a dataset is destroyed, the memory usage
+  will be written to the console.  In addition, if `RETURN_OS_MEMORY=1`
+  then the memory usage will be re-printed after the memory is returned
+  to the operating system.
+
+

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -18,6 +18,7 @@
 #include "mldb/server/dataset_context.h"
 #include "mldb/server/per_thread_accumulator.h"
 #include "mldb/jml/utils/worker_task.h"
+#include "mldb/jml/utils/environment.h"
 #include "mldb/types/any_impl.h"
 #include "mldb/http/http_exception.h"
 #include "mldb/rest/rest_request_router.h"
@@ -27,6 +28,24 @@
 
 using namespace std;
 
+extern "C" {
+    // For TCMalloc.  TODO: similar functionality exists in other memory
+    // allocators.
+    void MallocExtension_ReleaseFreeMemory(void) __attribute__((weak));
+    void MallocExtension_GetStats(char * buffer, int buffer_length) __attribute__((weak));
+
+    // Create weak versions of these symbols for when we're not using
+    // tcmalloc.
+    void MallocExtension_ReleaseFreeMemory(void)
+    {
+    }
+
+    void MallocExtension_GetStats(char * buffer, int buffer_length)
+    {
+        if (buffer_length)
+            *buffer = 0;
+    }
+} // extern "C"
 
 namespace Datacratic {
 namespace MLDB {
@@ -328,9 +347,30 @@ Dataset(MldbServer * server)
 {
 }
 
+ML::Env_Option<int> RETURN_OS_MEMORY("RETURN_OS_MEMORY", 1);
+ML::Env_Option<int> PRINT_OS_MEMORY("PRINT_OS_MEMORY", 0);
+
+
 Dataset::
 ~Dataset()
 {
+    // MLDBFB-329
+    // Once a dataset is deleted, try to free its memory from the system
+    if (PRINT_OS_MEMORY) {
+        char buf[8192];
+        MallocExtension_GetStats(buf, 8192);
+        cerr << buf << endl;
+    }
+
+    if (RETURN_OS_MEMORY) {
+        MallocExtension_ReleaseFreeMemory();    
+    
+        if (PRINT_OS_MEMORY) {
+            char buf[8192];
+            MallocExtension_GetStats(buf, 8192);
+            cerr << buf << endl;
+        }
+    }
 }
 
 void


### PR DESCRIPTION
Adds an option (enabled by default) to return memory to the OS by unmapping unused page ranges from tcmalloc.