### PR TITLE
Fixed git import issues (MLDB-1487)

### DIFF
--- a/plugins/embedding.cc
+++ b/plugins/embedding.cc
@@ -705,8 +705,6 @@ struct EmbeddingDataset::Itl
     recordRowItl(const RowName & rowName,
                  const std::vector<std::tuple<ColumnName, CellValue, Date> > & vals)
     {
-        cerr << "recording row " << rowName << endl;
-
         auto repr = committed();
 
         uint64_t rowHash = EmbeddingDatasetRepr::getRowHashForIndex(rowName);

--- a/plugins/git.cc
+++ b/plugins/git.cc
@@ -223,7 +223,8 @@ namespace MLDB {
 
 struct GitImporterConfig : ProcedureConfig {
     GitImporterConfig()
-        : revisions({"HEAD"}), importStats(false), importTree(false)
+        : revisions({"HEAD"}), importStats(false), importTree(false),
+          ignoreUnknownEncodings(true)
     {
         outputDataset.withType("sparse.mutable");
     }
@@ -233,6 +234,7 @@ struct GitImporterConfig : ProcedureConfig {
     std::vector<std::string> revisions;
     bool importStats;
     bool importTree;
+    bool ignoreUnknownEncodings;
 
     // TODO
     // when
@@ -269,6 +271,12 @@ GitImporterConfigDescription()
              "changed, lines added and lines deleted)", false);
     addField("importTree", &GitImporterConfig::importTree,
              "If true, then import the tree (names of files changed)", false);
+    addField("ignoreUnknownEncodings",
+             &GitImporterConfig::ignoreUnknownEncodings,
+             "If true (default), ignore commit messages with unknown encodings "
+             "(supported are ISO-8859-1 and UTF-8) and replace with a "
+             "placeholder.  If false, messages with unknown encodings will "
+             "cause the commit to abort.");
 
     addParent<ProcedureConfig>();
 }
@@ -327,6 +335,13 @@ struct GitImporter: public Procedure {
         Utf8String message;
         if (!encoding || strcmp(encoding, "UTF-8") == 0) {
             message = Utf8String(messageStr);
+        }
+        else if (strcmp(encoding,"ISO-8859-1") == 0) {
+            message = Utf8String::fromLatin1(messageStr);
+        }
+        else if (config.ignoreUnknownEncodings) {
+            message = "<<<couldn't decode message in "
+                + string(encoding) + " character set>>>";
         }
         else {
             throw HttpReturnException(500,
@@ -543,7 +558,10 @@ struct GitImporter: public Procedure {
             output->recordRows(t->rows);
         }
 
+        output->commit();
+
         RunOutput result;
+
         return result;
     }
 


### PR DESCRIPTION
- Commit is properly called, to avoid empty dataset issues
- We accept messages with ISO-8859-1 encodings, and other encodings that are unknown simply cause the commit message to be skipped.
- Note that the test is not enabled, since there is a separate error caused by problems with expression scope nesting.
