### PR TITLE
[MLDB-1357] turned to_timestamp and at function into operators

### DIFF
--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -1053,35 +1053,38 @@ matchJoinQualification(ML::Parse_Context & context, JoinQualification& joinQuali
 }
 
 const SqlExpression::Operator operators[] = {
-    { "~", true,        SqlExpression::bwise,  1, "Bitwise NOT" },
-    { "*", false,       SqlExpression::arith,  2, "Multiplication" },
-    { "/", false,       SqlExpression::arith,  2, "Division" },
-    { "%", false,       SqlExpression::arith,  2, "Modulo" },
-    { "+", true,        SqlExpression::arith,  3, "Unary positive" },
-    { "-", true,        SqlExpression::arith,  3, "Unary negative" },
-    { "+", false,       SqlExpression::arith,  3, "Addition / Concatenation" },
-    { "-", false,       SqlExpression::arith,  3, "Subtraction" },
-    { "&", false,       SqlExpression::bwise,  3, "Bitwise and" },
-    { "|", false,       SqlExpression::bwise,  3, "Bitwise or" },
-    { "^", false,       SqlExpression::bwise,  3, "Bitwise exclusive or" },
-    { "=", false,       SqlExpression::compar, 4, "Equality" },
-    { ">=", false,      SqlExpression::compar, 4, "Greater or equal to" },
-    { "<=", false,      SqlExpression::compar, 4, "Less or equal to" },
-    { "<>", false,      SqlExpression::compar, 4, "" },
-    { "!=", false,      SqlExpression::compar, 4, "Not equal to" },
-    { "!>", false,      SqlExpression::compar, 4, "Not greater than" },
-    { "!<", false,      SqlExpression::compar, 4, "Not less than" },
-    { ">", false,       SqlExpression::compar, 4, "Greater than" },
-    { "<", false,       SqlExpression::compar, 4, "Less than" },
-    { "NOT", true,      SqlExpression::booln,  5, "Boolean not" },
-    { "AND", false,     SqlExpression::booln,  6, "Boolean and" },
-    { "OR", false,      SqlExpression::booln,  7, "Boolean or" },
-    { "ALL", true,      SqlExpression::unimp,  7, "All true" },
-    { "ANY", true,      SqlExpression::unimp,  7, "Any true" },
-    { "BETWEEN", false, SqlExpression::unimp,  7, "Between operator" },
-    { "IN", true,       SqlExpression::unimp,  7, "In operator" },
-    { "LIKE", true,     SqlExpression::unimp,  7, "Like operator" },
-    { "SOME", true,     SqlExpression::unimp,  7, "Some true" }
+    //symbol, unary, handler, precedence, description
+    { "~", true,         SqlExpression::bwise,  1, "Bitwise NOT" },
+    { "@", false,        SqlExpression::func,   1, "Set timestamp" },
+    { "timestamp", true, SqlExpression::func,   1, "Coercion to timestamp" },
+    { "*", false,        SqlExpression::arith,  2, "Multiplication" },
+    { "/", false,        SqlExpression::arith,  2, "Division" },
+    { "%", false,        SqlExpression::arith,  2, "Modulo" },
+    { "+", true,         SqlExpression::arith,  3, "Unary positive" },
+    { "-", true,         SqlExpression::arith,  3, "Unary negative" },
+    { "+", false,        SqlExpression::arith,  3, "Addition / Concatenation" },
+    { "-", false,        SqlExpression::arith,  3, "Subtraction" },
+    { "&", false,        SqlExpression::bwise,  3, "Bitwise and" },
+    { "|", false,        SqlExpression::bwise,  3, "Bitwise or" },
+    { "^", false,        SqlExpression::bwise,  3, "Bitwise exclusive or" },
+    { "=", false,        SqlExpression::compar, 4, "Equality" },
+    { ">=", false,       SqlExpression::compar, 4, "Greater or equal to" },
+    { "<=", false,       SqlExpression::compar, 4, "Less or equal to" },
+    { "<>", false,       SqlExpression::compar, 4, "" },
+    { "!=", false,       SqlExpression::compar, 4, "Not equal to" },
+    { "!>", false,       SqlExpression::compar, 4, "Not greater than" },
+    { "!<", false,       SqlExpression::compar, 4, "Not less than" },
+    { ">", false,        SqlExpression::compar, 4, "Greater than" },
+    { "<", false,        SqlExpression::compar, 4, "Less than" },
+    { "NOT", true,       SqlExpression::booln,  5, "Boolean not" },
+    { "AND", false,      SqlExpression::booln,  6, "Boolean and" },
+    { "OR", false,       SqlExpression::booln,  7, "Boolean or" },
+    { "ALL", true,       SqlExpression::unimp,  7, "All true" },
+    { "ANY", true,       SqlExpression::unimp,  7, "Any true" },
+    { "BETWEEN", false,  SqlExpression::unimp,  7, "Between operator" },
+    { "IN", true,        SqlExpression::unimp,  7, "In operator" },
+    { "LIKE", true,      SqlExpression::unimp,  7, "Like operator" },
+    { "SOME", true,      SqlExpression::unimp,  7, "Some true" }
 };
 
 } // file scope
