### PR TITLE
MLDB-1369 MLDB-1419 routes

### DIFF
--- a/core/function.cc
+++ b/core/function.cc
@@ -14,6 +14,8 @@
 #include "mldb/sql/sql_expression_operations.h"
 #include "mldb/types/map_description.h"
 #include "mldb/types/any_impl.h"
+#include "mldb/rest/rest_request_router.h"
+
 
 using namespace std;
 
@@ -779,6 +781,20 @@ getFunctionInfo() const
                         + " needs to override getFunctionInfo()");
 }
 
+RestRequestMatchResult
+Function::
+handleRequest(RestConnection & connection,
+              const RestRequest & request,
+              RestRequestParsingContext & context) const
+{
+    Json::Value error;
+    error["error"] = "Function of type '" + ML::type_name(*this)
+        + "' does not respond to custom route '" + context.remaining + "'";
+    error["details"]["verb"] = request.verb;
+    error["details"]["resource"] = request.resource;
+    connection.sendErrorResponse(400, error);
+    return RestRequestRouter::MR_ERROR;
+}
 
 } // namespace MLDB
 } // namespace Datacratic

--- a/core/function.h
+++ b/core/function.h
@@ -284,8 +284,8 @@ struct FunctionValueInfo {
         return valueInfo;
     }
 
-    /** These two named values are the same.  Merge them together and make sure that
-        they are compatible.
+    /** These two named values are the same.  Merge them together and make
+        sure that they are compatible.
     */
     void merge(const FunctionValueInfo & other);
 
