### PR TITLE
Mldb 1342 added call to logger to ClassifierProcedure

### DIFF
--- a/core/function.h
+++ b/core/function.h
@@ -563,7 +563,9 @@ registerFunctionType(const Package & package,
                                     PolyConfig config,
                                     const std::function<bool (const Json::Value)> & onProgress)
                                 {
-                                    return new FunctionT(FunctionT::getOwner(server), config, onProgress);
+                                    auto function = new FunctionT(FunctionT::getOwner(server), config, onProgress);
+                                    function->logger = MLDB::getMldbLog<FunctionT>();
+                                    return function;
                                 },
                                 makeInternalDocRedirect(package, docRoute),
                                 customRoute,

--- a/core/mldb_entity.h
+++ b/core/mldb_entity.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "mldb/rest/poly_entity.h"
+#include "mldb/utils/log_fwd.h"
 
 namespace Datacratic {
 
@@ -64,6 +65,7 @@ struct MldbEntity: public PolyEntity {
     }
 
     static constexpr const char * INTERNAL_ENTITY  = "INTERNAL_ENTITY";
+    std::shared_ptr<spdlog::logger> logger;
 };
 
 

--- a/core/procedure.h
+++ b/core/procedure.h
@@ -12,6 +12,8 @@
 #include "mldb/rest/rest_entity.h"
 #include "mldb/sql/sql_expression.h"
 #include "mldb/sql/sql_expression_operations.h"
+#include "mldb/utils/log.h"
+#include "mldb/arch/demangle.h"
 #include <set>
 #include <iostream>
 #include <typeinfo>
@@ -338,7 +340,9 @@ registerProcedureType(const Package & package,
              PolyConfig config,
              const std::function<bool (const Json::Value)> & onProgress)
          {
-             return new ProcedureT(ProcedureT::getOwner(server), config, onProgress);
+             auto procedure = new ProcedureT(ProcedureT::getOwner(server), config, onProgress);
+             procedure->logger = MLDB::getMldbLog(ML::demangle(typeid(ProcedureT)));
+             return procedure;
          },
          makeInternalDocRedirect(package, docRoute),
          customRoute,

--- a/core/procedure.h
+++ b/core/procedure.h
@@ -13,7 +13,6 @@
 #include "mldb/sql/sql_expression.h"
 #include "mldb/sql/sql_expression_operations.h"
 #include "mldb/utils/log.h"
-#include "mldb/arch/demangle.h"
 #include <set>
 #include <iostream>
 #include <typeinfo>
@@ -341,7 +340,7 @@ registerProcedureType(const Package & package,
              const std::function<bool (const Json::Value)> & onProgress)
          {
              auto procedure = new ProcedureT(ProcedureT::getOwner(server), config, onProgress);
-             procedure->logger = MLDB::getMldbLog(ML::demangle(typeid(ProcedureT)));
+             procedure->logger = MLDB::getMldbLog<ProcedureT>();
              return procedure;
          },
          makeInternalDocRedirect(package, docRoute),

--- a/plugins/classifier.cc
+++ b/plugins/classifier.cc
@@ -223,7 +223,7 @@ run(const ProcedureRunConfig & run,
         }
     }
 
-    // cerr << "knownInputColumns are " << jsonEncode(knownInputColumns);
+    // logger->info() << "knownInputColumns are " << jsonEncode(knownInputColumns);
 
     ML::Timer timer;
 
