### PR TITLE
Added test-case for plugin implemented in multiple libraries (MLDB-1398)

### DIFF
--- a/container_files/assets/www/doc/builtin/plugins/SharedLibrary.md
+++ b/container_files/assets/www/doc/builtin/plugins/SharedLibrary.md
@@ -44,4 +44,26 @@ The return value of that function is:
 This allows the plugin to provide additional functionality that is
 linked to the MLDB server it's running under.
 
+## Linking a plugin implemented in multiple libraries
 
+If the plugin is implemented in multiple libraries, it will need to add
+an `rpath` entry that points to the current directory, or otherwise it
+may fail with a message like the following:
+
+```
+error loading plugin file:///mldb_data/plugins/myplugin/: couldn't load plugin library `libmyplugin.so`: libmyplugin-dependency.so: cannot open shared object file: No such file or directory
+plugin will be ignored
+```
+
+To do this, typically the following should be added to the compiler
+command line in the linking phase:
+
+```
+-Wl,-rpath,'$ORIGIN'
+```
+
+to enable to library loader to look in the current directory for other
+libraries associated with the plugin.  By default, it will only look in
+the MLDB and system library directories.
+
+See the discussion in the manual page here: http://man7.org/linux/man-pages/man8/ld.so.8.html

--- a/core/plugin.cc
+++ b/core/plugin.cc
@@ -149,7 +149,7 @@ struct SharedLibraryPlugin::Itl {
         if (!handle) {
             char * error = dlerror();
             ExcAssert(error);
-            throw ML::Exception("couldn't find plugin library %s: %s",
+            throw ML::Exception("couldn't find plugin library '%s': %s",
                                 path.c_str(), error);
         }
 

--- a/core/plugin.h
+++ b/core/plugin.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** plugin.h                                                       -*- C++ -*-
     Jeremy Barnes, 4 December 2014
     Copyright (c) 2014 Datacratic Inc.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Interface for plugins into MLDB.
 */

--- a/testing/MLDB-1398-plugin-library-dependency.js
+++ b/testing/MLDB-1398-plugin-library-dependency.js
@@ -1,0 +1,26 @@
+// This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+
+function assertEqual(expr, val)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    mldb.log(expr, 'IS NOT EQUAL TO', val);
+
+    throw "Assertion failure";
+}
+
+var resp = mldb.get("/v1/plugins");
+
+mldb.log(resp);
+
+var resp = mldb.get("/v1/plugins/MLDB-1398-plugin");
+
+mldb.log(resp);
+
+assertEqual(resp.json.status, "Hello, world");
+
+"success"
+

--- a/testing/MLDB-1398-plugin/MLDB-1398-dep-library.cc
+++ b/testing/MLDB-1398-plugin/MLDB-1398-dep-library.cc
@@ -1,0 +1,13 @@
+/* MLDB-1398-dep-library.cc
+   Jeremy Barnes, 22 February 2015
+   Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+
+   Dependent library for MLDB-1398 test.
+*/
+
+#include <string>
+
+std::string getStatusMessage()
+{
+    return "Hello, world";
+}

--- a/testing/MLDB-1398-plugin/MLDB-1398-main-library.cc
+++ b/testing/MLDB-1398-plugin/MLDB-1398-main-library.cc
@@ -1,0 +1,36 @@
+/* MLDB-1398-main-library.cc
+   Jeremy Barnes, 22 February 2015
+   Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+
+   Main library for MLDB-1398 test.
+*/
+
+#include "mldb/core/plugin.h"
+#include "mldb/types/basic_value_descriptions.h"
+#include <iostream>
+
+using namespace std;
+using namespace Datacratic;
+using namespace Datacratic::MLDB;
+
+// From the dependent plugin library
+std::string getStatusMessage();
+
+struct PluginHandler: public Plugin {
+    PluginHandler(MldbServer * server)
+        : Plugin(server)
+    {
+    }
+
+    virtual Any getStatus() const
+    {
+        return getStatusMessage();
+    }
+};
+
+Datacratic::MLDB::Plugin *
+mldbPluginEnterV100(Datacratic::MLDB::MldbServer * server)
+{
+    cerr << "entering plugin library" << endl;
+    return new PluginHandler(server);
+}

--- a/testing/MLDB-1398-plugin/MLDB-1398-plugin.mk
+++ b/testing/MLDB-1398-plugin/MLDB-1398-plugin.mk
@@ -1,0 +1,12 @@
+# MLDB-1398-plugin.mk
+# Jeremy Barnes, 22 February 2016
+# This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+#
+# Test plugin for MLDB-1398, which tests the ability to load a plugin with
+# functionality implemented in multiple libraries.
+
+$(eval $(call mldb_plugin_library,MLDB-1398-plugin,MLDB-1398-dep-library,MLDB-1398-dep-library.cc,))
+$(eval $(call mldb_plugin_library,MLDB-1398-plugin,MLDB-1398-main-library,MLDB-1398-main-library.cc,MLDB-1398-dep-library))
+
+$(eval $(call mldb_builtin_plugin,MLDB-1398-plugin,MLDB-1398-main-library))
+

--- a/testing/MLDB-1398-plugin/mldb_plugin.json
+++ b/testing/MLDB-1398-plugin/mldb_plugin.json
@@ -1,0 +1,11 @@
+{
+    "config": {
+        "type": "sharedLibrary",
+        "id": "MLDB-1398-plugin",
+        "params": {
+            "library": "lib/libMLDB-1398-main-library.so",
+            "version": "0.9",
+            "apiVersion": "1.0.0"
+        }
+    }
+}

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -323,3 +323,8 @@ $(eval $(call mldb_unit_test,get_http_bound_address.py))
 $(eval $(call mldb_unit_test,get_http_bound_address.js))
 $(eval $(call mldb_unit_test,MLDB-815-sparse-mutable-record-strings.js))
 $(eval $(call mldb_unit_test,MLDB-1395-error-message-file-doesnt-exist.js))
+
+# The MLDB-1398 test case requires a library and a plugin
+# Tensorflow plugins
+$(eval $(call include_sub_make,MLDB-1398-plugin))
+$(eval $(call mldb_unit_test,MLDB-1398-plugin-library-dependency.js,MLDB-1398-plugin))


### PR DESCRIPTION
This test-case was implemented to reproduce an issue in plugin loading.  In the end, the issue wasn't reproducible, but we should keep the test-case to ensure there isn't a regression.

This only changes tests.