### PR TITLE
Fixed type names not being found by demangled lookup (MLDB-1392)

### DIFF
--- a/container_files/assets/www/doc/builtin/procedures/InputQuery.md
+++ b/container_files/assets/www/doc/builtin/procedures/InputQuery.md
@@ -15,7 +15,13 @@ where `column1` and `column2` refer to columns in a pre-existing dataset with id
 
 ## As a JSON Object
 
-Input queries can also be specified as a JSON object representing a [Dataset Configuration](../datasets/DatasetConfig.md) and a decomposed [SQL query](../sql/Sql.md).  For example the object:
+Input queries can also be specified as a JSON object representing a [Dataset Configuration](../datasets/DatasetConfig.md) and a decomposed [SQL query](../sql/Sql.md).
+
+The fields in the JSON structure are as follows:
+
+![](%%type Datacratic::MLDB::SelectStatement)
+
+For example the object:
 
 ```javascript
 {

--- a/server/static_content_macro.cc
+++ b/server/static_content_macro.cc
@@ -115,7 +115,7 @@ static void renderType(MacroContext & context,
     const ValueDescription * vd = ValueDescription::get(cppType.rawString()).get();
         
     if (!vd) {
-        context.writeHtml("Type with name " + cppType + " not found");
+        context.writeHtml("Type with name '" + cppType + "' not found");
         return;
     }
 

--- a/types/value_description.cc
+++ b/types/value_description.cc
@@ -311,6 +311,7 @@ registerValueDescription(const std::type_info & type,
     ExcAssert(desc);
     registry()[desc->typeName] = desc;
     registry()[type.name()] = desc;
+    registry()[ML::demangle(type.name())] = desc;
     initFn(*desc);
 #if 0
     cerr << "type " << ML::demangle(type.name())


### PR DESCRIPTION
Fixes documentation error messages.  Looks like the root cause was that the typeName field of ValueDescription was inadvertently changed from the demangled to the non-demangled form.

Also adds a missing documentation block to the InputQuery, which is enabled by this change.