### PR TITLE
Improved stats collection & prettified (MLDB-1397)

### DIFF
--- a/ext/tensorflow.mk
+++ b/ext/tensorflow.mk
@@ -34,24 +34,24 @@ TF_CWD:=$(CWD)
 # We use a recursive make, since we don't care about anything apart from the
 # final executable.
 $(HOSTBIN)/protoc:
-	cd mldb/ext/tensorflow/google/protobuf && ./autogen.sh && ./configure --prefix $(PWD)/$(BUILD)/$(HOSTARCH) && $(MAKE) -j && $(MAKE) -j install
+	@(cd mldb/ext/tensorflow/google/protobuf && ./autogen.sh && ./configure --prefix $(PWD)/$(BUILD)/$(HOSTARCH) && $(MAKE) -j && $(MAKE) -j install) > $(TMP)/protoc-build.log || (echo "protobuf build failed" && cat $(TMP)/protoc-build.log && false)
 
 # We use the protobuf library at runtime, so it needs to be installed in
 # the right place.  Here we also rename it to avoid clashes with the system
 # version.
 ifneq ($(LIB),$(HOSTLIB))
 $(LIB)/libprotobuf3.so:	$(HOSTBIN)/protoc
-	cp $(HOSTLIB)/libprotobuf.so $@
-	cp $(HOSTLIB)/libprotobuf.so.* $(LIB)
+	@cp $(HOSTLIB)/libprotobuf.so $@
+	@cp $(HOSTLIB)/libprotobuf.so.* $(LIB)
 else
 $(LIB)/libprotobuf3.so:	$(HOSTBIN)/protoc
-	cp $(HOSTLIB)/libprotobuf.so $@
+	@cp $(HOSTLIB)/libprotobuf.so $@
 endif
 
 # We also need to make sure that the header files go in the right place
 ifneq ($(INC),$(HOSTINC))
 $(INC)/google/protobuf:	$(HOSTBIN)/protoc
-	mkdir -p $(INC)/google && ln -sf $(PWD)/$(HOSTINC)/google/protobuf $@
+	@mkdir -p $(INC)/google && ln -sf $(PWD)/$(HOSTINC)/google/protobuf $@
 else
 $(INC)/google/protobuf: $(HOSTBIN)/protoc
 endif
@@ -76,29 +76,30 @@ TENSORFLOW_INCLUDES:= \
 
 # How to actually make an include directory pointing to /usr/include
 $(TENSORFLOW_INCLUDES):
-	mkdir -p $(dir $(@)) && ln -s /usr/include $(@)
+	@mkdir -p $(dir $(@)) && ln -s /usr/include $(@)
 
 # We need the 9a release of libjpeg, which is incldued in ext.  Here we set
 # up the include path so it can be found.
 $(INC)/external/jpeg_archive/jpeg-9a: $(JPEG_INCLUDE_FILES)
-	mkdir -p $(dir $(@)) && ln -s $(PWD)/mldb/ext/jpeg $(@)
+	@mkdir -p $(dir $(@)) && ln -s $(PWD)/mldb/ext/jpeg $(@)
 
 # It also needs re2, which we have locally in ext.  We create the necessary
 # include directories.
 $(INC)/external/re2:
-	mkdir -p $(dir $(@)) && ln -s $(PWD)/mldb/ext/re2 $(@)
+	@mkdir -p $(dir $(@)) && ln -s $(PWD)/mldb/ext/re2 $(@)
 
 # Finally, we need eigen3.  It includes it with the specific Mercurial
 # hash needed, which we list here.  This is also included in ext.
 TENSORFLOW_EIGEN_MERCURIAL_HASH:=$(shell grep 'archive_dir' mldb/ext/tensorflow/eigen.BUILD | head -n1 | sed 's/.*"eigen-eigen-\(.*\)".*/\1/')
 $(if $(TENSORFLOW_EIGEN_MERCURIAL_HASH),,$(error Couldnt find Eigen hash.  You may need to run `git submodule update --init --recursive` to get all the required submodules.))
 $(INC)/external/eigen_archive/eigen-eigen-$(TENSORFLOW_EIGEN_MERCURIAL_HASH):
-	mkdir -p $(dir $(@)) && ln -sf $(PWD)/mldb/ext/eigen $(@)
+	@mkdir -p $(dir $(@)) && ln -sf $(PWD)/mldb/ext/eigen $(@)
 
 # To create a protobuf file, we compile the input file.  Same for the .h
 # file.
 $(CWD)/%.pb.cc $(CWD)/%.pb.h:		$(CWD)/%.proto $(HOSTBIN)/protoc
