### PR TITLE
MLDB-1454 remove table name in WHERE for function

### DIFF
--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -1228,7 +1228,7 @@ queryBasic(const SqlBindingScope & scope,
            bool allowParallel) const
 {
     // 1.  Get the rows that match the where clause
-    auto rowGenerator = generateRowsWhere(scope, "", where, 0 /* offset */, -1 /* limit */);
+    auto rowGenerator = generateRowsWhere(scope, "" /*alias*/ , where, 0 /* offset */, -1 /* limit */);
 
     // 2.  Find all the variables needed by the orderBy
     // Remove any constants from the order by clauses

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -352,11 +352,14 @@ struct Dataset: public MldbEntity {
         The where expression must only refer to columns in the dataset,
         or variables that are available in the context.
 
+        The alias is the potential alias of the dataset in the context
+
         This is called by queryStructured and queryBasic, so cannot use those
         functions.
     */
     virtual GenerateRowsWhereFunction
     generateRowsWhere(const SqlBindingScope & context,
+                      const Utf8String& alias,
                       const SqlExpression & where,
                       ssize_t offset,
                       ssize_t limit) const;

--- a/plugins/tabular_dataset.cc
+++ b/plugins/tabular_dataset.cc
@@ -481,6 +481,7 @@ getRowStream() const
 GenerateRowsWhereFunction
 TabularDataset::
 generateRowsWhere(const SqlBindingScope & context,
+                  const Utf8String& alias,
                   const SqlExpression & where,
                   ssize_t offset,
                   ssize_t limit) const
@@ -488,7 +489,7 @@ generateRowsWhere(const SqlBindingScope & context,
     GenerateRowsWhereFunction fn
         = itl->generateRowsWhere(context, where, offset, limit);
     if (!fn)
-        fn = Dataset::generateRowsWhere(context, where, offset, limit);
+        fn = Dataset::generateRowsWhere(context, alias, where, offset, limit);
     return fn;
 }
 

--- a/plugins/tabular_dataset.h
+++ b/plugins/tabular_dataset.h
@@ -487,6 +487,7 @@ struct TabularDataset : public Dataset {
 
     virtual GenerateRowsWhereFunction
     generateRowsWhere(const SqlBindingScope & context,
+                      const Utf8String& alias,
                       const SqlExpression & where,
                       ssize_t offset,
                       ssize_t limit) const;

--- a/server/dataset_context.h
+++ b/server/dataset_context.h
@@ -117,7 +117,6 @@ struct SqlExpressionDatasetContext: public SqlExpressionMldbContext {
     
 protected:
 
-    Utf8String removeTableName(const Utf8String & variableName) const;
     Utf8String removeQuotes(const Utf8String & variableName) const;
     Utf8String resolveTableName(const Utf8String& variableName) const;
     Utf8String resolveTableName(const Utf8String& variableName, Utf8String& resolvedTableName) const;

--- a/server/forwarded_dataset.cc
+++ b/server/forwarded_dataset.cc
@@ -178,12 +178,13 @@ overrideFunction(const Utf8String & tableName,
 GenerateRowsWhereFunction
 ForwardedDataset::
 generateRowsWhere(const SqlBindingScope & context,
+                  const Utf8String& alias,
                   const SqlExpression & where,
                   ssize_t offset,
                   ssize_t limit) const
 {
     ExcAssert(underlying);
-    return underlying->generateRowsWhere(context, where, offset, limit);
+    return underlying->generateRowsWhere(context, alias, where, offset, limit);
 }
 
 BasicRowGenerator

--- a/server/forwarded_dataset.h
+++ b/server/forwarded_dataset.h
@@ -87,6 +87,7 @@ struct ForwardedDataset: public Dataset {
 
     virtual GenerateRowsWhereFunction
     generateRowsWhere(const SqlBindingScope & context,
+                      const Utf8String& alias,
                       const SqlExpression & where,
                       ssize_t offset,
                       ssize_t limit) const;

--- a/sql/sql_utils.cc
+++ b/sql/sql_utils.cc
@@ -38,6 +38,70 @@ std::string escapeSql(const char * str)
     return escapeSql(std::string(str));
 }
 
+//In a single-dataset context
+//If we know the alias of the dataset we are working on, this will remove it from the variable's name
+//It will also verify that the variable identifier does not explicitly specify an dataset that is not of this context.
+//Aka "unknown".identifier
+Utf8String
+removeTableName(const Utf8String & alias, const Utf8String & variableName)
+{    
+    Utf8String shortVariableName = variableName;
+
+    if (!alias.empty() && !variableName.empty()) {
+
+        Utf8String aliasWithDot = alias + ".";
+
+        if (!shortVariableName.removePrefix(aliasWithDot)) {
+
+            //check if there is a quoted prefix
+            auto it1 = shortVariableName.begin();
+            if (*it1 == '\"')
+            {
+                ++it1;
+                auto end1 = shortVariableName.end();
+                auto it2 = alias.begin(), end2 = alias.end();
+
+                while (it1 != end1 && it2 != end2 && *it1 == *it2) {
+                    ++it1;
+                    ++it2;
+                }
+
+                if (it2 == end2 && it1 != end1 && *(it1) == '\"') {
+
+                    shortVariableName.erase(shortVariableName.begin(), it1);
+                    it1 = shortVariableName.begin();
+                    end1 = shortVariableName.end();
+
+                    //if the context's dataset name is specified we requite a .identifier to follow
+                    if (it1 == end1 || *(++it1) != '.') 
+                        throw HttpReturnException(400, "Expected a dot '.' after table name " + alias);
+                    else
+                        shortVariableName.erase(shortVariableName.begin(), ++it1);
+                }
+                else {
+
+                    //no match, but return an error on an unknown explicit table name.
+                    while (it1 != end1) {
+                        if (*it1 == '\"') {
+                            if (++it1 != end1)
+                            {
+                                Utf8String datasetName(shortVariableName.begin(), it1);
+                                throw HttpReturnException(400, "Unknown dataset '" + datasetName + "'");
+                            }  
+                        }
+                        else {
+                            ++it1;
+                        }
+                    }
+
+                }
+            }  
+        }
+    }   
+
+    return std::move(shortVariableName); 
+}
+
 
 } // namespace MLDB
 } // namespace Datacratic

--- a/sql/sql_utils.h
+++ b/sql/sql_utils.h
@@ -18,6 +18,8 @@ Utf8String escapeSql(const Utf8String & str);
 std::string escapeSql(const std::string & str);
 std::string escapeSql(const char * str);
 
+Utf8String removeTableName(const Utf8String & alias, const Utf8String & variableName);
+
 
 } // namespace MLDB
 } // namespace Datacratic

--- a/testing/MLDB-1305_rowNames_join.py
+++ b/testing/MLDB-1305_rowNames_join.py
@@ -26,6 +26,83 @@ dataset.record_row("row1", [["col1", "a", now], ["otherRow", "row1", now]])
 dataset.record_row("row2", [["col2", "b", now], ["otherRow", "row2", now]])
 dataset.commit()
 
+#MLDB-1454 rownames in WHERE regular
+
+mldb.log("MLDB-1454 rownames in WHERE regular")
+
+expected = [["_rowName","col1"],["row1","a"]]
+
+res = mldb.perform("GET", "/v1/query", [["q", """
+    SELECT *
+    FROM dataset1
+    WHERE dataset1.col1 = 'a'
+    """],['format', 'table']])
+
+assert res["statusCode"] != 404
+assert json.loads(res['response']) == expected
+##
+expected = [["_rowName","col1"],["row1","a"]]
+
+res = mldb.perform("GET", "/v1/query", [["q", """
+    SELECT *
+    FROM dataset1 as blah
+    WHERE blah.col1 = 'a'
+    """],['format', 'table']])
+
+assert res["statusCode"] != 404
+assert json.loads(res['response']) == expected
+
+expected = [["_rowName","col1"],["row1","a"]]
+
+res = mldb.perform("GET", "/v1/query", [["q", """
+    SELECT *
+    FROM dataset1
+    WHERE dataset1.rowName() = 'row1'
+    """],['format', 'table']])
+
+assert res["statusCode"] != 404
+assert json.loads(res['response']) == expected
+
+res = mldb.perform("GET", "/v1/query", [["q", """
+    SELECT *
+    FROM dataset1 as blah
+    WHERE blah.rowName() = 'row1'
+    """],['format', 'table']])
+
+assert res["statusCode"] != 404
+assert json.loads(res['response']) == expected
+
+expected = [[ "_rowName", "dataset1.rowName()" ],[ "[\"row1\"]", "[\"row1\"]" ],[ "[\"row2\"]", "[\"row2\"]" ]]
+
+res = mldb.perform("GET", "/v1/query", [["q", """
+    SELECT dataset1.rowName()
+    FROM dataset1
+    GROUP BY dataset1.rowName()
+    """],['format', 'table']])
+
+mldb.log(json.loads(res['response']))
+
+assert res["statusCode"] != 404
+assert json.loads(res['response']) == expected
+
+expected = [[ "_rowName", "dataset1.col1" ],[ "[null]", None ],[ "[\"a\"]", "a" ]]
+
+res = mldb.perform("GET", "/v1/query", [["q", """
+    SELECT dataset1.col1
+    FROM dataset1
+    GROUP BY dataset1.col1
+        """],['format', 'table']])
+
+mldb.log(json.loads(res['response']))
+mldb.log(expected)
+
+assert res["statusCode"] != 404
+assert json.loads(res['response']) == expected
+
+#MLDB-1305 rownames in join
+
+mldb.log("MLDB-1305 rownames in join")
+
 expected = [["_rowName","dataset1.rowName()","dataset2.rowName()"],["[row1]-[row1]","row1","row1"],["[row2]-[row2]","row2","row2"]]
 
 res = mldb.perform("GET", "/v1/query", [["q", """
@@ -33,6 +110,8 @@ res = mldb.perform("GET", "/v1/query", [["q", """
     FROM dataset1
     JOIN dataset2 ON dataset2.rowName() = dataset1.rowName()
     """],['format', 'table']])
+
+mldb.log(json.loads(res['response']))
 
 assert res["statusCode"] != 404
 assert json.loads(res['response']) == expected


### PR DESCRIPTION
The WHERE optimizations are done by the dataset but the dataset doesn't know its alias which is context-dependant so we had to pass the alias to the dataset.