### PR TITLE
Allow MD in comment fields for structures (MLDB-1261)

### DIFF
--- a/plugins/experiment_procedure.cc
+++ b/plugins/experiment_procedure.cc
@@ -78,9 +78,13 @@ ExperimentProcedureConfigDescription()
 {
     addField("trainingData", &ExperimentProcedureConfig::trainingData,
              "Specification of the data for input to the classifier procedure. "
-             "The select expression must contain these two sub-expressions: one row expression "
-             "to identify the features on which to train and one scalar expression "
-             "to identify the label.  The type of the label expression must match "
+             "The select expression must contain these two sub-expressions: \n"
+             "\n"
+             "1.  one row expression to identify the features on which to \n"
+             "    train, and \n"
+             "2.  one scalar expression to identify the label.\n"
+             "\n"
+             "The type of the label expression must match "
              "that of the classifier mode: a boolean (0 or 1) for `boolean` mode; "
              "a real for regression mode, and any combination of numbers and strings "
              "for `categorical` mode.  Labels with a null value will have their row skipped. "

--- a/server/static_content_macro.cc
+++ b/server/static_content_macro.cc
@@ -15,6 +15,7 @@
 #include "mldb/rest/in_process_rest_connection.h"
 #include "mldb/server/mldb_server.h"
 #include "mldb/core/mldb_entity.h"
+#include "mldb/base/scope.h"
 #include "mldb/jml/utils/file_functions.h"
 #include "mldb/jml/utils/string_functions.h"
 
@@ -28,6 +29,9 @@ namespace MLDB {
 /*****************************************************************************/
 /* UTILITY FUNCTIONS                                                         */
 /*****************************************************************************/
+
+// Defined in static_content_handler.cc
+std::string renderMarkdown(const std::string & str, MacroData & macroData);
 
 using namespace Json;
 
@@ -146,7 +150,7 @@ static void renderType(MacroContext & context,
                                          fd.fieldName.c_str(),
                                          getTypeName(*fd.description).c_str(),
                                          getDefaultValue(*fd.description).c_str(),
-                                         fd.comment.c_str()));
+                                                 renderMarkdown(fd.comment.c_str(), context)));
                 };
             vd->forEachField(nullptr, onField);
             context.writeHtml("</table>");

--- a/server/static_content_macro.h
+++ b/server/static_content_macro.h
@@ -1,10 +1,11 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** static_content_macro.h                                         -*- C++ -*-
     Jeremy Barnes, 23 November 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
 
-    Macros for static content handling.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+    Macros for static content handling.  These allow for a plugin to extend
+    the documentation system to make calls into MLDB.
 */
 
 #pragma once


### PR DESCRIPTION
Slight refactoring of MD support to allow for the field descriptions to be rendered in Markdown.