-	$(HOSTBIN)/protoc $< -Imldb/ext/tensorflow --cpp_out=$(TF_CWD)
+	@echo "         $(COLOR_CYAN)[PROTO]$(COLOR_RESET)			$(basename $<)"
+	@$(HOSTBIN)/protoc $< -Imldb/ext/tensorflow --cpp_out=$(TF_CWD)
 
 # Flags required to include the eigen linear algebra framework.  This
 # has moved around a fair bit over the Tensorflow releases.
@@ -133,8 +134,8 @@ CUDA_HEADERS := cuda.h cublas.h cufft.h cuComplex.h vector_types.h builtin_types
 # third_party/gpus/cuda/include
 
 $(INC)/third_party/gpus/cuda/include/%: $(CUDA_SYSTEM_HEADER_DIR)/%
-	mkdir -p $(dir $@)
-	ln -s $< $@
+	@mkdir -p $(dir $@)
+	@ln -s $< $@
 
 # Anything that's to do with Cuda depends on these header files, so set
 # up the dependency.
@@ -309,8 +310,8 @@ tensorflow_lib: $(LIB)/libtensorflow.so
 # don't want to modify the source tree, we put a dummy, empty header in there
 # to signify that there are no user operations available.
 $(CWD)/tensorflow/cc/ops/%_ops.cc $(CWD)/tensorflow/cc/ops/%_ops.h:	$(BIN)/cc_op_gen $(LIB)/libtensorflow_%_ops.so
-	LD_PRELOAD=$(LIB)/libtensorflow_$(*)_ops.so $(BIN)/cc_op_gen $(TF_CWD)/tensorflow/cc/ops/$(*)_ops.h $(TF_CWD)/tensorflow/cc/ops/$(*)_ops.cc 0
-	touch $(TF_CWD)/tensorflow/cc/ops/user_ops.h
+	@LD_PRELOAD=$(LIB)/libtensorflow_$(*)_ops.so $(BIN)/cc_op_gen $(TF_CWD)/tensorflow/cc/ops/$(*)_ops.h $(TF_CWD)/tensorflow/cc/ops/$(*)_ops.cc 0
+	@touch $(TF_CWD)/tensorflow/cc/ops/user_ops.h
 
 # Find the source files needed for the C++ interface.  Some are pre-packaged and
 # others were generated above.

--- a/jml-build/functions.mk
+++ b/jml-build/functions.mk
@@ -45,6 +45,7 @@ ifneq ($(__BASH_MAKE_COMPLETION__),1)
 # Command to hash the name of a command.
 NOTHING :=
 SPACE := $(NOTHING) $(NOTHING)
+TAB := $(NOTHING)	$(NOTHING)
 
 hash_command2 = $(wordlist 1,1,$(shell echo $(strip $(1)) | md5sum))
 
