### PR TITLE
Quick fix for Accuracy procedure thread-safety issue

### DIFF
--- a/plugins/accuracy.cc
+++ b/plugins/accuracy.cc
@@ -435,6 +435,7 @@ runRegression(AccuracyConfig & runAccuracyConf,
 
     PerThreadAccumulator<Rows> rowsAccum;
     Date recordDate = Date::now();
+    mutex lineMutex;
 
     auto aggregator = [&] (NamedRowValue & row,
                            const std::vector<ExpressionValue> & scoreLabelWeight)
@@ -454,6 +455,7 @@ runRegression(AccuracyConfig & runAccuracyConf,
 
                 rowsAccum.get().emplace_back(row.rowName, outputRow);
                 if(rowsAccum.get().size() > 1000) {
+                    std::unique_lock<std::mutex> guard(lineMutex);
                     output->recordRows(rowsAccum.get());
                     rowsAccum.get().clear();
                 }


### PR DESCRIPTION
recordRows is NOT guaranteed to be multithread-safe and so calls to it must be properly protected.