@@ -232,7 +232,7 @@ run(const ProcedureRunConfig & run,
     auto featureSpace = std::make_shared<DatasetFeatureSpace>
         (boundDataset.dataset, labelInfo, knownInputColumns);
     
-    cerr << "initialized feature space in " << timer.elapsed() << endl;
+    logger->info() << "initialized feature space in " << timer.elapsed();
     
     // We want to calculate the label and weight of each row as well
     // as the select expression
@@ -371,10 +371,10 @@ run(const ProcedureRunConfig & run,
 
             float weight = extraVals.at(1).toDouble();
 
-            //cerr << "label = " << label << " weight = " << weight << endl;
-            //cerr << "row.columns.size() = " << row.columns.size() << endl;
+            //logger->info() << "label = " << label << " weight = " << weight << endl;
+            //logger->info() << "row.columns.size() = " << row.columns.size();
 
-            //cerr << "got row " << jsonEncode(row) << endl;
+            //logger->info() << "got row " << jsonEncode(row);
             ++numRows;
 
             std::vector<std::pair<ML::Feature, float> > features
@@ -411,7 +411,7 @@ run(const ProcedureRunConfig & run,
                  runProcConf.trainingData.stm->limit, 
                  nullptr /* progress */);
 
-    cerr << "extracted feature vectors in " << timer.elapsed() << endl;
+    logger->info() << "extracted feature vectors in " << timer.elapsed();
     
     // If we're categorical, we need to sort out the labels over all
     // of the threads.
@@ -469,7 +469,7 @@ run(const ProcedureRunConfig & run,
                                },
                                10000 /* thread threshold */);
     
-    cerr << "merged feature vectors in " << timer.elapsed() << endl;
+    logger->info() << "merged feature vectors in " << timer.elapsed();
 
     if (!accum.threads.empty()) {
         fvs = std::move(accum.threads[0]->fvs);
@@ -529,20 +529,20 @@ run(const ProcedureRunConfig & run,
 
     ExcAssertEqual(nx, trainingSet.example_count());
 
-    cerr << "added feature vectors in " << timer.elapsed() << endl;
+    logger->info() << "added feature vectors in " << timer.elapsed();
 
 
     {
         timer.restart();
         trainingSet.preindex(labelFeature);
 
-        //cerr << "indexed " << nx
+        //logger->info() << "indexed " << nx
         //     << " feature vectors in " << after.secondsSince(before)
         //     << " at " << nx / after.secondsSince(before)
-        //     << " per second" << endl;
+        //     << " per second";
     }
 
-    cerr << "indexed training data in " << timer.elapsed() << endl;
+    logger->info() << "indexed training data in " << timer.elapsed();
 
     // ...
     //trainingSet.dump("training_set.txt.gz");
@@ -550,15 +550,15 @@ run(const ProcedureRunConfig & run,
     // Find all features
     std::vector<ML::Feature> allFeatures = trainingSet.index().all_features();
 
-    cerr << "Training with " << allFeatures.size() << " features" << endl;
+    logger->info() << "Training with " << allFeatures.size() << " features";
 
     std::vector<ML::Feature> trainingFeatures;
 
     for (unsigned i = 0;  i < allFeatures.size();  ++i) {
-        //cerr << "allFeatures[i] = " << allFeatures[i] << endl;
+        //logger->info() << "allFeatures[i] = " << allFeatures[i];
 
         string featureName = featureSpace->print(allFeatures[i]);
-        //cerr << "featureName = " << featureName << endl;
+        //logger->info() << "featureName = " << featureName;
 
         if (allFeatures[i] == labelFeature)
             continue;
@@ -568,8 +568,7 @@ run(const ProcedureRunConfig & run,
 #if 0
         if (boost::regex_match(featureName, excludeFeatures)
             || featureName == "LABEL") {
-            cerr << "excluding feature " << featureName << " from training"
-                 << endl;
+            logger->info() << "excluding feature " << featureName << " from training";
             continue;
         }
 #endif
@@ -611,8 +610,8 @@ run(const ProcedureRunConfig & run,
         double factorTrue  = pow(labelWeights[1].total(), -equalizationFactor);
         double factorFalse = pow(labelWeights[0].total(), -equalizationFactor);
 
-        cerr << "factorTrue = " << factorTrue << endl;
-        cerr << "factorFalse = " << factorFalse << endl;
+        logger->info() << "factorTrue = " << factorTrue;
+        logger->info() << "factorFalse = " << factorFalse;
 
         weights = exampleWeights
             * (factorTrue  * labelWeights[true]
@@ -621,12 +620,12 @@ run(const ProcedureRunConfig & run,
         weights.normalize();
     }
 
-    //cerr << "training classifier" << endl;
+    //logger->info() << "training classifier";
     ML::Classifier classifier(trainer->generate(threadContext, trainingSet, weights,
                                                 trainingFeatures));
-    //cerr << "done training classifier" << endl;
+    //logger->info() << "done training classifier";
 
-    cerr << "trained classifier in " << timer.elapsed() << endl;
+    logger->info() << "trained classifier in " << timer.elapsed();
 
     bool saved = true;
     try {
@@ -635,7 +634,7 @@ run(const ProcedureRunConfig & run,
     }
     catch (const std::exception & exc) {
         saved = false;
-        cerr << "Error saving classifier: " << exc.what() << endl;
+        logger->info() << "Error saving classifier: " << exc.what();
     }
 
 
@@ -651,7 +650,7 @@ run(const ProcedureRunConfig & run,
         server->handleRequest(connection, request);
     }
 
-    //cerr << "done saving classifier" << endl;
+    //logger->info() << "done saving classifier";
 
     //trainingSet.dump("training_set.txt.gz");
  
@@ -698,7 +697,7 @@ ClassifyFunction(MldbServer * owner,
 
     itl->labelInfo = labelInfo;
 
-    //cerr << "labelInfo = " << labelInfo << endl;
+    //logger->info() << "labelInfo = " << labelInfo;
 }
 
 ClassifyFunction::
@@ -783,7 +782,7 @@ getFeatureSet(const FunctionContext & context, bool attemptDense) const
 
     std::vector<std::pair<ML::Feature, float> > features;
 
-    //cerr << "row = " << jsonEncode(row) << endl;
+    //logger->info() << "row = " << jsonEncode(row);
 
     for (auto & r: row) {
         ColumnName columnName(std::get<0>(r));
@@ -920,8 +919,7 @@ getFunctionInfo() const
         ColumnSparsity sparsity = col.second.info.optional()
             ? COLUMN_IS_SPARSE : COLUMN_IS_DENSE;
 
-        //cerr << "column " << col.second.columnName << " info " << col.second.info
-        //     << endl;
+        //logger->info() << "column " << col.second.columnName << " info " << col.second.info;
 
         // Be specific about what type we're looking for.  This will allow
         // us to be more leniant when encoding for input.

--- a/rest/http_rest_endpoint.h
+++ b/rest/http_rest_endpoint.h
@@ -9,14 +9,11 @@
 
 #include "mldb/http/http_socket_handler.h"
 #include "mldb/http/port_range_service.h"
+#include "mldb/utils/log_fwd.h"
 #include <atomic>
 #include <memory>
 #include <string>
 #include <time.h>
-
-namespace spdlog {
-    class logger;
-}
 
 namespace Datacratic {
 

--- a/utils/log.cc
+++ b/utils/log.cc
@@ -26,10 +26,12 @@ std::shared_ptr<spdlog::logger> getQueryLog() {
     return queryLog;
 }
 
-std::shared_ptr<spdlog::logger> getMldbLog() {
-    static std::shared_ptr<spdlog::logger> mldbLog = 
-        getConfiguredLogger("mldb", std::string("L [") + timestampFormat + "] %l %v");
-    return mldbLog;
+std::shared_ptr<spdlog::logger> getMldbLog(const std::string & loggerName) {
+    auto logger = spdlog::get(loggerName);
+    if (!logger) {
+       logger = getConfiguredLogger(loggerName, loggerName + std::string(" [") + timestampFormat + "] %l %v");
+    }
+    return logger;
 }
 
 

--- a/utils/log.cc
+++ b/utils/log.cc
@@ -44,7 +44,7 @@ std::shared_ptr<spdlog::logger> getServerLog() {
 // force gcc to export these types
 void dummy() {
     (void)getQueryLog();
-    (void)getMldbLog();
+    (void)getMldbLog("dummy");
     (void)getServerLog();
 }
 

--- a/utils/log.h
+++ b/utils/log.h
@@ -1,0 +1,12 @@
+/* log.h                                                           -*- C++ -*-
+   Guy Dumais, 7 March 2016
+
+   This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+
+   Include this file where the logging interface is used.
+*/
+
+#pragma once
+
+#include "log_fwd.h"
+#include "mldb/ext/spdlog/include/spdlog/spdlog.h"

--- a/utils/log_fwd.h
+++ b/utils/log_fwd.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "mldb/ext/spdlog/include/spdlog/spdlog.h"
+#include <memory>
 
 namespace spdlog {
     class logger;
@@ -19,7 +19,7 @@ namespace Datacratic {
 namespace MLDB {
 
 std::shared_ptr<spdlog::logger> getQueryLog();
-std::shared_ptr<spdlog::logger> getMldbLog();
+std::shared_ptr<spdlog::logger> getMldbLog(const std::string & loggerName = "L");
 std::shared_ptr<spdlog::logger> getServerLog();
 
 } // MLDB

--- a/utils/log_fwd.h
+++ b/utils/log_fwd.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "mldb/arch/demangle.h"
 #include <memory>
 
 namespace spdlog {
@@ -19,8 +20,21 @@ namespace Datacratic {
 namespace MLDB {
 
 std::shared_ptr<spdlog::logger> getQueryLog();
-std::shared_ptr<spdlog::logger> getMldbLog(const std::string & loggerName = "L");
+std::shared_ptr<spdlog::logger> getMldbLog(const std::string & loggerName);
 std::shared_ptr<spdlog::logger> getServerLog();
+
+template <typename Class> 
+std::string 
+getLoggerNameFromClass() {
+    std::string demangledName = ML::demangle(typeid(Class));
+    return demangledName.substr(demangledName.find_last_of(':') + 1);
+}
+    
+template <typename Class> 
+std::shared_ptr<spdlog::logger> 
+getMldbLog() {
+    return getMldbLog(getLoggerNameFromClass<Class>());
+}
 
 } // MLDB
 


### PR DESCRIPTION
This is an early stage of the logger integration to see what you think:
- all entities will have a link to its class logger and logger output is specific for each class (here ClassifierProcedure) and use the type name for lookup
- cerr are changed to info level in most cases

The output looks like this:
```
Datacratic::MLDB::ClassifierProcedure [2016-03-07T13:16:19.901--5:00] info initialized feature space in elapsed: [0.00s cpu, 0.9277 mticks, 0.00s wall]
Datacratic::MLDB::ClassifierProcedure [2016-03-07T13:16:19.901--5:00] info extracted feature vectors in elapsed: [0.00s cpu, 1.3139 mticks, 0.00s wall]
Datacratic::MLDB::ClassifierProcedure [2016-03-07T13:16:19.902--5:00] info merged feature vectors in elapsed: [0.00s cpu, 0.3506 mticks, 0.00s wall]
Datacratic::MLDB::ClassifierProcedure [2016-03-07T13:16:19.902--5:00] info added feature vectors in elapsed: [0.00s cpu, 0.1196 mticks, 0.00s wall]
Datacratic::MLDB::ClassifierProcedure [2016-03-07T13:16:19.902--5:00] info indexed training data in elapsed: [0.00s cpu, 0.0110 mticks, 0.00s wall]
Datacratic::MLDB::ClassifierProcedure [2016-03-07T13:16:19.902--5:00] info Training with 6 features
Datacratic::MLDB::ClassifierProcedure [2016-03-07T13:16:19.902--5:00] info factorTrue = 0.141421
Datacratic::MLDB::ClassifierProcedure [2016-03-07T13:16:19.902--5:00] info factorFalse = 0.1
```

The configuration (not implemented yet) would be part of a general MLDB config.  The log section would look like this
```
[logging]
# specifies the default logging handler
handler=Console
# specifies the default logging level
level=WARNING
# specifies a logging level for class ClassifierProcedure
Datacratic::MLDB::ClassifierProcedure.level=ALL
```