@@ -105,10 +106,9 @@ BUILD_$(CWD)/$(2).lo_COMMAND2 := $$(subst $(OBJ)/$(CWD)/$(2).lo,$$(BUILD_$(CWD)/
 
 $(OBJ)/$(CWD)/$(2).d:
 $$(BUILD_$(CWD)/$(2).lo_OBJ):	$$(tmpDIR)/$(CWD)/$(1) $(OBJ)/$(CWD)/.dir_exists $$(dir $$(OBJ)/$(CWD)/$(2))/.dir_exists
-	$$(if $(verbose_build),@echo $$(BUILD_$(CWD)/$(2).lo_COMMAND2),@echo "           $(COLOR_CYAN)[C++]$(COLOR_RESET)                $(CWD)/$(1)")
+	$$(if $(verbose_build),@echo $$(BUILD_$(CWD)/$(2).lo_COMMAND2),@echo "           $(COLOR_CYAN)[C++]$(COLOR_RESET)                      	$(CWD)/$(1)")
 	@/usr/bin/time -v -o $$@.timing $$(BUILD_$(CWD)/$(2).lo_COMMAND2)
-	$$(if $(verbose_build),,@echo "           $(COLOR_GREEN)[C++]$(COLOR_RESET) $(COLOR_DARK_GRAY)[" `cat $$@.timing | awk '/User time/ { user=$$$$4*1; } /System time/ { sys=$$$$4*1; } /Maximum resident/ { rss=$$$$6;  } END { printf("%04.1fs %4.1fG", user+sys, rss*0.000001); }'` "]$(COLOR_RESET) $(CWD)/$(1)")
-
+	$$(if $(verbose_build),,@echo "           $(COLOR_GREEN)     $(COLOR_RESET) $(COLOR_DARK_GRAY)`awk -f mldb/jml-build/print-timing.awk $$@.timing`$(COLOR_RESET)	$(CWD)/$(1)")
 	@if [ -f $(2).d ] ; then mv $(2).d $(OBJ)/$(CWD)/$(2).d; fi
 
 compile_$(basename $(1)): $$(BUILD_$(CWD)/$(2).lo_OBJ)
@@ -140,9 +140,10 @@ BUILD_$(CWD)/$(2).lo_OBJ  := $$(OBJ)/$(CWD)/$(2).$$(BUILD_$(CWD)/$(2).lo_HASH).l
 BUILD_$(CWD)/$(2).lo_COMMAND2 := $$(subst $(OBJ)/$(CWD)/$(2).lo,$$(BUILD_$(CWD)/$(2).lo_OBJ),$$(BUILD_$(CWD)/$(2).lo_COMMAND))
 
 $(OBJ)/$(CWD)/$(2).d:
-$$(BUILD_$(CWD)/$(2).lo_OBJ):	$$(tmpDIR)/$(CWD)/$(1) $(OBJ)/$(CWD)/.dir_exists $$(dir $$(OBJ)/$(CWD)/$(2))/.dir_exists
-	$$(if $(verbose_build),@echo $$(BUILD_$(CWD)/$(2).lo_COMMAND2),@echo "             $(COLOR_CYAN)[C]$(COLOR_RESET) $(CWD)/$(1)")
-	@$$(BUILD_$(CWD)/$(2).lo_COMMAND2)
+$$(BUILD_$(CWD)/$(2).lo_OBJ):	$$(tmpDIR)/$(CWD)/$(1) $(OBJ)/$(CWD)/.dir_exists  $$(dir $$(OBJ)/$(CWD)/$(2))/.dir_exists
+	$$(if $(verbose_build),@echo $$(BUILD_$(CWD)/$(2).lo_COMMAND2),@echo "             $(COLOR_CYAN)[C]$(COLOR_RESET)                      	$(CWD)/$(1)")
+	@/usr/bin/time -v -o $$@.timing $$(BUILD_$(CWD)/$(2).lo_COMMAND2)
+	$$(if $(verbose_build),,@echo "             $(COLOR_GREEN)   $(COLOR_RESET) $(COLOR_DARK_GRAY)`awk -f mldb/jml-build/print-timing.awk $$@.timing`$(COLOR_RESET)	$(CWD)/$(1)")
 	@if [ -f $(2).d ] ; then mv $(2).d $(OBJ)/$(CWD)/$(2).d; fi
 
 ifneq ($(__BASH_MAKE_COMPLETION__),1)
@@ -336,8 +337,9 @@ LINK_$(1)_COMMAND2 := $$(subst $$(sodir)/$$(tmpLIBNAME)$$(so),$$(LIB_$(1)_SO),$$
 LIB_$(1)_FILENAME := $$(tmpLIBNAME)$$(so)
 
 $$(LIB_$(1)_SO):	$$(dir $$(LIB_$(1)_SO))/.dir_exists $$(OBJFILES_$(1)) $$(foreach lib,$(3),$$(LIB_$$(lib)_DEPS))
-	$$(if $(verbose_build),@echo $$(LINK_$(1)_COMMAND2),@echo $$(LIB_$(1)_BUILD_NAME) $$(LIB_$(1)_FILENAME))
-	@$$(LINK_$(1)_COMMAND2)
+	$$(if $(verbose_build),@echo $$(BUILD_$(CWD)/$(2).lo_COMMAND2),@echo "            $(COLOR_YELLOW)[SO]$(COLOR_RESET)                      	$$(LIB_$(1)_FILENAME)")
+	@/usr/bin/time -v -o $$@.timing $$(LINK_$(1)_COMMAND2)
+	$$(if $(verbose_build),,@echo "            $(COLOR_YELLOW)    $(COLOR_RESET) $(COLOR_DARK_GRAY)`awk -f mldb/jml-build/print-timing.awk $$@.timing`$(COLOR_RESET)	$$(LIB_$(1)_FILENAME)")
 
 $$(tmpLIBNAME): $$(sodir)/$$(tmpLIBNAME)$$(so)
 .PHONY:	$$(tmpLIBNAME)
@@ -384,8 +386,9 @@ LINK_$(1)_COMMAND:=$$(CXX) $$(CXXFLAGS) $$(CXXEXEFLAGS) $$(CXXNODEBUGFLAGS) -o $
 
 
 $(BIN)/$(1):	$(BIN)/.dir_exists $$($(1)_OBJFILES) $$(foreach lib,$(2),$$(LIB_$$(lib)_DEPS)) $$(if $$(HAS_EXCEPTION_HOOK),$$(LIB)/libexception_hook.so)
-	$$(if $(verbose_build),@echo $$(LINK_$(1)_COMMAND),@echo "           $(COLOR_BLUE)[BIN]$(COLOR_RESET) $(1)")
-	@$$(LINK_$(1)_COMMAND)
+	$$(if $(verbose_build),@echo $$(LINK_$(1)_COMMAND),@echo "           $(COLOR_BLUE)[BIN]$(COLOR_RESET)                   	$(1)")
+	@/usr/bin/time -v -o $$@.timing $$(LINK_$(1)_COMMAND)
+	$$(if $(verbose_build),,@echo "            $(COLOR_YELLOW)    $(COLOR_RESET) $(COLOR_DARK_GRAY)`awk -f mldb/jml-build/print-timing.awk $$@.timing`$(COLOR_RESET)	$(1)")
 
 $$(foreach target,$(4) programs,$$(eval $$(target): $(BIN)/$(1)))
 
@@ -430,20 +433,18 @@ $(1)_OBJFILES:=$$(BUILD_$(CWD)/$(1).cc.lo_OBJ)
 LINK_$(1)_COMMAND:=$$(CXX) $$(CXXFLAGS) $$(CXXEXEFLAGS) $$(CXXNODEBUGFLAGS) -o $(TESTS)/$(1) -lexception_hook -ldl  $$($(1)_OBJFILES) $$(foreach lib,$(2), $$(LIB_$$(lib)_LINKER_OPTIONS) -l$$(lib)) $(if $(findstring boost,$(3)), -lboost_unit_test_framework) $$(CXXEXEPOSTFLAGS)
 
 $(TESTS)/$(1):	$(TESTS)/.dir_exists $(TEST_TMP)/.dir_exists  $$($(1)_OBJFILES) $$(foreach lib,$(2),$$(LIB_$$(lib)_DEPS)) $$(if $$(HAS_EXCEPTION_HOOK),$$(LIB)/libexception_hook.so)
-	$$(if $(verbose_build),@echo $$(LINK_$(1)_COMMAND),@echo "           $(COLOR_BLUE)[BIN]$(COLOR_RESET) $(1)")
+	$$(if $(verbose_build),@echo $$(LINK_$(1)_COMMAND),@echo "       $(COLOR_BLUE)[TESTBIN]$(COLOR_RESET)                     	$(1)")
 	@$$(LINK_$(1)_COMMAND)
 
 tests:	$(TESTS)/$(1)
 $$(CURRENT)_tests: $(TESTS)/$(1)
 
-TEST_$(1)_COMMAND := rm -f $(TESTS)/$(1).{passed,failed} && ((set -o pipefail && $(call TEST_PRE_OPTIONS,$(3))$(TESTS)/$(1) $(TESTS)/$(1) > $(TESTS)/$(1).running 2>&1 && mv $(TESTS)/$(1).running $(TESTS)/$(1).passed) || (mv $(TESTS)/$(1).running $(TESTS)/$(1).failed && echo "                 $(COLOR_RED)$(1) FAILED$(COLOR_RESET)" && cat $(TESTS)/$(1).failed && echo "                       $(COLOR_RED)$(1) FAILED$(COLOR_RESET)" && false))
+TEST_$(1)_COMMAND := rm -f $(TESTS)/$(1).{passed,failed} && ((set -o pipefail && /usr/bin/time -v -o $(TESTS)/$(1).timing $(call TEST_PRE_OPTIONS,$(3))$(TESTS)/$(1) $(TESTS)/$(1) > $(TESTS)/$(1).running 2>&1 && mv $(TESTS)/$(1).running $(TESTS)/$(1).passed) || (mv $(TESTS)/$(1).running $(TESTS)/$(1).failed && echo "                 $(COLOR_RED)$(1) FAILED$(COLOR_RESET)" && cat $(TESTS)/$(1).failed && echo "                       $(COLOR_RED)$(1) FAILED$(COLOR_RESET)" && false))
 
 $(TESTS)/$(1).passed:	$(TESTS)/$(1)
-	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "      $(COLOR_VIOLET)[TESTCASE]$(COLOR_RESET) $(1)")
-	@date -u +%s.%N > $(TESTS)/$(1).timing
+	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "      $(COLOR_VIOLET)[TESTCASE]$(COLOR_RESET)                     	$(1)")
 	@$$(TEST_$(1)_COMMAND)
-	@date -u +%s.%N >> $(TESTS)/$(1).timing
-	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "                 $(COLOR_GREEN)$(1) passed $(COLOR_RESET)$(COLOR_DARK_GRAY)[" `cat $(TESTS)/$(1).timing | awk 'FNR == 1 { start = $$$$1; } FNR == 2 { end = $$$$1; } END { printf("%.1fs", 1.0 * end - 1.0 * start) }'` "]$(COLOR_RESET)")
+	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "                 $(COLOR_DARK_GRAY)`awk -f mldb/jml-build/print-timing.awk $(TESTS)/$(1).timing`$(COLOR_RESET)	$(COLOR_GREEN)$(1) passed $(COLOR_RESET)")
 
 $(1):	$(TESTS)/$(1)
 	$(call TEST_PRE_OPTIONS,$(3))$(TESTS)/$(1)