@@ -1131,7 +1134,7 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
             if (!op.unary)
                 continue;
             if (op.precedence > currentPrecedence) {
-                /* Will need to be bound outside our expression, since the precence is wrong. */
+                /* Will need to be bound outside our expression, since the precedence is wrong. */
                 break;
             }
             if (matchOperator(context, op.token)) {
@@ -1741,6 +1744,20 @@ booln(std::shared_ptr<SqlExpression> lhs,
       const std::string & op)
 {
     return std::make_shared<BooleanOperatorExpression>(lhs, rhs, op);
+}
+
+std::shared_ptr<SqlExpression>
+SqlExpression::
+func(std::shared_ptr<SqlExpression> lhs,
+      std::shared_ptr<SqlExpression> rhs,
+      const std::string & op)
+{
+    static std::map<std::string, Utf8String> funcMap = {{"@", "at"}, {"timestamp", "to_timestamp"}};
+    std::vector<std::shared_ptr<SqlExpression> > args;
+    if (lhs)
+        args.push_back(lhs); // binary operator
+    args.push_back(rhs);
+    return std::make_shared<FunctionCallWrapper>("", funcMap[op], args, nullptr);
 }
 
 std::shared_ptr<SqlExpression>

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -966,6 +966,11 @@ struct SqlExpression: public std::enable_shared_from_this<SqlExpression> {
     (std::shared_ptr<SqlExpression> lhs,
      std::shared_ptr<SqlExpression> rhs, const std::string & op);
 
+    // Handle infix operator as function invocation
+    static std::shared_ptr<SqlExpression> func
+    (std::shared_ptr<SqlExpression> lhs,
+     std::shared_ptr<SqlExpression> rhs, const std::string & op);
+
     // Handle an unimplemented operator
     static std::shared_ptr<SqlExpression> unimp
     (std::shared_ptr<SqlExpression> lhs,

--- a/testing/MLDB-909-simple-WHEN-expression.py
+++ b/testing/MLDB-909-simple-WHEN-expression.py
@@ -62,7 +62,7 @@ class SimpleWhenExpressionTest(unittest.TestCase):
                 'expected tuple matching row name %s' % row["rowName"])
 
         rows = query("SELECT * FROM dataset1 WHEN value_timestamp() BETWEEN "
-                          "to_timestamp('{}') AND to_timestamp('{}')"
+                          "TIMESTAMP '{}' AND TIMESTAMP '{}'"
                           .format(year_ago_str, year_from_now_str))
 
         for row in rows:
@@ -73,7 +73,7 @@ class SimpleWhenExpressionTest(unittest.TestCase):
     def test_get_no_tuples(self):
         rows = query(
             "SELECT * FROM dataset1 WHEN value_timestamp() BETWEEN "
-            "to_timestamp('{}') AND to_timestamp('{}')".format(year_ago_str, week_ago_str))
+            "TIMESTAMP '{}' AND TIMESTAMP '{}'".format(year_ago_str, week_ago_str))
         log(rows)
         for row in rows:
             self.assertTrue(
@@ -91,7 +91,7 @@ class SimpleWhenExpressionTest(unittest.TestCase):
     def test_last_tuple_filtered_out(self):
         rows = query(
             "SELECT x FROM dataset1 WHEN value_timestamp() BETWEEN "
-            "to_timestamp('%s') and to_timestamp('%s')" % (a_second_before_now, in_two_hours))
+            "TIMESTAMP '%s' and TIMESTAMP '%s'" % (a_second_before_now, in_two_hours))
         log(rows)
         for row in rows:
             if row['rowName'] is 9:
@@ -102,7 +102,7 @@ class SimpleWhenExpressionTest(unittest.TestCase):
     def test_when_exec_after_where(self):
         # check that the when clause is executed after the where one
         rows = query("SELECT x FROM dataset1 WHEN value_timestamp() BETWEEN "
-                          "to_timestamp('%s') and to_timestamp('%s') WHERE x = 9"
+                          "TIMESTAMP '%s' and TIMESTAMP '%s' WHERE x = 9"
                           % (a_second_before_now, in_two_hours))
         self.assertTrue(
             rows[0]["columns"][0][1] is None and len(rows) == 1,
@@ -119,28 +119,28 @@ class SimpleWhenExpressionTest(unittest.TestCase):
             self.assertEqual(res[0]['columns'][0][2], '1970-01-04T00:00:00Z')
 
         res = query('SELECT * FROM dataset2 WHEN value_timestamp() BETWEEN '
-                         "to_timestamp('1970-01-03T00:00:00Z') AND to_timestamp('1970-01-05T00:00:00Z')")
+                         "TIMESTAMP '1970-01-03T00:00:00Z' AND to_timestamp('1970-01-05T00:00:00Z')")
         expect()
 
         res = query("SELECT * FROM dataset2 WHEN "
-                         "value_timestamp() >= to_timestamp('1970-01-03T00:00:00Z') AND "
-                         "value_timestamp() <= to_timestamp('1970-01-05T00:00:00Z')")
+                         "value_timestamp() >= TIMESTAMP '1970-01-03T00:00:00Z' AND "
+                         "value_timestamp() <= TIMESTAMP '1970-01-05T00:00:00Z'")
         expect()
 
         res = query('SELECT * FROM dataset2 WHEN value_timestamp() BETWEEN '
-                        "to_timestamp('1970-01-04T00:00:00Z') AND to_timestamp('1970-01-04T00:00:00Z')")
+                        "TIMESTAMP '1970-01-04T00:00:00Z' AND to_timestamp('1970-01-04T00:00:00Z')")
         expect()
 
         res = query('SELECT * FROM dataset2 WHEN value_timestamp() BETWEEN '
-                         "to_timestamp('1970-01-03T23:59:59Z') AND to_timestamp('1970-01-04T23:59:59Z')")
+                         "TIMESTAMP '1970-01-03T23:59:59Z' AND to_timestamp('1970-01-04T23:59:59Z')")
         expect()
 
         res = query('SELECT * FROM dataset2 WHEN '
-                         "value_timestamp() = to_timestamp('1970-01-04T00:00:00Z')")
+                         "value_timestamp() = TIMESTAMP '1970-01-04T00:00:00Z'")
         expect()
 
         res = query('SELECT * FROM dataset2 WHEN value_timestamp() BETWEEN '
-                         "to_timestamp('1970-01-04T23:59:59Z') AND to_timestamp('1970-01-03T23:59:59Z')")
+                         "TIMESTAMP '1970-01-04T23:59:59Z' AND to_timestamp('1970-01-03T23:59:59Z')")
         self.assertTrue('columns' not in res[0])
 
     def test_multiple_ts(self):