@@ -321,8 +321,8 @@ struct FunctionValues {
     void addEmbeddingValue(const std::string & name,
                          ssize_t numDimensions);
 
-    /** Add a named value that has a row value (key/value/timestamp tuples).  This
-        one is temporary and simply says that there is an open schema and
+    /** Add a named value that has a row value (key/value/timestamp tuples).
+        This one is temporary and simply says that there is an open schema and
         so all columns are known.
     */
     void addRowValue(const std::string & name);
@@ -353,8 +353,9 @@ struct FunctionValues {
     /** Check that this value is compatible as input to the other value.  Will
         throw an exception if not.
     */
-    void checkValueCompatibleAsInputTo(const Utf8String & otherName,
-                                     const FunctionValueInfo & otherValueInfo) const;
+    void checkValueCompatibleAsInputTo
+        (const Utf8String & otherName,
+         const FunctionValueInfo & otherValueInfo) const;
 
     /** Check that the entire set of values is compatible as an input to the
         function with the given input values requirements.
@@ -425,7 +426,9 @@ struct FunctionApplier {
 /* FUNCTION                                                                  */
 /*****************************************************************************/
 
-/** This represents a function.
+/** This represents a function: something that is called in real-time as part
+    of a query.  It models an SQL function or a sequence of prediction steps
+    that make up a deployed model.
 
     To use a function, you need to:
 
@@ -468,9 +471,9 @@ struct Function: public MldbEntity {
     bind(SqlBindingScope & outerContext,
          const FunctionValues & input) const;
 
-    /** Return the input and the output expected by the function.  Every function
-        needs to be able to say what it expects; there is no such thing as
-        a function that will take "whatever comes in".
+    /** Return the input and the output expected by the function.  Every
+        function needs to be able to say what it expects; there is no
+        such thing as a function that will take "whatever comes in".
     */
     virtual FunctionInfo getFunctionInfo() const = 0;
 
@@ -489,13 +492,23 @@ struct Function: public MldbEntity {
     FunctionOutput
     call(const std::map<Utf8String, ExpressionValue> & input) const;
 
+    /** Method to overwrite to handle a request.  By default, the function
+        will return that it can't handle any requests.  Used to expose
+        function-specific functionality.
+    */
+    virtual RestRequestMatchResult
+    handleRequest(RestConnection & connection,
+                  const RestRequest & request,
+                  RestRequestParsingContext & context) const;
+
 protected:
     /** Used by the FunctionApplier to actually apply the function.  It allows
         access to the information put in the applier by the bind()
         method.
     */
 
-    virtual FunctionOutput apply(const FunctionApplier & applier, const FunctionContext & context) const = 0;
+    virtual FunctionOutput apply(const FunctionApplier & applier,
+                                 const FunctionContext & context) const = 0;
 
     friend class FunctionApplier;
 };

--- a/core/plugin.h
+++ b/core/plugin.h
@@ -59,10 +59,23 @@ struct Plugin: MldbEntity {
                   const RestRequest & request,
                   RestRequestParsingContext & context) const;
 
+    /** Method to respond to a route under /v1/plugins/xxx/doc, which
+        should serve up the documentation.  Default implementation
+        says no documentation is available.
+    */
     virtual RestRequestMatchResult
     handleDocumentationRoute(RestConnection & connection,
                   const RestRequest & request,
                   RestRequestParsingContext & context) const;
+
+    /** Method to respond to a route under /v1/plugins/xxx/static, which
+        should serve up static resources for the plugin.  Default implementation
+        says no static resources are available.
+    */
+    virtual RestRequestMatchResult
+    handleStaticRoute(RestConnection & connection,
+                      const RestRequest & request,
+                      RestRequestParsingContext & context) const;
 };
 
 
@@ -76,6 +89,7 @@ struct SharedLibraryConfig {
     std::string address;        ///< Directory for the plugin
     std::string library;        ///< Library to load
     std::string doc;            ///< Documentation path to be served static
+    std::string staticAssets;   ///< Path to static assets to be served
     std::string version;        ///< Version of plugin
     std::string apiVersion;     ///< Version of the API we require
     bool allowInsecureLoading;  ///< Must be set to true
@@ -104,10 +118,16 @@ struct SharedLibraryPlugin: public Plugin {
                              const RestRequest & request,
                              RestRequestParsingContext & context) const;
 
+    virtual RestRequestMatchResult
+    handleStaticRoute(RestConnection & connection,
+                      const RestRequest & request,
+                      RestRequestParsingContext & context) const;
+
     // Entry point.  It will attempt to call this when initializing
     // the plugin.  It is OK for the function to return a null pointer;
     // if not the given object will be used for the status, version
-    // and request calls.
+    // and request calls and for the documentation and static route calls
+    // if no directory is configured in the configuration.
     typedef Plugin * (*MldbPluginEnterV100) (MldbServer * server);
 private:
     struct Itl;

--- a/mldb_macros.mk
+++ b/mldb_macros.mk
@@ -99,9 +99,15 @@ MLDB_PLUGIN_$(1)_STATIC_FILES_$(2) := $$(filter-out $$(STATIC_CONTENT_FILTER_PAT
 
 # Tell make that in order to create a file in a plugin static content
 # directory, it just has to copy it from the source
+ifeq ($(MLDB_LINK_PLUGIN_RESOURCES),1)
+$(PLUGINS)/$(1)/$(2)/%:	$(CWD)/$(2)/%
+	@echo "   $(COLOR_VIOLET)[MLDB PLUGIN LN]$(COLOR_RESET)" $(1)/$(2)/$$*
+	ln -sf $(PWD)/$$< $$@
+else
 $(PLUGINS)/$(1)/$(2)/%:	$(CWD)/$(2)/%
 	@echo "   $(COLOR_VIOLET)[MLDB PLUGIN CP]$(COLOR_RESET)" $(1)/$(2)/$$*
 	@install -D $$< $$@
+endif
 
 endef
 

--- a/rest/rest_request_router.h
+++ b/rest/rest_request_router.h
@@ -1,9 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** rest_request_router.h                                          -*- C++ -*-
     Jeremy Barnes, 13 November 2012
     Copyright (c) 2012 Datacratic Inc.  All rights reserved.
 
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 */
 
 #pragma once

--- a/server/plugin_collection.cc
+++ b/server/plugin_collection.cc
@@ -101,8 +101,6 @@ initRoutes(RouteManager & manager)
             Plugin * plugin = getPlugin(cxt);
             auto key = manager.getKey(cxt);
 
-            cerr << "***** plugin handling route *****" << req.resource << endl;
-
             try {
                 return plugin->handleRequest(connection, req, cxt);
             }
@@ -127,8 +125,6 @@ initRoutes(RouteManager & manager)
             Plugin * plugin = getPlugin(cxt);
             auto key = manager.getKey(cxt);
 
-            //cerr << "***** plugin handling version route *****" << req.resource << endl;
-
             try {
                 connection.sendResponse(200, jsonEncode(plugin->getVersion()));
                 return RestRequestRouter::MR_YES;
@@ -151,8 +147,6 @@ initRoutes(RouteManager & manager)
             Plugin * plugin = getPlugin(cxt);
             auto key = manager.getKey(cxt);
 
-            cerr << "***** plugin handling documentation route *****" << req.resource << endl;
-
             try {
                 return plugin->handleDocumentationRoute(connection, req, cxt);
             }
@@ -164,6 +158,26 @@ initRoutes(RouteManager & manager)
     manager.valueNode->addRoute(Rx("/doc/(.*)", "<resource>"), {"GET"},
                 "Get documentation of instantiated plugin",
                 handleGetDocumentationRoute, Json::Value());
+
+    RestRequestRouter::OnProcessRequest handleStaticRoute
+        = [=] (RestConnection & connection,
+               const RestRequest & req,
+               RestRequestParsingContext & cxt)
+        {
+            Plugin * plugin = getPlugin(cxt);
+            auto key = manager.getKey(cxt);
+
+            try {
+                return plugin->handleStaticRoute(connection, req, cxt);
+            }
+            catch (const HttpReturnException & exc) {
+                return sendExceptionResponse(connection, exc);
+            }
+        };
+
+    manager.valueNode->addRoute(Rx("/static/(.*)", "<resource>"), {"GET"},
+                                "Get static files of of instantiated plugin",
+                                handleStaticRoute, Json::Value());
 }
 
 Any


### PR DESCRIPTION
Adds the ability for functions to have custom routes, and for plugins to host their own static content.

Concrete use-case is to allow the Tensorflow plugin to host a graph that can be used to explore a loaded model, as well as an eventual Tensorboard integration.