--- a/jml-build/print-timing.awk
+++ b/jml-build/print-timing.awk
@@ -1,0 +1,15 @@
+/User time/ {
+    user=$4*1;
+}
+/System time/ {
+    sys=$4*1;
+}
+/Maximum resident/ {
+    rss=$6;
+}
+/Percent of CPU/ {
+    cores=substr($7, 1, length($7-1))*0.01;
+}
+END {
+    printf("[ %5.1fs %4.1fG %4.1fc ]", user+sys, rss*0.000001, cores);
+}

--- a/jml-build/python.mk
+++ b/jml-build/python.mk
@@ -97,11 +97,9 @@ $$(if $(trace),$$(warning called python_test "$(1)" "$(2)" "$(3)" "$(4)"))
 TEST_$(1)_COMMAND := rm -f $(TESTS)/$(1).{passed,failed} && $(PYFLAKES) $(CWD)/$(1).py && ((set -o pipefail && PYTHONPATH=$(RUN_PYTHONPATH) $(PYTHON) $(CWD)/$(1).py > $(TESTS)/$(1).running 2>&1 && mv $(TESTS)/$(1).running $(TESTS)/$(1).passed) || (mv $(TESTS)/$(1).running $(TESTS)/$(1).failed && echo "                 $(COLOR_RED)$(1) FAILED$(COLOR_RESET)" && cat $(TESTS)/$(1).failed && false))
 
 $(TESTS)/$(1).passed:	$(TESTS)/.dir_exists $(CWD)/$(1).py $$(foreach lib,$(2),$$(PYTHON_$$(lib)_DEPS)) $$(foreach pymod,$(2),$(TMPBIN)/$$(pymod)_pymod)
