### PR TITLE
Mldb 1443 cls test coverage

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -2,7 +2,7 @@
 
 These instructions are designed for a vanilla installation of **Ubuntu 14.04** and its default compiler, **GCC 4.8**.
 
-It will take around 45 minutes to run through these steps on an Amazon EC2 r3.8xlarge machine (32 cores, 244GB of RAM) and longer on smaller machines. However, you can get up and running in 5 minutes by [using a pre-built Docker images of the MLDB Enterprise Edition](http://mldb.ai/doc/#builtin/Running.md.html) for free with a trial license, which can be obtained instantly by filling out [this form](http://mldb.ai/licensing.html).
+It will take around **45 minutes on a 32-core machine with 244GB of RAM** to run through these steps (i.e. on an Amazon EC2 r3.8xlarge instance) and longer on smaller machines. However, you can get up and running in 5 minutes by [using a pre-built Docker images of the MLDB Enterprise Edition](http://mldb.ai/doc/#builtin/Running.md.html) for free with a trial license, which can be obtained instantly by filling out [this form](http://mldb.ai/licensing.html).
 
 ## System dependencies
 

--- a/Building.md
+++ b/Building.md
@@ -1,6 +1,6 @@
 # Building and running the MLDB Community Edition Docker image
 
-These instructions are designed for a vanilla installation of **Ubuntu 14.04** and its default compiler, **GCC 4.8**.
+These instructions are designed for a vanilla installation of **Ubuntu 14.04** and its default compiler, **GCC 4.8** and assume that you have a Github account with [SSH keys](https://help.github.com/categories/ssh/).
 
 It will take around **45 minutes on a 32-core machine with 244GB of RAM** to run through these steps (i.e. on an Amazon EC2 r3.8xlarge instance) and longer on smaller machines. However, you can get up and running in 5 minutes by [using a pre-built Docker images of the MLDB Enterprise Edition](http://mldb.ai/doc/#builtin/Running.md.html) for free with a trial license, which can be obtained instantly by filling out [this form](http://mldb.ai/licensing.html).
 
@@ -13,12 +13,19 @@ apt-get install -y git valgrind build-essential libboost-all-dev \
 libgoogle-perftools-dev liblzma-dev libcrypto++-dev libblas-dev \
 liblapack-dev python-virtualenv libcurl4-openssl-dev libssh2-1-dev \
 libpython-dev libgit2-dev libv8-dev libarchive-dev libffi-dev \
-libfreetype6-dev libpng12-dev libcap-dev autoconf libtool
+libfreetype6-dev libpng12-dev libcap-dev autoconf libtool unzip \
+language-pack-en
 ```
 
 To build and run the Docker image, you will need to install Docker: https://docs.docker.com/engine/installation/ubuntulinux/
 
 ## Cloning, compiling and test
+
+You will first need to have a Github account with [SSH keys](https://help.github.com/categories/ssh/) set up because the repo uses SSH paths in its submodule configuration. You can test that keys are correctly set up by running the following command and seeing "successfully authenticated":
+
+```bash
+ssh -T git@github.com
+```
 
 **Note** the `master` branch is bleeding edge and the demos or documentation may be slightly out of sync with the code at any given point in time. To avoid this, it is recommended to build the Community Edition from [the latest tagged release](https://github.com/mldbai/mldb/releases/latest).
 

--- a/container_files/public_html/doc/builtin/functions/ClassifierApply.md
+++ b/container_files/public_html/doc/builtin/functions/ClassifierApply.md
@@ -31,8 +31,11 @@ These functions output a single value where the name depends on the classifier m
 
 ## Status
 
-The status of a Classifier Apply function will return a JSON representation of the
-model parameters of the trained classifier, to allow introspection.
+To allow introspection into a trained model, the following routes of a Classifier function will 
+return status information:
+
+* `/status`: overview of the trained model
+* `/details`: parameters of the trained model, such as weights
 
 ## Examples
 

--- a/container_files/public_html/doc/rest.html
+++ b/container_files/public_html/doc/rest.html
@@ -13,7 +13,7 @@ Copyright (c) 2015 Datacratic Inc.  All rights reserved.
     <script src="{{HTTP_BASE_URL}}/resources/js/ace.js"  type="text/javascript" charset="utf-8"></script>
 
     <style>
-        @import url(http://fonts.googleapis.com/css?family=Roboto:400,700|Roboto+Slab:400,700);
+        @import url(//fonts.googleapis.com/css?family=Roboto:400,700|Roboto+Slab:400,700);
         h2, h3  { font-family: "Roboto Slab"; font-weight: bold;}
         .row {margin-left: 15px; }
         .row > p { font-size: 16px; }

--- a/ml/jml/boosted_stumps.cc
+++ b/ml/jml/boosted_stumps.cc
@@ -773,10 +773,13 @@ struct Results_Explain {
 Explanation
 Boosted_Stumps::
 explain(const Feature_Set & feature_set,
-        int label,
+        float label,
         double weight,
         PredictionContext * context) const
 {
+    if(label >= bias.size())
+        throw ML::Exception("Boosted Stumps do not support explain for regression tasks");
+
     Explanation result(feature_space(), weight); 
 
     // Get the bias for the label

--- a/ml/jml/boosted_stumps.cc
+++ b/ml/jml/boosted_stumps.cc
@@ -777,9 +777,6 @@ explain(const Feature_Set & feature_set,
         double weight,
         PredictionContext * context) const
 {
-    if(label >= bias.size())
-        throw ML::Exception("Boosted Stumps do not support explain for regression tasks");
-
     Explanation result(feature_space(), weight); 
 
     // Get the bias for the label

--- a/ml/jml/boosted_stumps.h
+++ b/ml/jml/boosted_stumps.h
@@ -255,7 +255,7 @@ public:
     merge(const Classifier_Impl & other, float weight = 1.0) const;
 
     virtual Explanation explain(const Feature_Set & feature_set,
-                                int label,
+                                float label,
                                 double weight = 1.0,
                                 PredictionContext * context = 0) const;
     

--- a/ml/jml/classifier.cc
+++ b/ml/jml/classifier.cc
@@ -779,7 +779,7 @@ predict(const Training_Data & data,
 Explanation
 Classifier_Impl::
 explain(const Feature_Set & feature_set,
-        int label,
+        float label,
         double weight,
         PredictionContext * context) const
 {

--- a/ml/jml/classifier.h
+++ b/ml/jml/classifier.h
@@ -426,12 +426,12 @@ public:
         given way.  If not implemented, an exception will be thrown.
     */
     virtual Explanation explain(const Feature_Set & feature_set,
-                                int label,
+                                float label,
                                 double weight = 1.0,
                                 PredictionContext * context = 0) const;
 
     virtual Explanation explainContext(const Feature_Set & feature_set,
-                                       int label,
+                                       float label,
                                        const PredictionContext & context,
                                        double weight = 1.0) const
     {

--- a/ml/jml/committee.cc
+++ b/ml/jml/committee.cc
@@ -183,7 +183,7 @@ optimized_predict_impl(int label,
 Explanation
 Committee::
 explain(const Feature_Set & feature_set,
-        int label,
+        float label,
         double weight,
         PredictionContext * context) const
 {

--- a/ml/jml/committee.h
+++ b/ml/jml/committee.h
@@ -104,7 +104,7 @@ public:
                            PredictionContext * context = 0) const;
 
     virtual Explanation explain(const Feature_Set & feature_set,
-                                int label,
+                                float label,
                                 double weight = 1.0,
                                 PredictionContext * context = 0) const;
 

--- a/ml/jml/decision_tree.cc
+++ b/ml/jml/decision_tree.cc
@@ -421,7 +421,7 @@ print_recursive(int level, const Tree::Ptr & ptr,
 Explanation
 Decision_Tree::
 explain(const Feature_Set & feature_set,
-        int label,
+        float label,
         double weight,
         PredictionContext * context) const
 {
@@ -436,7 +436,7 @@ void
 Decision_Tree::
 explain_recursive(Explanation & explanation,
                   const Feature_Set & feature_set,
-                  int label,
+                  float label,
                   double weight,
                   const Tree::Ptr & ptr,
                   const Tree::Node * parent) const

--- a/ml/jml/decision_tree.cc
+++ b/ml/jml/decision_tree.cc
@@ -444,6 +444,10 @@ explain_recursive(Explanation & explanation,
     StandardGetFeatures get_features(feature_set);
     int nl = label_count();
 
+    if(nl < 2)
+        throw ML::Exception("Decision_Tree does not support explain "
+            "for regressions");
+
     if (label < 0 || label >= nl)
         throw Exception("Decision_Tree::explain(): no label");
 

--- a/ml/jml/decision_tree.h
+++ b/ml/jml/decision_tree.h
@@ -114,13 +114,13 @@ public:
                                 double weight = 1.0) const;
 
     virtual Explanation explain(const Feature_Set & feature_set,
-                                int label,
+                                float label,
                                 double weight = 1.0,
                                 PredictionContext * context = 0) const;
 
     void explain_recursive(Explanation & explanation,
                            const Feature_Set & fset,
-                           int label,
+                           float label,
                            double weight,
                            const Tree::Ptr & ptr,
                            const Tree::Node * parent) const;

--- a/ml/jml/decoded_classifier.cc
+++ b/ml/jml/decoded_classifier.cc
@@ -128,7 +128,7 @@ std::string Decoded_Classifier::print() const
 Explanation
 Decoded_Classifier::
 explain(const Feature_Set & feature_set,
-        int label,
+        float label,
         double weight,
         PredictionContext * context) const
 {

--- a/ml/jml/decoded_classifier.h
+++ b/ml/jml/decoded_classifier.h
@@ -86,7 +86,7 @@ public:
 
 
     virtual Explanation explain(const Feature_Set & feature_set,
-                                int label,
+                                float label,
                                 double weight = 1.0,
                                 PredictionContext * context = 0) const;
 

--- a/ml/jml/feature_set.h
+++ b/ml/jml/feature_set.h
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <algorithm>
 #include "mldb/base/parse_context.h"
+#include "mldb/base/exc_assert.h"
 #include "feature.h"
 
 namespace ML {
@@ -365,8 +366,7 @@ public:
     virtual std::tuple<const Feature *, const float *, int, int, size_t>
     get_data(bool need_sorted = false) const
     {
-        if(features.size() == 0)
-            throw ML::Exception("features_type is empty!");
+        ExcAssertGreater(features.size(), 0);
 
         if (need_sorted && !is_sorted) sort();
 

--- a/ml/jml/feature_set.h
+++ b/ml/jml/feature_set.h
@@ -365,6 +365,9 @@ public:
     virtual std::tuple<const Feature *, const float *, int, int, size_t>
     get_data(bool need_sorted = false) const
     {
+        if(features.size() == 0)
+            throw ML::Exception("features_type is empty!");
+
         if (need_sorted && !is_sorted) sort();
 
         return std::make_tuple

--- a/ml/jml/glz_classifier.cc
+++ b/ml/jml/glz_classifier.cc
@@ -353,7 +353,7 @@ output_encoding() const
 Explanation
 GLZ_Classifier::
 explain(const Feature_Set & feature_set,
-        int label,
+        float label,
         double weight,
         PredictionContext * context) const
 {
@@ -363,12 +363,25 @@ explain(const Feature_Set & feature_set,
 
     ExcAssertEqual(decoded.size(), features.size());
 
+    // if we're in regression mode
+    int label_idx = -1;
+    if(weights.size() == 1) {
+        label_idx = 0;
+    }
+    else {
+        label_idx = label;
+    }
+    if(label_idx >= weights.size()) {
+        throw ML::Exception("label bigger than weight vector");
+    }
+
     for (unsigned j = 0;  j < features.size();  ++j) {
         result.feature_weights[features[j].feature]
-            += weight * weights[label][j] * decoded[j];
+            += weight * weights[label_idx][j] * decoded[j];
     }
-    
-    if (add_bias) result.bias += weight * weights[label][features.size()];
+
+    if (add_bias)
+        result.bias += weight * weights[label_idx][features.size()];
 
     return result;
 }

--- a/ml/jml/glz_classifier.h
+++ b/ml/jml/glz_classifier.h
@@ -181,7 +181,7 @@ protected:
 
 public:
     virtual Explanation explain(const Feature_Set & feature_set,
-                                int label,
+                                float label,
                                 double weight = 1.0,
                                 PredictionContext * context = 0) const;
 

--- a/ml/separation_stats.cc
+++ b/ml/separation_stats.cc
@@ -42,10 +42,20 @@ void
 BinaryStats::
 add(const BinaryStats & other, double weight)
 {
-    counts[0][0] += weight * other.counts[0][0];
-    counts[0][1] += weight * other.counts[0][1];
-    counts[1][0] += weight * other.counts[1][0];
-    counts[1][1] += weight * other.counts[1][1];
+    auto addCounts = [&] (      Array2D & local,
+                          const Array2D & other,
+                                       float w)
+
+    {
+        local[0][0] += w * other[0][0];
+        local[0][1] += w * other[0][1];
+        local[1][0] += w * other[1][0];
+        local[1][1] += w * other[1][1];
+    };
+
+    addCounts(counts, other.counts, weight);
+    addCounts(unweighted_counts, other.unweighted_counts, 1);
+
     threshold += weight * other.threshold;
 }
 
@@ -255,6 +265,9 @@ calculate()
 
         current.counts[label][false] -= weight;
         current.counts[label][true] += weight;
+
+        current.unweighted_counts[label][false] -= 1;
+        current.unweighted_counts[label][true] += 1;
 
     }
     

--- a/ml/separation_stats.h
+++ b/ml/separation_stats.h
@@ -157,8 +157,8 @@ struct BinaryStats {
         another point. */
     double rocAreaSince(const BinaryStats & other) const;
 
-    Array2D counts;//double counts[2][2];  // [label][output]
-    Array2D unweighted_counts;//double unweighted_counts[2][2];  // [label][output]
+    Array2D counts; // [label][output]
+    Array2D unweighted_counts; // [label][output]
     double threshold;  // threshold at which stats are taken
     boost::any key;    // Key for this reading
 

--- a/plugins/accuracy.cc
+++ b/plugins/accuracy.cc
@@ -152,7 +152,7 @@ runBoolean(AccuracyConfig & runAccuracyConf,
                       thrStats->sort();
                       stats.add(*thrStats);
                   });
-    
+
 
     //stats.sort();
     stats.calculate();
@@ -169,9 +169,11 @@ runBoolean(AccuracyConfig & runAccuracyConf,
 
             // the difference between included population of the current versus
             // last stats.stats represents the number of exemples included in the stats.
-            // examples get grouped when they have the same score
-            j += (bstats.includedPopulation() - prevIncludedPop);
-            prevIncludedPop = bstats.includedPopulation();
+            // examples get grouped when they have the same score. use the unweighted
+            // scores because we care about the actual number of examples, whatever
+            // what their training weight was
+            j += (bstats.includedPopulation(false) - prevIncludedPop);
+            prevIncludedPop = bstats.includedPopulation(false);
 
             ExcAssertEqual(bstats.threshold, entry.score);
 

--- a/plugins/classifier.cc
+++ b/plugins/classifier.cc
@@ -852,11 +852,6 @@ apply(const FunctionApplier & applier_,
 
     std::tie(dense, fset, ts) = getFeatureSet(context, true /* try to optimize */);
 
-    if(!fset) {
-        throw ML::Exception("Feature_Set is null! Are you giving only null features to "
-            " the classifier function?");
-    }
-
     auto cat = itl->labelInfo.categorical();
     if (!dense.empty()) {
         if (cat) {
@@ -883,6 +878,11 @@ apply(const FunctionApplier & applier_,
         }
     }
     else {
+        if(!fset) {
+            throw ML::Exception("Feature_Set is null! Are you giving only null features to "
+                " the classifier function?");
+        }
+
         if (cat) {
             auto scores = itl->classifier.predict(*fset);
             ExcAssertEqual(scores.size(), labelCount);

--- a/plugins/classifier.cc
+++ b/plugins/classifier.cc
@@ -852,6 +852,11 @@ apply(const FunctionApplier & applier_,
 
     std::tie(dense, fset, ts) = getFeatureSet(context, true /* try to optimize */);
 
+    if(!fset) {
+        throw ML::Exception("Feature_Set is null! Are you giving only null features to "
+            " the classifier function?");
+    }
+
     auto cat = itl->labelInfo.categorical();
     if (!dense.empty()) {
         if (cat) {

--- a/testing/MLDB-174-regression.py
+++ b/testing/MLDB-174-regression.py
@@ -20,9 +20,9 @@ class Mldb174Test(MldbUnitTest):
             "glz": {
                 "type": "glz",
                 "verbosity": 3,
-                "normalize": False,
+                "normalize": True,
                 "link_function": 'linear',
-                "ridge_regression": False
+                "ridge_regression": True
             },
             "dt": {
                 "type": "decision_tree",
@@ -141,7 +141,7 @@ class Mldb174Test(MldbUnitTest):
         mldb.log(jsSelected)
         result = jsSelected["output"]["score"]
 
-        self.assertAlmostEqual(result, value)
+        self.assertAlmostEqual(result, value, delta=0.0001)
 
     def test_wine_quality_merged_regression_glz(self):
         def getConfig(dataset):
@@ -179,7 +179,7 @@ class Mldb174Test(MldbUnitTest):
         rez = mldb.put('/v1/procedures/wine_trainer', config)
 
         # check the performance is in the expected range
-        self.assertAlmostEqual(rez.json()["status"]["firstRun"]["status"]["folds"][0]["results"]["r2"], 0.26, places=2)
+        self.assertAlmostEqual(rez.json()["status"]["firstRun"]["status"]["folds"][0]["results"]["r2"], 0.28, places=2)
 
         # make sure the trained model used all features
         scorerDetails = mldb.get("/v1/functions/winer_scorer_0/details").json()

--- a/testing/MLDB-174-regression.py
+++ b/testing/MLDB-174-regression.py
@@ -150,7 +150,6 @@ class Mldb174Test(MldbUnitTest):
             "type": "transform",
             "params": {
                 "inputData": """
-
                     SELECT * FROM merge(
                         (
                             SELECT *, 'red' as color
@@ -182,6 +181,26 @@ class Mldb174Test(MldbUnitTest):
         mldb.log(usedFeatures)
         self.assertGreater(len(usedFeatures), 2)
 
+
+        # run an explain over the 
+        mldb.put("/v1/functions/explainer", {
+            "type": "classifier.explain",
+            "params": {
+                "modelFileUrl": config["params"]["modelFileUrlPattern"]
+            }
+        })
+
+        explain_rez = mldb.query("""
+                select explainer({{* EXCLUDING(quality)} as features,
+                                  quality as label})
+                from wine_full
+                where rowHash() % 2 = 1
+                limit 2
+        """)
+        
+        self.assertEqual(len(explain_rez), 3)
+
+        # TODO an actual test
 
 
 mldb.run_tests()

--- a/testing/MLDB-174-regression.py
+++ b/testing/MLDB-174-regression.py
@@ -16,13 +16,19 @@ class Mldb174Test(MldbUnitTest):
             ds.record_row(row, [ [ "x", x, 0 ], ["y", y, 0] ])
         ds.commit()
 
-        self.glz_conf =  {
+        self.cls_conf =  {
             "glz": {
                 "type": "glz",
                 "verbosity": 3,
                 "normalize": False,
                 "link_function": 'linear',
                 "ridge_regression": False
+            },
+            "dt": {
+                "type": "decision_tree",
+                "max_depth": 8,
+                "verbosity": 3,
+                "update_alg": "prob"
             }
         }
         
@@ -50,6 +56,51 @@ class Mldb174Test(MldbUnitTest):
             }
         })
 
+        ## create a merged dataset and train on that
+        # the problem here is that there are duplicated rowNames
+        mldb.put('/v1/procedures/column_adder', {
+            "type": "transform",
+            "params": {
+                "inputData": """
+                    SELECT * FROM merge(
+                        (
+                            SELECT *, 'red' as color
+                            FROM wine_red
+                        ),
+                        (
+                            SELECT *, 'white' as color
+                            FROM wine_white
+                        )
+                    )
+                """,
+                "outputDataset": "wine_full_collision",
+                "runOnCreation": True
+            }
+        })
+
+        # let's recreate by avoiding collissions in and therefore duplicated columns
+        mldb.put('/v1/procedures/column_adder', {
+            "type": "transform",
+            "params": {
+                "inputData": """
+                    SELECT * FROM merge(
+                        (
+                            SELECT *, 'red' as color
+                            NAMED rowName() + '_red'
+                            FROM wine_red
+                        ),
+                        (
+                            SELECT *, 'white' as color
+                            NAMED rowName() + '_white'
+                            FROM wine_white
+                        )
+                    )
+                """,
+                "outputDataset": "wine_full",
+                "runOnCreation": True
+            }
+        })
+
 
     def test_select_simple_regression(self):
         modelFileUrl = "file://tmp/MLDB-174.cls"
@@ -61,7 +112,7 @@ class Mldb174Test(MldbUnitTest):
                     "select": "{x} as features, y as label",
                     "from": { "id": "test" }
                 },
-                "configuration": self.glz_conf,
+                "configuration": self.cls_conf,
                 "algorithm": "glz",
                 "modelFileUrl": modelFileUrl,
                 "mode": "regression",
@@ -92,83 +143,39 @@ class Mldb174Test(MldbUnitTest):
 
         self.assertAlmostEqual(result, value)
 
-    def test_wine_quality_merged_regression(self):
-        ## now create a merged dataset and train on that
-        # the problem here is that there are duplicated rowNames
-        mldb.put('/v1/procedures/column_adder', {
-            "type": "transform",
-            "params": {
-                "inputData": """
-
-                    SELECT * FROM merge(
-                        (
-                            SELECT *, 'red' as color
-                            FROM wine_red
-                        ),
-                        (
-                            SELECT *, 'white' as color
-                            FROM wine_white                  
-                        )               
-                    )
-                """,
-                "outputDataset": "wine_full",
-                "runOnCreation": True
+    def test_wine_quality_merged_regression_glz(self):
+        def getConfig(dataset):
+            return {
+                "type": "classifier.experiment",
+                "params": {
+                    "trainingData": """
+                        select
+                        {* EXCLUDING(quality)} as features,
+                        quality as label
+                        from %s
+                    """ % dataset,
+                    "datasetFolds": [
+                            {
+                                "training_where": "rowHash() % 2 = 0", 
+                                "testing_where": "rowHash() % 2 = 1"
+                            }
+                        ],
+                    "experimentName": "winer",
+                    "modelFileUrlPattern": "file://tmp/MLDB-174-wine.cls",
+                    "algorithm": "glz",
+                    "configuration": self.cls_conf,
+                    "mode": "regression",
+                    "runOnCreation": True
+                }
             }
-        })
-        
-        config = {
-            "type": "classifier.experiment",
-            "params": {
-                "trainingData": """
-                    select
-                    {* EXCLUDING(quality)} as features,
-                    quality as label
-                    from wine_full
-                """,
-                "datasetFolds": [
-                        {
-                            "training_where": "rowHash() % 2 = 0", 
-                            "testing_where": "rowHash() % 2 = 1"
-                        }
-                    ],
-                "experimentName": "winer",
-                "modelFileUrlPattern": "file://tmp/MLDB-174-wine.cls",
-                "algorithm": "glz",
-                "configuration": self.glz_conf,
-                "mode": "regression",
-                "runOnCreation": True
-            }
-        }
 
         # this should fail because we check for dupes
         with self.assertRaises(mldb_wrapper.ResponseException) as re:
-            rez = mldb.put('/v1/procedures/wine_trainer', config)
+            mldb.put('/v1/procedures/wine_trainer', getConfig("wine_full_collision"))
 
-        
-        # let's recreate by avoiding collissions in and therefore duplicated columns
-        mldb.put('/v1/procedures/column_adder', {
-            "type": "transform",
-            "params": {
-                "inputData": """
-                    SELECT * FROM merge(
-                        (
-                            SELECT *, 'red' as color
-                            NAMED rowName() + '_red'
-                            FROM wine_red
-                        ),
-                        (
-                            SELECT *, 'white' as color
-                            NAMED rowName() + '_white'
-                            FROM wine_white                  
-                        )               
-                    )
-                """,
-                "outputDataset": "wine_full",
-                "runOnCreation": True
-            }
-        })
-            
+
         # the training should now work
+        config = getConfig("wine_full")
         rez = mldb.put('/v1/procedures/wine_trainer', config)
 
         # check the performance is in the expected range
@@ -201,6 +208,63 @@ class Mldb174Test(MldbUnitTest):
         self.assertEqual(len(explain_rez), 3)
 
         # TODO an actual test
+
+    def test_wine_quality_merged_regression_dt(self):
+        def getConfig(dataset):
+            return {
+                "type": "classifier.experiment",
+                "params": {
+                    "trainingData": """
+                        select
+                        {* EXCLUDING(quality)} as features,
+                        quality as label
+                        from %s
+                    """ % dataset,
+                    "datasetFolds": [
+                            {
+                                "training_where": "rowHash() % 2 = 0", 
+                                "testing_where": "rowHash() % 2 = 1"
+                            }
+                        ],
+                    "experimentName": "winer_dt",
+                    "modelFileUrlPattern": "file://tmp/MLDB-174-wine_dt.cls",
+                    "algorithm": "dt",
+                    "configuration": self.cls_conf,
+                    "mode": "regression",
+                    "runOnCreation": True
+                }
+            }
+
+
+        # the training should now work
+        config = getConfig("wine_full")
+        rez = mldb.put('/v1/procedures/wine_trainer_dt', config)
+
+        # check the performance is in the expected range
+        self.assertAlmostEqual(rez.json()["status"]["firstRun"]["status"]["folds"][0]["results"]["r2"], 0.27, places=2)
+
+        mldb.log(rez)
+
+
+        # run an explain over the 
+        mldb.put("/v1/functions/explainer_dt", {
+            "type": "classifier.explain",
+            "params": {
+                "modelFileUrl": config["params"]["modelFileUrlPattern"]
+            }
+        })
+
+
+        # TODO we should support this
+        with self.assertRaises(mldb_wrapper.ResponseException) as re:
+            explain_rez = mldb.query("""
+                    select explainer_dt({{* EXCLUDING(quality)} as features,
+                                      quality as label})
+                    from wine_full
+                    where rowHash() % 2 = 1
+                    limit 2
+            """)
+
 
 
 mldb.run_tests()

--- a/utils/command.h
+++ b/utils/command.h
@@ -78,6 +78,9 @@ struct Command {
     /// human eyes
     std::string jobName;
 
+    /// Category of the job to aggregate stats
+    std::string jobCategory;
+
     /// The group to which the command belongs, if any
     std::string groupName;
 


### PR DESCRIPTION
This fixes a couple of things. Apologies for mixing up things. A commit-by-commit review is probably easier.

- Changed Classifier_Impl inferface so that the label passed in explain function is now a float so we can deal with regression tasks.
- Added check for a null feature-set when we try to use the classifier function with no columns matching (ie doing a select on columns where none exist in the dataset)
- Binary stats track weighted counts as well as unweighted counts to fix the accuracy plugin when doing a weighted training. the code incremented counters assuming it got actual example counts, but when doing a weighted training, examples were represented by floats possibly smaller than 1 so counters would not move in the expected manner