@@ -156,7 +156,7 @@ class SimpleWhenExpressionTest(unittest.TestCase):
         ds.commit()
 
         res = query('SELECT * FROM dataset3 WHEN value_timestamp() < '
-                        "to_timestamp('1970-01-03T00:00:00Z')")
+                        "TIMESTAMP '1970-01-03T00:00:00Z'")
         self.assertEqual(len(res), 1)
         self.assertEqual(len(res[0]['columns']), 1)
         self.assertEqual(res[0]['columns'][0][2], '1970-01-02T00:00:00Z')
@@ -168,25 +168,25 @@ class SimpleWhenExpressionTest(unittest.TestCase):
             self.assertEqual(res[0]['columns'][0][2], '1970-01-04T00:00:00Z')
 
         res = query('SELECT * FROM dataset2 WHEN value_timestamp() BETWEEN '
-                    "to_timestamp('1970-01-04T01:00:00+01:00') AND "
-                    "to_timestamp('1970-01-04T01:00:00+01:00')")
+                    "TIMESTAMP '1970-01-04T01:00:00+01:00' AND "
+                    "TIMESTAMP '1970-01-04T01:00:00+01:00'")
         expect()
 
         res = query('SELECT * FROM dataset2 WHEN value_timestamp() '
-                    "= to_timestamp('1970-01-04T01:00:00+01:00')")
+                    "= TIMESTAMP '1970-01-04T01:00:00+01:00'")
         expect()
 
         res = query('SELECT * FROM dataset2 WHEN value_timestamp() < '
-                         "to_timestamp('1970-01-02T00:00:00+01:00')")
+                         "TIMESTAMP '1970-01-02T00:00:00+01:00'")
         self.assertTrue('columns' not in res[0])
 
         res = query('SELECT * FROM dataset2 WHEN value_timestamp() BETWEEN '
-                         "to_timestamp('1970-01-03T23:00:00-01:00') AND "
-                         "to_timestamp('1970-01-03T23:00:00-01:00')")
+                         "TIMESTAMP '1970-01-03T23:00:00-01:00' AND "
+                         "TIMESTAMP '1970-01-03T23:00:00-01:00'")
         expect()
 
         res = query('SELECT * FROM dataset2 WHEN value_timestamp() '
-                    "= to_timestamp('1970-01-03T23:00:00-01:00')")
+                    "= TIMESTAMP '1970-01-03T23:00:00-01:00'")
         expect()
 
 

--- a/testing/sql_expression_test.cc
+++ b/testing/sql_expression_test.cc
@@ -826,7 +826,7 @@ BOOST_AUTO_TEST_CASE(test_timestamps)
             return expr(createRow({}), GET_LATEST).getAtom();
         };
     
-    BOOST_CHECK_EQUAL(run("latest_timestamp(at(1, to_timestamp('2015-01-01T00:00:00Z')))"),
+    BOOST_CHECK_EQUAL(run("latest_timestamp(1 @ '2015-01-01T00:00:00Z')"),
                       Date(2015,1,1,0,0,0));
 }
 


### PR DESCRIPTION
This is the new syntax for at() and to_timestamp() functions.  The new syntax is in fact interpreted as a builtin function call.

Comments on the syntax are welcomed.   I will update the test to the new syntax once I get the green light on that.