-	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "      $(COLOR_VIOLET)[TESTCASE]$(COLOR_RESET) $(1)")
-	@date -u +%s.%N > $(TESTS)/$(1).timing
-	@$$(TEST_$(1)_COMMAND)
-	@date -u +%s.%N >> $(TESTS)/$(1).timing
-	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "                 $(COLOR_GREEN)$(1) passed $(COLOR_RESET)$(COLOR_DARK_GRAY)[" `cat $(TESTS)/$(1).timing | awk 'FNR == 1 { start = $$$$1; } FNR == 2 { end = $$$$1; } END { printf("%.1fs", 1.0 * end - 1.0 * start) }'` "]$(COLOR_RESET)")
+	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "      $(COLOR_VIOLET)[TESTCASE]$(COLOR_RESET)			$(1)")
+	@/usr/bin/time -v -o $$@.timing $$(TEST_$(1)_COMMAND)
+	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "                 $(COLOR_DARK_GRAY)`awk -f mldb/jml-build/print-timing.awk $$@.timing`$(COLOR_RESET)	$(COLOR_GREEN)$(1) passed $(COLOR_RESET)")
 
 $(1):	$(CWD)/$(1).py $$(foreach lib,$(2),$$(PYTHON_$$(lib)_DEPS)) $$(foreach pymod,$(2),$(TMPBIN)/$$(pymod)_pymod)
 	@$(PYFLAKES) $(CWD)/$(1).py
@@ -122,7 +120,7 @@ ifneq ($(PREMAKE),1)
 $$(if $(trace),$$(warning called install_python_file "$(1)" "$(2)"))
 
 $(PYTHON_PURE_LIB_PATH)/$(2)/$(1):	$(CWD)/$(1) $(PYTHON_PURE_LIB_PATH)/$(2)/.dir_exists
-	$$(if $(verbose_build),@echo "cp $$< $$@",@echo " $(COLOR_YELLOW)[PYTHON_MODULE]$(COLOR_RESET) $(2)/$(1)")
+	$$(if $(verbose_build),@echo "cp $$< $$@",@echo " $(COLOR_YELLOW)[PYTHON_MODULE]$(COLOR_RESET)			$(2)/$(1)")
 	@$(PYFLAKES) $$<
 	@cp $$< $$@~
 	@mv $$@~ $$@

--- a/mldb_macros.mk
+++ b/mldb_macros.mk
@@ -20,15 +20,13 @@ TEST_$(1)_RAW_COMMAND := $$(BIN)/mldb_runner -h localhost -p '11700-12700' $$(fo
 
 # Command that is run in the shell.  This takes care of printing the right message
 # out and capturing the output in the right place.
-TEST_$(1)_COMMAND := rm -f $(TESTS)/$(1).{passed,failed} && ((set -o pipefail && $$(TEST_$(1)_SETUP) $$(TEST_$(1)_RAW_COMMAND) >> $(TESTS)/$(1).running 2>&1 && mv $(TESTS)/$(1).running $(TESTS)/$(1).passed) || (mv $(TESTS)/$(1).running $(TESTS)/$(1).failed && echo "                 $(COLOR_RED)$(1) FAILED$(COLOR_RESET)" && cat $(TESTS)/$(1).failed && echo "                       $(COLOR_RED)$(1) FAILED$(COLOR_RESET)" && false))
+TEST_$(1)_COMMAND := rm -f $(TESTS)/$(1).{passed,failed} && ((set -o pipefail && $$(TEST_$(1)_SETUP) /usr/bin/time -v -o $(TESTS)/$(1).timing $$(TEST_$(1)_RAW_COMMAND) >> $(TESTS)/$(1).running 2>&1 && mv $(TESTS)/$(1).running $(TESTS)/$(1).passed) || (mv $(TESTS)/$(1).running $(TESTS)/$(1).failed && echo "                 $(COLOR_RED)$(1) FAILED$(COLOR_RESET)" && cat $(TESTS)/$(1).failed && echo "                       $(COLOR_RED)$(1) FAILED$(COLOR_RESET)" && false))
 
 $(TESTS)/$(1).passed:	$$(BIN)/mldb_runner  $(CWD)/$(1) $(foreach plugin,$(2),mldb_plugin_$(plugin))
-	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "      $(COLOR_VIOLET)[MLDB TEST]$(COLOR_RESET) $(1)")
-	@date -u +%s.%N > $(TESTS)/$(1).timing
+	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "      $(COLOR_VIOLET)[MLDBTEST]$(COLOR_RESET)                     	$(1)")
 	@echo "$$(TEST_$(1)_SETUP) $$(TEST_$(1)_RAW_COMMAND)" > $(TESTS)/$(1).running
 	@$$(TEST_$(1)_COMMAND)
-	@date -u +%s.%N >> $(TESTS)/$(1).timing
-	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "                 $(COLOR_GREEN)$(1) passed $(COLOR_RESET)$(COLOR_DARK_GRAY)[" `cat $(TESTS)/$(1).timing | awk 'FNR == 1 { start = $$$$1; } FNR == 2 { end = $$$$1; } END { printf("%.1fs", 1.0 * end - 1.0 * start) }'` "]$(COLOR_RESET)")
+	$$(if $(verbose_build),@echo '$$(TEST_$(1)_COMMAND)',@echo "                 $(COLOR_DARK_GRAY)`awk -f mldb/jml-build/print-timing.awk $(TESTS)/$(1).timing`$(COLOR_RESET)	$(COLOR_GREEN)$(1) passed $(COLOR_RESET)")
 
 # If ARGS
 TEST_$(1)_ARGS := $$(if $$(findstring $(ARGS), $(ARGS)), $(ARGS), )


### PR DESCRIPTION
This further prettifies the output of the MLDB build, and keeps full timing statistics for all tests.  This allows us to easily compare two trees for differences in performance.

It also modifies the default display to show CPU seconds, not elapsed seconds, as this is less variable run over run.  Finally, it shows the average number of cores used by the test.

![jeremy_khan____projects_mldb-integration](https://cloud.githubusercontent.com/assets/112556/13158752/603ae998-d65c-11e5-8c1e-34530f6881e6.png)
