### PR TITLE
MLDB-1360 sparse mutable multithreaded insert

### DIFF
--- a/plugins/importtext_procedure.cc
+++ b/plugins/importtext_procedure.cc
@@ -54,7 +54,7 @@ ImportTextConfigDescription::ImportTextConfigDescription()
              "contribute to the limit.  As a result, it is possible for the dataset "
              "to contain less rows that the requested limit.");
     addField("offset", &ImportTextConfig::offset,
-            "Skip the first n lines (excluding the header if present).", int64_t(0));
+             "Skip the first n lines (excluding the header if present).", int64_t(0));
     addField("encoding", &ImportTextConfig::encoding,
              "Character encoding of file: 'us-ascii', 'ascii', 'latin1', 'iso8859-1', 'utf8' or 'utf-8'",
              string("utf-8"));
@@ -113,7 +113,8 @@ ImportTextConfigDescription::ImportTextConfigDescription()
 struct SqlCsvScope: public SqlExpressionMldbContext {
 
     struct RowScope: public SqlRowScope {
-        RowScope(const CellValue * row, Date ts, int64_t lineNumber, int64_t lineOffset)
+        RowScope(const CellValue * row, Date ts, int64_t lineNumber,
+                 int64_t lineOffset)
             : row(row), ts(ts), lineNumber(lineNumber), lineOffset(lineOffset)
         {
         }
@@ -124,7 +125,8 @@ struct SqlCsvScope: public SqlExpressionMldbContext {
         int64_t lineOffset;
     };
 
-    SqlCsvScope(MldbServer * server, const std::vector<ColumnName> & columnNames,
+    SqlCsvScope(MldbServer * server,
+                const std::vector<ColumnName> & columnNames,
                 Date fileTimestamp, Utf8String dataFileUrl)
         : SqlExpressionMldbContext(server), columnNames(columnNames),
           fileTimestamp(fileTimestamp),
@@ -235,7 +237,7 @@ struct SqlCsvScope: public SqlExpressionMldbContext {
                         return ExpressionValue(row.lineNumber, fileTimestamp);
                     },
                     std::make_shared<IntegerValueInfo>()
-                    };
+                        };
         }
         else if (functionName == "fileTimestamp") {
             return {[=] (const std::vector<ExpressionValue> & args,
@@ -244,7 +246,7 @@ struct SqlCsvScope: public SqlExpressionMldbContext {
                         return ExpressionValue(fileTimestamp, fileTimestamp);
                     },
                     std::make_shared<TimestampValueInfo>()
-                    };
+                        };
         }
         else if (functionName == "dataFileUrl") {
             return {[=] (const std::vector<ExpressionValue> & args,
@@ -253,7 +255,7 @@ struct SqlCsvScope: public SqlExpressionMldbContext {
                         return ExpressionValue(dataFileUrl, fileTimestamp);
                     },
                     std::make_shared<Utf8StringValueInfo>()
-                    };
+                        };
         }
         else if (functionName == "lineOffset") {
             return {[=] (const std::vector<ExpressionValue> & args,
@@ -263,7 +265,7 @@ struct SqlCsvScope: public SqlExpressionMldbContext {
                         return ExpressionValue(row.lineOffset, fileTimestamp);
                     },
                     std::make_shared<IntegerValueInfo>()
-                    };
+                        };
         }
         return SqlBindingScope::doGetFunction(tableName, functionName, args,
                                               argScope);
@@ -320,16 +322,16 @@ Encoding parseEncoding(const std::string & encodingStr)
     Parameters:
     - line: pointer to the start of the line being parsed
     - length: number of characters in the line.  No null terminator is
-      required or expected.
+    required or expected.
     - values: output array of CellValues to recieve output.  These should all
-              be initialized to null on entry.
+    be initialized to null on entry.
     - numColumns: length of the values array, which is the number of columns
-                  expected to be found.
+    expected to be found.
     - separator: CSV separator character; usually a comma
     - quote: CSV quote character, usually a double quote
     - encoding: encoding of lines
     - replaceInvalidCharactersWith: if -1, badly encoded lines will cause an error
-      Otherwise, it's the ASCII code point to put in place of them.
+    Otherwise, it's the ASCII code point to put in place of them.
     - isTextLine: optimization to ignore separator and quote chars and get a single column per line
     - hasQuoteChar: should we use the quote char
 */
@@ -368,33 +370,33 @@ parseFixedWidthCsvRow(const char * & line,
             // Parse differently based upon encoding
             switch (encoding) {
             case ASCII:
-                throw ML::Exception("non-ASCII character in ASCII text file");
+            throw ML::Exception("non-ASCII character in ASCII text file");
             case LATIN1:
-                return CellValue(Utf8String::fromLatin1(string(start, len)));
+            return CellValue(Utf8String::fromLatin1(string(start, len)));
             case UTF8:
-                if (replaceInvalidCharactersWith != -1) {
-                    const char * end = utf8::find_invalid(start, start + len);
-                    if (end == start + len)
-                        return CellValue(start, len, STRING_UNKNOWN);
-                    else {
-                        static constexpr int BUF_PADDING = 64; // defensive; only 5 chars should be needed
-                        char buf[len + BUF_PADDING];
-                        char * end
-                            = utf8::replace_invalid(start, start + len, buf,
-                                                    replaceInvalidCharactersWith);
+            if (replaceInvalidCharactersWith != -1) {
+                const char * end = utf8::find_invalid(start, start + len);
+                if (end == start + len)
+                    return CellValue(start, len, STRING_UNKNOWN);
+                else {
+                    static constexpr int BUF_PADDING = 64; // defensive; only 5 chars should be needed
+                    char buf[len + BUF_PADDING];
+                    char * end
+                        = utf8::replace_invalid(start, start + len, buf,
+                                                replaceInvalidCharactersWith);
 
-                        if (end < buf || end > buf + len + BUF_PADDING) {
-                            // Abort immediately without unwinding as stack has
-                            // been smashed
-                            ::fprintf(stderr, "Replace invalid smashed stack");
-                            abort();
-                        }
-                        return CellValue(buf, end - buf, STRING_UNKNOWN);
+                    if (end < buf || end > buf + len + BUF_PADDING) {
+                        // Abort immediately without unwinding as stack has
+                        // been smashed
+                        ::fprintf(stderr, "Replace invalid smashed stack");
+                        abort();
                     }
+                    return CellValue(buf, end - buf, STRING_UNKNOWN);
                 }
-                return CellValue(start, len, STRING_UNKNOWN);
+            }
+            return CellValue(start, len, STRING_UNKNOWN);
             default:
-                ExcAssert(false);
+            ExcAssert(false);
             }
         };
 
@@ -572,29 +574,29 @@ parseFixedWidthCsvRow(const char * & line,
 
 struct ImportTextProcedureWorkInstance
 {
-	ImportTextProcedureWorkInstance() : lineOffset(1), // we start at line 1
-										isTextLine(false),
-                    areOutputColumnNamesKnown(true),
-										separator(0),
-										quote(0),
-										replaceInvalidCharactersWith(-1),
-										hasQuoteChar(false),
-										isIdentitySelect(false),
-										rowCount(0),
-										numLineErrors(0)
-	{
+    ImportTextProcedureWorkInstance() : lineOffset(1), // we start at line 1
+                                        isTextLine(false),
+                                        areOutputColumnNamesKnown(true),
+                                        separator(0),
+                                        quote(0),
+                                        replaceInvalidCharactersWith(-1),
+                                        hasQuoteChar(false),
+                                        isIdentitySelect(false),
+                                        rowCount(0),
+        numLineErrors(0)
+    {
 
-	}
+    }
 
-	vector<ColumnName> knownColumnNames;
-	ML::Lightweight_Hash<ColumnHash, int> columnIndex; //To check for duplicates column names
-	int64_t lineOffset;  
-	// Column names in the CSV file.  This is distinct from the
+    vector<ColumnName> knownColumnNames;
+    ML::Lightweight_Hash<ColumnHash, int> columnIndex; //To check for duplicates column names
+    int64_t lineOffset;  
+    // Column names in the CSV file.  This is distinct from the
     // output column names that will be created once parsing has
     // happened.
     vector<ColumnName> inputColumnNames;
     bool isTextLine;
-    bool areOutputColumnNamesKnown;
+    std::atomic<int> areOutputColumnNamesKnown;
     char separator;
     char quote;
     int replaceInvalidCharactersWith;
@@ -612,88 +614,88 @@ struct ImportTextProcedureWorkInstance
     uint64_t numLineErrors;
 
     /*    Load a text file and filter according to the configuration  */
-	void loadText(const ImportTextConfig& config, std::shared_ptr<Dataset> dataset, MldbServer * server)
-	{
+    void loadText(const ImportTextConfig& config, std::shared_ptr<Dataset> dataset, MldbServer * server)
+    {
 
-	    string filename = config.dataFileUrl.toString();
+        string filename = config.dataFileUrl.toString();
         
     	// Ask for a memory mappable stream if possible
     	Datacratic::filter_istream stream(filename, { { "mapped", "true" } });
 
-	    // Get the file timestamp out
-	    ts = stream.info().lastModified;
+        // Get the file timestamp out
+        ts = stream.info().lastModified;
 
-	    string header;
+        string header;
 
-	    if (config.delimiter.length() == 1) {
-	        separator = config.delimiter[0];
-	    }
-	    else if (config.delimiter.length() > 1) {
-	        throw HttpReturnException(400, "Separator string must have one character");
-	    }
-	    else if (config.quoter.length() > 0)
+        if (config.delimiter.length() == 1) {
+            separator = config.delimiter[0];
+        }
+        else if (config.delimiter.length() > 1) {
+            throw HttpReturnException(400, "Separator string must have one character");
+        }
+        else if (config.quoter.length() > 0)
 	    {
 	        throw HttpReturnException(400, "Separator string must not be empty if we have a quoter string");
 	    }
 	    
-	    if (config.quoter.length() == 1) {
-	        quote = config.quoter[0];
-	        hasQuoteChar = true;
-	    }
-	    else if (config.quoter.length() > 1) {
-	        throw HttpReturnException(400, "Quoter string must have one character");
-	    }
+        if (config.quoter.length() == 1) {
+            quote = config.quoter[0];
+            hasQuoteChar = true;
+        }
+        else if (config.quoter.length() > 1) {
+            throw HttpReturnException(400, "Quoter string must have one character");
+        }
 
-	    isTextLine = config.quoter.empty() && config.delimiter.empty();
+        isTextLine = config.quoter.empty() && config.delimiter.empty();
 
-	    if (!config.replaceInvalidCharactersWith.empty()) {
-	        if (config.replaceInvalidCharactersWith.length() != 1)
-	            throw HttpReturnException(400, "replaceInvalidCharactersWith string must have one character");
-	        replaceInvalidCharactersWith = *config.replaceInvalidCharactersWith.begin();
-	    }  
+        if (!config.replaceInvalidCharactersWith.empty()) {
+            if (config.replaceInvalidCharactersWith.length() != 1)
+                throw HttpReturnException(400, "replaceInvalidCharactersWith string must have one character");
+            replaceInvalidCharactersWith = *config.replaceInvalidCharactersWith.begin();
+        }  
 
-	    encoding = parseEncoding(config.encoding);
+        encoding = parseEncoding(config.encoding);
 
-	    if (isTextLine) {
+        if (isTextLine) {
 
-	        //MLDB-1312 optimize if there is no delimiter: only 1 column
-	        if (config.headers.empty()) {
-	            inputColumnNames = { ColumnName("lineText") };
-	        }
-	        else {
-	            if (inputColumnNames.size() != 1)
-	                throw HttpReturnException(400, "Custom CSV header must have only one element if there is no delimiter");
-	        }
-	    }
-	    else {  
+            //MLDB-1312 optimize if there is no delimiter: only 1 column
+            if (config.headers.empty()) {
+                inputColumnNames = { ColumnName("lineText") };
+            }
+            else {
+                if (inputColumnNames.size() != 1)
+                    throw HttpReturnException(400, "Custom CSV header must have only one element if there is no delimiter");
+            }
+        }
+        else {  
 
-	        if (config.headers.empty()) {
-	            // Read header line
-	            std::getline(stream, header);
-	            lineOffset += 1;
-	            ML::Parse_Context pcontext(filename, 
-	                                       header.c_str(), header.length(), 1, 0);
+            if (config.headers.empty()) {
+                // Read header line
+                std::getline(stream, header);
+                lineOffset += 1;
+                ML::Parse_Context pcontext(filename, 
+                                           header.c_str(), header.length(), 1, 0);
 	            
-	            vector<string> fields = ML::expect_csv_row(pcontext, -1, separator);
+                vector<string> fields = ML::expect_csv_row(pcontext, -1, separator);
 
-	            switch (encoding) {
-	            case ASCII:
-	                for (const auto & f: fields)
-	                    inputColumnNames.emplace_back(ColumnName(f));
-	                break;
-	            case UTF8:
-	                for (const auto & f: fields)
-	                    inputColumnNames.emplace_back(ColumnName(Utf8String(f)));
-	                break;
-	            case LATIN1:
-	                for (const auto & f: fields)
-	                    inputColumnNames.emplace_back(ColumnName(Utf8String::fromLatin1(f)));
-	                break;
-	            };
-	        }
+                switch (encoding) {
+                case ASCII:
+                    for (const auto & f: fields)
+                        inputColumnNames.emplace_back(ColumnName(f));
+                    break;
+                case UTF8:
+                    for (const auto & f: fields)
+                        inputColumnNames.emplace_back(ColumnName(Utf8String(f)));
+                    break;
+                case LATIN1:
+                    for (const auto & f: fields)
+                        inputColumnNames.emplace_back(ColumnName(Utf8String::fromLatin1(f)));
+                    break;
+                };
+            }
             else {
                 for (const auto & f: config.headers)
-	                inputColumnNames.emplace_back(ColumnName(f));
+                    inputColumnNames.emplace_back(ColumnName(f));
             }             
         }
 
@@ -707,100 +709,100 @@ struct ImportTextProcedureWorkInstance
                                           "columnName", c.toString());
         }
 
-	    // Now we know the columns, we can bind our SQL expressions for the
-	    // select, where, named and timestamp parts of the expression.
-	    SqlCsvScope scope(server, inputColumnNames, ts,
-	                      Utf8String(config.dataFileUrl.toString()));
+        // Now we know the columns, we can bind our SQL expressions for the
+        // select, where, named and timestamp parts of the expression.
+        SqlCsvScope scope(server, inputColumnNames, ts,
+                          Utf8String(config.dataFileUrl.toString()));
 	    
-	    selectBound = config.select.bind(scope);
-	    whereBound = config.where->bind(scope);
-	    namedBound = config.named->bind(scope);
-	    timestampBound = config.timestamp->bind(scope);
+        selectBound = config.select.bind(scope);
+        whereBound = config.where->bind(scope);
+        namedBound = config.named->bind(scope);
+        timestampBound = config.timestamp->bind(scope);
 
-	    // Do we have a "select *"?  In that case, we can perform various
-	    // optimizations to avoid calling into the SQL layer
-	    SqlExpressionDatasetContext noContext(*dataset, ""); //needs a context because x.* is ambiguous
-	    isIdentitySelect = config.select.isIdentitySelect(noContext);  
+        // Do we have a "select *"?  In that case, we can perform various
+        // optimizations to avoid calling into the SQL layer
+        SqlExpressionDatasetContext noContext(*dataset, ""); //needs a context because x.* is ambiguous
+        isIdentitySelect = config.select.isIdentitySelect(noContext);  
 
-	    // Is the name the lineNumber()?  If so, we can save on
-	    // calculating it
-	    //cerr << "name = " << config.named->print() << endl;
+        // Is the name the lineNumber()?  If so, we can save on
+        // calculating it
+        //cerr << "name = " << config.named->print() << endl;
 
-	    // Figure out our output column names from the bound
-	    // select clause
+        // Figure out our output column names from the bound
+        // select clause
 
-	    if (selectBound.info->getSchemaCompleteness() != SCHEMA_CLOSED) {
-                areOutputColumnNamesKnown = false;
-	    }
+        if (selectBound.info->getSchemaCompleteness() != SCHEMA_CLOSED) {
+            areOutputColumnNamesKnown = false;
+        }
 
-	    auto cols = selectBound.info->getKnownColumns();
+        auto cols = selectBound.info->getKnownColumns();
 	    
         for (unsigned i = 0;  i < cols.size();  ++i) {
             const auto& col = cols[i];
-	        if (!col.valueInfo->isScalar())
-	            throw HttpReturnException
-	                (400,
-	                 "Import select expression cannot have row-valued columns.",
-	                 "select", config.select,
-	                 "selectOutputInfo", selectBound.info,
-	                 "columnName", col.columnName);
+            if (!col.valueInfo->isScalar())
+                throw HttpReturnException
+                    (400,
+                     "Import select expression cannot have row-valued columns.",
+                     "select", config.select,
+                     "selectOutputInfo", selectBound.info,
+                     "columnName", col.columnName);
 
             ColumnHash ch(col.columnName);
             if (!columnIndex.insert(make_pair(ch, i)).second)
                 throw HttpReturnException(400, "Duplicate column name in select expression",
-                                               "columnName", col.columnName.toString());
+                                          "columnName", col.columnName.toString());
 	        
-	        knownColumnNames.emplace_back(col.columnName);
-	    }
+            knownColumnNames.emplace_back(col.columnName);
+        }
 
-	    if (isIdentitySelect)
-	        ExcAssertEqual(inputColumnNames, knownColumnNames);
+        if (isIdentitySelect)
+            ExcAssertEqual(inputColumnNames, knownColumnNames);
 
-	    //cerr << "reading " << inputColumnNames.size() << " columns "
-	    //     << jsonEncodeStr(inputColumnNames) << endl;
+        //cerr << "reading " << inputColumnNames.size() << " columns "
+        //     << jsonEncodeStr(inputColumnNames) << endl;
 
-	    //cerr << "writing " << columnNames.size() << " columns "
-	    //     << jsonEncodeStr(columnNames) << endl;
+        //cerr << "writing " << columnNames.size() << " columns "
+        //     << jsonEncodeStr(columnNames) << endl;
 
-	    std::string line;
+        std::string line;
 
-	    // Skip those up to the offset
-	    for (size_t i = 0;  stream && i < config.offset;  ++i, ++lineOffset) {
-	        getline(stream, line);
-	    }
+        // Skip those up to the offset
+        for (size_t i = 0;  stream && i < config.offset;  ++i, ++lineOffset) {
+            getline(stream, line);
+        }
 
-	    Date start = Date::now();
+        Date start = Date::now();
 
-	    std::shared_ptr<TabularDataset> tabular = dynamic_pointer_cast<TabularDataset>(dataset);
+        std::shared_ptr<TabularDataset> tabular = dynamic_pointer_cast<TabularDataset>(dataset);
 
-	    if (tabular)
-	    	loadToTabularDataset(tabular, stream, config, scope);
-	    else
-	    	loadToGeneric(dataset, stream, config, scope);
+        if (tabular)
+            loadToTabularDataset(tabular, stream, config, scope);
+        else
+            loadToGeneric(dataset, stream, config, scope);
 
-	    Date end = Date::now();
+        Date end = Date::now();
 
-	    //double elapsed = start.secondsUntil(end);
-	    //cerr << "read " << rowCount << " lines in "
-	    //     << elapsed << " at " << rowCount / elapsed
-	    //     << " lines/second" << endl;
+        //double elapsed = start.secondsUntil(end);
+        //cerr << "read " << rowCount << " lines in "
+        //     << elapsed << " at " << rowCount / elapsed
+        //     << " lines/second" << endl;
 	    
-	}
+    }
 
-	/*    Load to any non-tabular dataset  */
-	void 
-	loadToGeneric(std::shared_ptr<Dataset> dataset,
-		          Datacratic::filter_istream& stream,
-		          const ImportTextConfig& config,
-		          SqlCsvScope& scope)
-	{
+    /*    Load to any non-tabular dataset  */
+    void 
+    loadToGeneric(std::shared_ptr<Dataset> dataset,
+                  Datacratic::filter_istream& stream,
+                  const ImportTextConfig& config,
+                  SqlCsvScope& scope)
+    {
 
-        const bool outputColumnNames = !areOutputColumnNamesKnown;
+        const bool outputColumnNamesUnknown = !areOutputColumnNamesKnown;
 
         PerThreadAccumulator< std::vector<std::pair<RowName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > > accum;
         std::atomic<size_t> totalRows;
 
-	    auto onLine = [&] (int chunkNum, int64_t actualLineNum, RowName rowName, Date rowTs, CellValue * vals, ColumnName * names, int numberOutputColumns) {
+        auto onLine = [&] (int chunkNum, int64_t actualLineNum, RowName rowName, Date rowTs, CellValue * vals, ColumnName * names, int numberOutputColumns) {
 	    	
             std::vector<std::pair<RowName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > & rows = accum.get();
 
@@ -808,24 +810,24 @@ struct ImportTextProcedureWorkInstance
             for (int i = 0; i < numberOutputColumns; ++i) {
 
                 if (names)
-                    rowvalues.push_back( make_tuple(names[i], std::move(vals[i]), rowTs) );
+                    rowvalues.emplace_back(names[i], std::move(vals[i]), rowTs);
                 else
-                    rowvalues.push_back( make_tuple(knownColumnNames[i], std::move(vals[i]), rowTs) );
+                    rowvalues.emplace_back( knownColumnNames[i],
+                                            std::move(vals[i]), rowTs);
             }
 
-            rows.push_back( { rowName, std::move(rowvalues) } );
-
+            rows.emplace_back(rowName, std::move(rowvalues));
+            
             if (rows.size() == ROWS_PER_CHUNK) {
-     		    {
-          	        dataset->recordRows(rows);
-          	    }
+                dataset->recordRows(rows);
                 rows.clear();
             }
             
             ++totalRows;
         };
 
-        loadTextData(dataset, stream, config, scope, outputColumnNames, onLine);
+        loadTextData(dataset, stream, config, scope, outputColumnNamesUnknown,
+                     onLine);
 
         for (int i = 0; i < accum.threads.size(); ++i) {
             auto & rows = *(accum.threads.at(i).get());
@@ -833,40 +835,40 @@ struct ImportTextProcedureWorkInstance
                 dataset->recordRows(rows);
         };
 
-	    this->rowCount = totalRows;
-	}
+        this->rowCount = totalRows;
+    }
 
-	/*    Load to a tabular dataset  */
-	void 
-	loadToTabularDataset(std::shared_ptr<TabularDataset> dataset, 
-						 Datacratic::filter_istream& stream, 
-						 const ImportTextConfig& config,
-						 SqlCsvScope& scope)
-	{
-        const bool outputColumnNames = !areOutputColumnNamesKnown;
+    /*    Load to a tabular dataset  */
+    void 
+    loadToTabularDataset(std::shared_ptr<TabularDataset> dataset, 
+                         Datacratic::filter_istream& stream, 
+                         const ImportTextConfig& config,
+                         SqlCsvScope& scope)
+    {
+        const bool outputColumnNamesUnknown = !areOutputColumnNamesKnown;
 
         if (areOutputColumnNamesKnown)
-	        dataset->initialize(knownColumnNames, columnIndex);
+            dataset->initialize(knownColumnNames, columnIndex);
 
-	    auto createPayload = [=] ()
+        auto createPayload = [=] ()
 	    {
 	        return dataset->createNewChunk(ROWS_PER_CHUNK);
 	    };
 	    
-	    PerThreadAccumulator<TabularDatasetChunk> accum(createPayload);
+        PerThreadAccumulator<TabularDatasetChunk> accum(createPayload);
 
-	    /// Finished chunks, ordered by chunk number
-	    std::vector<TabularDatasetChunk> doneChunks;
+        /// Finished chunks, ordered by chunk number
+        std::vector<TabularDatasetChunk> doneChunks;
 
-	    mutex lineMutex;
+        mutex lineMutex;
 
-	    auto onLine = [&] (int chunkNum, int64_t actualLineNum, RowName rowName, Date rowTs, CellValue * vals, ColumnName * names, int numVals) {
+        auto onLine = [&] (int chunkNum, int64_t actualLineNum, RowName rowName, Date rowTs, CellValue * vals, ColumnName * names, int numVals) {
 
             TabularDatasetChunk & threadAccum = accum.get();
 
-	        if (threadAccum.chunkNumber == -1) {
-	             threadAccum.chunkNumber = chunkNum;
-	        }
+            if (threadAccum.chunkNumber == -1) {
+                threadAccum.chunkNumber = chunkNum;
+            }
 
             if (!areOutputColumnNamesKnown) {
 
@@ -896,120 +898,119 @@ struct ImportTextProcedureWorkInstance
                 if (numVals != knownColumnNames.size())
                     throw HttpReturnException(400, "Variable number of columns while importing text to tabular dataset");
 
-                    std::vector<CellValue> orderedValues(knownColumnNames.size());
-                    for (int i = 0; i < numVals; ++i) {
+                std::vector<CellValue> orderedValues(knownColumnNames.size());
+                for (int i = 0; i < numVals; ++i) {
 
-                       auto iter = columnIndex.find(names[i]);
-                       if (iter == columnIndex.end())
-                          throw HttpReturnException(400, "Inconsistent column names while importing text to tabular dataset");
+                    auto iter = columnIndex.find(names[i]);
+                    if (iter == columnIndex.end())
+                        throw HttpReturnException(400, "Inconsistent column names while importing text to tabular dataset");
 
-                       orderedValues[iter->second] = vals[i];
-                    }
-
-                    threadAccum.add(std::move(rowName), rowTs, &orderedValues[0]);
+                    orderedValues[iter->second] = vals[i];
                 }
 
-	        if (threadAccum.rowCount() == ROWS_PER_CHUNK) {
-	            //size_t before JML_UNUSED = threadAccum.memusage();
-	            threadAccum.freeze();
-	            //size_t after JML_UNUSED = threadAccum.memusage();
-	            TabularDatasetChunk newChunk(numVals, ROWS_PER_CHUNK);
-	            std::unique_lock<std::mutex> guard(lineMutex);
-	            doneChunks.emplace_back(std::move(newChunk));
-	            doneChunks.back().swap(threadAccum);
-	            ExcAssertEqual(threadAccum.rowCount(), 0);
+                threadAccum.add(std::move(rowName), rowTs, &orderedValues[0]);
+            }
 
-	#if 0
-	            cerr << "compressed from " << before << " to " << after << " bytes ("
-	                  << 100.0 * after / before << "%)" << endl;
+            if (threadAccum.rowCount() == ROWS_PER_CHUNK) {
+                //size_t before JML_UNUSED = threadAccum.memusage();
+                threadAccum.freeze();
+                //size_t after JML_UNUSED = threadAccum.memusage();
+                TabularDatasetChunk newChunk(numVals, ROWS_PER_CHUNK);
+                std::unique_lock<std::mutex> guard(lineMutex);
+                doneChunks.emplace_back(std::move(newChunk));
+                doneChunks.back().swap(threadAccum);
+                ExcAssertEqual(threadAccum.rowCount(), 0);
 
-	            int rowBits = 0;
-	            for (auto & c: doneChunks.back().columns) {
-	                rowBits += c.frozen->getIndexBits();
-	                //cerr << "column had " << c.indexedVals.size()
-	                //     << " distinct values on " << c.indexes.size()
-	                //     << " total entries" << endl;
-	            }
-	            cerr << "rowBits = " << rowBits << endl;
-	#endif                    
-	        }
-	    };
+#if 0
+                cerr << "compressed from " << before << " to " << after << " bytes ("
+                << 100.0 * after / before << "%)" << endl;
 
-	    loadTextData(dataset, stream, config, scope, outputColumnNames, onLine);
+                int rowBits = 0;
+                for (auto & c: doneChunks.back().columns) {
+                    rowBits += c.frozen->getIndexBits();
+                    //cerr << "column had " << c.indexedVals.size()
+                    //     << " distinct values on " << c.indexes.size()
+                    //     << " total entries" << endl;
+                }
+                cerr << "rowBits = " << rowBits << endl;
+#endif                    
+            }
+        };
 
-            // Accumulate the partial chunks, too, at the end
-	    std::mutex doneChunksLock;
+        loadTextData(dataset, stream, config, scope, outputColumnNamesUnknown,
+                     onLine);
 
-	    auto doLeftoverChunk = [&] (int threadNum) {
-	        TabularDatasetChunk * ent = accum.threads.at(threadNum).get();
+        // Accumulate the partial chunks, too, at the end
+        std::mutex doneChunksLock;
+
+        auto doLeftoverChunk = [&] (int threadNum) {
+            TabularDatasetChunk * ent = accum.threads.at(threadNum).get();
             ExcAssert(ent != nullptr);
-	        ent->freeze();
-	        std::unique_lock<std::mutex> guard(doneChunksLock);
-	        doneChunks.emplace_back(std::move(*ent));
-	    };
+            ent->freeze();
+            std::unique_lock<std::mutex> guard(doneChunksLock);
+            doneChunks.emplace_back(std::move(*ent));
+        };
 
-	    parallelMap(0, accum.threads.size(), doLeftoverChunk);
+        parallelMap(0, accum.threads.size(), doLeftoverChunk);
 
-	    //cerr << "got a total of " << doneChunks.size() << " chunks" << endl;
+        //cerr << "got a total of " << doneChunks.size() << " chunks" << endl;
 
-	    size_t totalMemUsage = 0;
-	    size_t totalRows = 0;
-	    for (auto & c: doneChunks) {
-	        totalMemUsage += c.memusage();
-	        totalRows += c.rowCount();
-	    }
-	    //cerr << "total memory usage of " << totalMemUsage / 1000000.0 << "MB "
-	    //     << " over " << totalRows << " rows at "
-	    //     << 1.0 * totalMemUsage / totalRows << " bytes/row and "
-	    //     << 1.0 * totalMemUsage / totalRows / numberOutputColumns
-	    //     << " bytes/value" << endl;
+        size_t totalMemUsage = 0;
+        size_t totalRows = 0;
+        for (auto & c: doneChunks) {
+            totalMemUsage += c.memusage();
+            totalRows += c.rowCount();
+        }
+        //cerr << "total memory usage of " << totalMemUsage / 1000000.0 << "MB "
+        //     << " over " << totalRows << " rows at "
+        //     << 1.0 * totalMemUsage / totalRows << " bytes/row and "
+        //     << 1.0 * totalMemUsage / totalRows / numberOutputColumns
+        //     << " bytes/value" << endl;
 
-	    this->rowCount = totalRows;
+        this->rowCount = totalRows;
 
-	    dataset->finalize(doneChunks, totalRows);	  
+        dataset->finalize(doneChunks, totalRows);	  
 		
-	}
+    }
 
-	/*    Load, filter and format all lines and process them  */
-	void 
-	loadTextData(std::shared_ptr<Dataset> dataset, 
-	             Datacratic::filter_istream& stream, 
-		         const ImportTextConfig& config,
-		         SqlCsvScope& scope,
-                 bool outputColumnNames,
-		         const std::function<void (int, int64_t , RowName , Date , CellValue *, ColumnName * , int)> & processLine)
-	{	
-	    std::mutex lineMutex;
-
-	    // Do we have a "where true'?  In that case, we don't need to
-	    // call the SQL parser
-	    bool isWhereTrue = config.where->isConstantTrue();
+    /*    Load, filter and format all lines and process them  */
+    void 
+    loadTextData(std::shared_ptr<Dataset> dataset, 
+                 Datacratic::filter_istream& stream, 
+                 const ImportTextConfig& config,
+                 SqlCsvScope& scope,
+                 bool outputColumnNamesUnknown,
+                 const std::function<void (int, int64_t , RowName , Date , CellValue *, ColumnName * , int)> & processLine)
+    {	
+        // Do we have a "where true'?  In that case, we don't need to
+        // call the SQL parser
+        bool isWhereTrue = config.where->isConstantTrue();
 	    
-	    std::atomic<uint64_t> numSkipped(0);
-	    std::atomic<uint64_t> totalLinesProcessed(0);
+        std::atomic<uint64_t> numSkipped(0);
+        std::atomic<uint64_t> totalLinesProcessed(0);
 
-	    ML::Timer timer;
+        ML::Timer timer;
 
-	    auto handleError = [&](const std::string & message, 
-	                           int64_t lineNumber, 
-	                           int64_t columnNumber, 
-	                           const std::string& line) {
-	        if (config.ignoreBadLines) {
-	            ++numSkipped;
-	            return true;
-	        }
+        auto handleError = [&](const std::string & message, 
+                               int64_t lineNumber, 
+                               int64_t columnNumber, 
+                               const std::string& line) {
+            if (config.ignoreBadLines) {
+                ++numSkipped;
+                return true;
+            }
 	        
-	        throw HttpReturnException(400, "Error parsing CSV row: "
-	                                  + message,
-	                                  "lineNumber", lineNumber,
-	                                  "columnNumber", columnNumber, 
-	                                  "line", line);
-	    };
+            throw HttpReturnException(400, "Error parsing CSV row: "
+                                      + message,
+                                      "lineNumber", lineNumber,
+                                      "columnNumber", columnNumber, 
+                                      "line", line);
+        };
 
-	    auto onLine = [&] (const char * line,
-	                       size_t length,
-	                       int chunkNum,
-	                       int64_t lineNum)
+        auto onLine = [&] (const char * line,
+                           size_t length,
+                           int chunkNum,
+                           int64_t lineNum)
 	    {
 	        //cerr << "doing line with lineNum " << lineNum << endl;
 	        //cerr << "online " << string(line, length) << endl;
@@ -1036,16 +1037,16 @@ struct ImportTextProcedureWorkInstance
 
 	        const char * lineStart = line;
 
-            const size_t numInputColumn = inputColumnNames.size();
+                const size_t numInputColumn = inputColumnNames.size();
 
 	        const char * errorMsg = parseFixedWidthCsvRow(line, length, &values[0],
-	                                        numInputColumn,
-	                                        separator, quote, encoding,
-	                                        replaceInvalidCharactersWith,
-	                                        isTextLine,
-	                                        hasQuoteChar);
+                                                              numInputColumn,
+                                                              separator, quote, encoding,
+                                                              replaceInvalidCharactersWith,
+                                                              isTextLine,
+                                                              hasQuoteChar);
 
-            if (errorMsg)
+                if (errorMsg)
 	            return handleError(errorMsg, actualLineNum, line - lineStart + 1, string(line, length));
 
 	        //cerr << "got values " << jsonEncode(vector<CellValue>(values, values + inputColumnNames.size())) << endl;
@@ -1071,7 +1072,7 @@ struct ImportTextProcedureWorkInstance
 	            
 	        //cerr << jsonEncodeStr(vector<CellValue>(values, values + numberOutputColumns)) << endl;
 	            
-            ExcAssert(!(isIdentitySelect && outputColumnNames));
+                ExcAssert(!(isIdentitySelect && outputColumnNamesUnknown));
 
 	        if (isIdentitySelect) {
 	            // If it's a select *, we don't really need to run the
@@ -1085,44 +1086,44 @@ struct ImportTextProcedureWorkInstance
 	            ExpressionValue selectStorage;
 	            const ExpressionValue & selectOutput = selectBound(row, selectStorage, GET_LATEST);
 
-                const auto & selectRow = selectOutput.getRow();
+                    const auto & selectRow = selectOutput.getRow();
 
-                // TODO: clang doesn't like a variable length array
-                // here.  Find another way to allocate it on the
-                // stack.
-                // CellValue valuesOut[numberOutputColumns];
+                    // TODO: clang doesn't like a variable length array
+                    // here.  Find another way to allocate it on the
+                    // stack.
+                    // CellValue valuesOut[numberOutputColumns];
 
-                vector<CellValue> valuesOut(selectRow.size());
-                vector<ColumnName> namesOut;
+                    vector<CellValue> valuesOut(selectRow.size());
+                    vector<ColumnName> namesOut;
 
-                if (outputColumnNames)
-                    namesOut.resize(selectRow.size());
+                    if (outputColumnNamesUnknown)
+                        namesOut.resize(selectRow.size());
 
 	            if (&selectOutput == &selectStorage) {
 	                // We can destructively work with it
 
 	                auto selectRow = selectStorage.stealRow();
 	                for (unsigned i = 0;  i < selectRow.size();  ++i) {
-                        auto& rItem = selectRow[i];
-                        if (!std::get<1>(rItem).isAtom())
-                            throw HttpReturnException(400, "select expression must return atomic values in import.text procedure");
+                            auto& rItem = selectRow[i];
+                            if (!std::get<1>(rItem).isAtom())
+                                throw HttpReturnException(400, "select expression must return atomic values in import.text procedure");
 	                    valuesOut[i] = std::move(std::get<1>(rItem).stealAtom());
-                        if (outputColumnNames)
-                            namesOut[i] =  std::move(std::get<0>(rItem));
+                            if (outputColumnNamesUnknown)
+                                namesOut[i] =  std::move(std::get<0>(rItem));
 	                }
 	                    
 	            }
 	            else {
 	                // Need to copy things
 	                for (unsigned i = 0;  i < selectRow.size();  ++i) {
-                        auto& rItem = selectRow[i];
-                        if (!std::get<1>(rItem).isAtom())
-                            throw HttpReturnException(400, "select expression must return atomic values in import.text procedure");
+                            auto& rItem = selectRow[i];
+                            if (!std::get<1>(rItem).isAtom())
+                                throw HttpReturnException(400, "select expression must return atomic values in import.text procedure");
 
 	                    valuesOut[i] = std::get<1>(rItem).getAtom();
-                        if (outputColumnNames)
-                            namesOut[i] =  std::move(std::get<0>(rItem));
-                    }
+                            if (outputColumnNamesUnknown)
+                                namesOut[i] =  std::move(std::get<0>(rItem));
+                        }
 	            }
 	                
 	            processLine(chunkNum, actualLineNum, std::move(rowName), rowTs, &valuesOut[0], namesOut.data(), selectRow.size());
@@ -1140,14 +1141,14 @@ struct ImportTextProcedureWorkInstance
 	        //threadAccum.emplace_back(std::move(lineEntry));
 	    };
 
-	    forEachLineBlock(stream, onLine, config.limit,
-                             32 /* parallelism */);
+        forEachLineBlock(stream, onLine, config.limit,
+                         32 /* parallelism */);
 
-	    //cerr << timer.elapsed() << endl;
-	    timer.restart();	   
+        //cerr << timer.elapsed() << endl;
+        timer.restart();	   
 
-	    numLineErrors = numSkipped;
-	}
+        numLineErrors = numSkipped;
+    }
 };
 
 
@@ -1157,8 +1158,8 @@ struct ImportTextProcedureWorkInstance
 
 ImportTextProcedure::
 ImportTextProcedure(MldbServer * owner,
-               PolyConfig config,
-               const std::function<bool (const Json::Value &)> & onProgress)
+                    PolyConfig config,
+                    const std::function<bool (const Json::Value &)> & onProgress)
     : Procedure(owner)
 {
     this->config = config.params.convert<ImportTextConfig>();
@@ -1181,8 +1182,8 @@ run(const ProcedureRunConfig & run,
 
     auto onProgress2 = [&] (const Json::Value & progress) {
         Json::Value value;
-  	    value["dataset"] = progress;
-  	    return onProgress(value);
+        value["dataset"] = progress;
+        return onProgress(value);
     };
 
     std::shared_ptr<Dataset> dataset = createDataset(server, runProcConf.outputDataset, onProgress2, true /*overwrite*/);
@@ -1203,9 +1204,9 @@ run(const ProcedureRunConfig & run,
 namespace {
 
 RegisterProcedureType<ImportTextProcedure, ImportTextConfig>
-regEM(builtinPackage(), "import.text",
-          "Import from a text file, line by line.",
-          "procedures/importtextprocedure.md.html");
+regImportText(builtinPackage(), "import.text",
+      "Import from a text file, line by line.",
+      "procedures/importtextprocedure.md.html");
 
 } // file scope
 

--- a/plugins/sparse_matrix_dataset.cc
+++ b/plugins/sparse_matrix_dataset.cc
@@ -15,17 +15,48 @@
 #include "mldb/sql/sql_expression.h"
 #include "mldb/http/http_exception.h"
 #include "mldb/types/any_impl.h"
-#include "mldb/arch/rcu_protected.h"
 #include "mldb/arch/timers.h"
 #include "mldb/base/parallel.h"
 #include "mldb/base/thread_pool.h"
-
+#include "mldb/arch/spinlock.h"
+#include <mutex>
 
 using namespace std;
 
 
 namespace Datacratic {
 namespace MLDB {
+
+// Note: in GCC 4.9+, we can use the std::atomic_xxx overloads for
+// std::shared_ptr.  Once the Concurrency TR is available, we can
+// replace with those classes.  For the moment we use a simple,
+// spinlock protected implementation that is a lowest common
+// denominator.
+template<typename T>
+struct atomic_shared_ptr {
+
+    template<typename... Args>
+    atomic_shared_ptr(Args&&... args)
+        : ptr(std::forward<Args>(args)...)
+    {
+    }
+    
+    std::shared_ptr<T> load() const
+    {
+        std::unique_lock<ML::Spinlock> guard(lock);
+        return ptr;
+    }
+
+    void store(std::shared_ptr<T> newVal)
+    {
+        std::unique_lock<ML::Spinlock> guard(lock);
+        ptr = std::move(newVal);
+    }
+
+private:
+    mutable ML::Spinlock lock;
+    std::shared_ptr<T> ptr;
+};
 
 
 DEFINE_STRUCTURE_DESCRIPTION(BaseEntry);
@@ -76,7 +107,7 @@ struct SparseMatrixDataset::Itl
     : public MatrixView, public ColumnIndex {
 
     Itl()
-        : epoch(0), defaultTransaction(gc), timeQuantumSeconds(1.0)
+        : epoch(0), timeQuantumSeconds(1.0)
     {
     }
 
@@ -90,12 +121,13 @@ struct SparseMatrixDataset::Itl
         this->inverse  = std::move(inverse);
         this->values = std::move(values);
 
-        auto defaultTransaction = std::make_shared<ReadTransaction>();
-        defaultTransaction->matrix = this->matrix->startReadTransaction();
-        defaultTransaction->inverse = this->inverse->startReadTransaction();
-        defaultTransaction->values = this->values->startReadTransaction();
+        auto newDefaultTransaction = std::make_shared<ReadTransaction>();
+        newDefaultTransaction->matrix = this->matrix->startReadTransaction();
+        newDefaultTransaction->inverse = this->inverse->startReadTransaction();
+        newDefaultTransaction->values = this->values->startReadTransaction();
+        newDefaultTransaction->epoch = this->epoch;
 
-        setDefaultTransaction(defaultTransaction);
+        setDefaultTransaction(newDefaultTransaction);
     }
     
     ~Itl()
@@ -167,10 +199,8 @@ struct SparseMatrixDataset::Itl
             return std::shared_ptr<SparseRowStream>();
     }
 
-    GcLock gc;
-
     /// Default transaction when none was passed
-    RcuProtected<std::shared_ptr<ReadTransaction> > defaultTransaction;
+    atomic_shared_ptr<ReadTransaction> defaultTransaction;
 
     /// Control the quantization of timestamp (default is quantize to second)
     double timeQuantumSeconds;
@@ -179,15 +209,25 @@ struct SparseMatrixDataset::Itl
     std::shared_ptr<ReadTransaction>
     getReadTransaction() const
     {
-        return *defaultTransaction();
+        std::shared_ptr<ReadTransaction> result = defaultTransaction.load();
+
+        // Assertion failures here mean problems with the MVCC mechanism
+        ExcAssert(result->matrix);
+        ExcAssert(result->inverse);
+        ExcAssert(result->values);
+
+        return result;
     }
 
     /// Update the current default read transaction after a commit
     void setDefaultTransaction(std::shared_ptr<ReadTransaction> trans)
     {
-        this->defaultTransaction
-            .replace(new std::shared_ptr<ReadTransaction>
-                     (std::move(trans)));
+        ExcAssert(trans);
+        ExcAssert(trans->matrix);
+        ExcAssert(trans->inverse);
+        ExcAssert(trans->values);
+        
+        defaultTransaction.store(std::move(trans));
     }
 
     /// Obtain a new write transaction based upon a current read transaction
@@ -205,31 +245,47 @@ struct SparseMatrixDataset::Itl
 
         ThreadPool tp;
 
-        auto doCommit = [&] (MatrixWriteTransaction & trans)
+        // Everything that takes a long time: add it to the thread
+        // pool to do in parallel
+        auto doCommitInThread = [&] (MatrixWriteTransaction & trans)
             {
                 if (trans.commitNeedsThread())
                     tp.add(std::bind(&MatrixWriteTransaction::commit,
                                      &trans));
             };
+
+        doCommitInThread(*trans.matrix);
+        doCommitInThread(*trans.inverse);
+        doCommitInThread(*trans.values);
+
+        // Everything that doesn't take a long time: do it now,
+        // in this thread
+        auto doCommitNow = [&] (MatrixWriteTransaction & trans)
+            {
+                if (!trans.commitNeedsThread())
+                    trans.commit();
+            };
         
-        doCommit(*trans.matrix);
-        doCommit(*trans.inverse);
-        doCommit(*trans.values);
+        doCommitNow(*trans.matrix);
+        doCommitNow(*trans.inverse);
+        doCommitNow(*trans.values);
         
+        // Wait for the thread pool work to finish
         tp.waitForAll();
 
         auto result = std::make_shared<ReadTransaction>();
         result->matrix = matrix->startReadTransaction();
         result->inverse = inverse->startReadTransaction();
         result->values = values->startReadTransaction();
+        result->epoch = epoch;
 
-        setDefaultTransaction(result);
+        setDefaultTransaction(std::move(result));
     }
 
     void optimize()
     {
         //cerr << "optimize() on MutableSparseMatrixDataset" << endl;
-        ML::Timer timer;
+        //ML::Timer timer;
 
         std::unique_lock<RootLock> guard(rootLock);
         // We don't increment the epoch since logically it's exactly the same
@@ -249,8 +305,9 @@ struct SparseMatrixDataset::Itl
         result->matrix = matrix->startReadTransaction();
         result->inverse = inverse->startReadTransaction();
         result->values = values->startReadTransaction();
+        result->epoch = epoch;
 
-        setDefaultTransaction(result);
+        setDefaultTransaction(std::move(result));
     }
 
     Date decodeTs(int64_t ts) const
@@ -716,8 +773,9 @@ struct SparseMatrixDataset::Itl
     recordRow(const RowName & rowName,
               const std::vector<std::tuple<ColumnName, CellValue, Date> > & vals)
     {
+        auto rtrans = getReadTransaction();
         std::shared_ptr<WriteTransaction> trans
-            = getWriteTransaction(**defaultTransaction());
+            = getWriteTransaction(*rtrans);
         recordRowTrans(rowName, vals, *trans);
         commitWrites(*trans);
     }
@@ -725,8 +783,9 @@ struct SparseMatrixDataset::Itl
     virtual void
     recordRows(const std::vector<std::pair<RowName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > & rows)
     {
+        auto rtrans = getReadTransaction();
         std::shared_ptr<WriteTransaction> trans
-            = getWriteTransaction(**defaultTransaction());
+            = getWriteTransaction(*rtrans);
         
         for (auto & r: rows) {
             recordRowTrans(r.first, r.second, *trans);
@@ -873,8 +932,8 @@ enum CommitMode {
 
 struct MutableBaseData {
 
-    MutableBaseData(GcLock & gc, CommitMode commitMode)
-        : repr(gc, new Repr()), commitMode(commitMode)
+    MutableBaseData(CommitMode commitMode)
+        : repr(new Repr()), commitMode(commitMode)
     {
     }
 
@@ -895,6 +954,13 @@ struct MutableBaseData {
         Rows(const Rows & other)
             : entries(other.entries),
               cachedRowCount(other.cachedRowCount.load())
+        {
+        }
+
+        Rows(std::vector<std::shared_ptr<const RowsEntry> > entries,
+             int64_t cachedRowCount)
+            : entries(std::move(entries)),
+              cachedRowCount(cachedRowCount)
         {
         }
 
@@ -1021,7 +1087,7 @@ struct MutableBaseData {
             nonReadableWrites.clear();
 
             result.entries.emplace_back(new RowsEntry(std::move(newEntries)));
-            return std::move(result);
+            return result;
         }
 
         struct Stream {       
@@ -1078,10 +1144,25 @@ struct MutableBaseData {
     };
 
     struct Repr {
+        Repr()
+        {
+        }
+    
+        Repr(Rows newRows)
+            : rows(std::move(newRows))
+        {
+        }
+        
+        Repr(std::vector<std::shared_ptr<const RowsEntry> > entries,
+             int64_t cachedRowCount)
+            : rows(std::move(entries), cachedRowCount)
+        {
+        }
+
         Rows rows;
     };
 
-    RcuProtected<std::shared_ptr<Repr> > repr;
+    atomic_shared_ptr<Repr> repr;
     CommitMode commitMode;
     std::vector<std::shared_ptr<RowsEntry> > nonReadableWrites;
 
@@ -1089,15 +1170,9 @@ struct MutableBaseData {
     void optimize()
     {
         std::unique_lock<std::mutex> guard(mutex);
-
-        auto newRows = (*repr.unsafePtr())->rows.optimize(nonReadableWrites);
-
-        std::unique_ptr<std::shared_ptr<Repr> > newRepr
-            (new std::shared_ptr<Repr>);
-        newRepr->reset(new Repr());
-        (**newRepr).rows = std::move(newRows);
-
-        repr.replace(newRepr.release());
+        auto newRows = repr.load()->rows.optimize(nonReadableWrites);
+        auto newRepr = std::make_shared<Repr>(std::move(newRows));
+        repr.store(std::move(newRepr));
     }
 
     /** Insert the given set of rows very quickly, but in a way that they
@@ -1117,23 +1192,18 @@ struct MutableBaseData {
     {
         std::unique_lock<std::mutex> guard(this->mutex);
 
-        auto r = this->repr();
-        const Rows & oldRows = (*r)->rows;
+        auto r = repr.load();
+        const Rows & oldRows = r->rows;
         
         std::vector<std::shared_ptr<const RowsEntry> >
             newRows = oldRows.entries;
         newRows.emplace_back(std::move(written));
 
-        std::unique_ptr<std::shared_ptr<Repr> > newRepr
-            (new std::shared_ptr<Repr>);
-        newRepr->reset(new Repr());
-
-        (**newRepr).rows.entries = std::move(newRows);
-        (**newRepr).rows.cachedRowCount = oldRows.cachedRowCount.load();
-
-        this->repr.replace(newRepr.release());
+        auto newRepr = std::make_shared<Repr>(std::move(newRows),
+                                              oldRows.cachedRowCount.load());
+        repr.store(std::move(newRepr));
     }
-
+    
     /** Insert the given set of rows in a manner that may have significant
         latency but will be fast to read back afterwards.
     */
@@ -1145,8 +1215,8 @@ struct MutableBaseData {
         ML::Timer timer;
 
         // Get a reference to the data
-        auto r = this->repr();
-        const Rows & oldRows = (*r)->rows;
+        auto r = this->repr.load();
+        const Rows & oldRows = r->rows;
         
         std::shared_ptr<RowsEntry> current = written;
 
@@ -1212,14 +1282,9 @@ struct MutableBaseData {
         //         << endl;
         //}
 
-        std::unique_ptr<std::shared_ptr<Repr> > newRepr
-            (new std::shared_ptr<Repr>);
-        newRepr->reset(new Repr());
-
-        (**newRepr).rows.entries = std::move(newRows);
-        (**newRepr).rows.cachedRowCount = oldRows.cachedRowCount.load();
-
-        this->repr.replace(newRepr.release());
+        auto newRepr = std::make_shared<Repr>(std::move(newRows),
+                                              oldRows.cachedRowCount.load());
+        repr.store(std::move(newRepr));
     }
 
     void insert(std::shared_ptr<RowsEntry> written)
@@ -1248,7 +1313,7 @@ struct MutableWriteTransaction: public MatrixWriteTransaction {
 
     MutableWriteTransaction(std::shared_ptr<MutableBaseData> data)
         : data(data),
-          view(*data->repr()),
+          view(data->repr.load()),
           rows(view->rows),
           written(new MutableBaseData::RowsEntry)
     {
@@ -1343,7 +1408,7 @@ struct MutableWriteTransaction: public MatrixWriteTransaction {
 
 struct MutableReadTransaction: public MatrixReadTransaction {
     MutableReadTransaction(std::shared_ptr<MutableBaseData> data)
-        : data(data), repr(*data->repr()), rows(repr->rows)
+        : data(data), repr(data->repr.load()), rows(repr->rows)
     {
     }
 
@@ -1415,8 +1480,8 @@ struct MutableReadTransaction: public MatrixReadTransaction {
 struct MutableBaseMatrix: public BaseMatrix {
     std::shared_ptr<MutableBaseData> data;
     
-    MutableBaseMatrix(GcLock & gc, CommitMode commitMode)
-        : data(new MutableBaseData(gc, commitMode))
+    MutableBaseMatrix(CommitMode commitMode)
+        : data(new MutableBaseData(commitMode))
     {
     }
 
@@ -1516,8 +1581,6 @@ MutableSparseMatrixDatasetConfigDescription()
 struct MutableSparseMatrixDataset::Itl
     : public SparseMatrixDataset::Itl {
 
-    GcLock gc;
-
     Itl(double timeQuantumSeconds,
         WriteTransactionLevel consistencyLevel,
         TransactionFavor favor) 
@@ -1530,10 +1593,10 @@ struct MutableSparseMatrixDataset::Itl
         else mode = WRITE_FAST;
 
         SparseMatrixDataset::Itl::timeQuantumSeconds = timeQuantumSeconds;
-        init(std::make_shared<MutableBaseMatrix>(gc, mode),
-             std::make_shared<MutableBaseMatrix>(gc, mode),
-             std::make_shared<MutableBaseMatrix>(gc, mode),
-             std::make_shared<MutableBaseMatrix>(gc, mode));
+        init(std::make_shared<MutableBaseMatrix>(mode),
+             std::make_shared<MutableBaseMatrix>(mode),
+             std::make_shared<MutableBaseMatrix>(mode),
+             std::make_shared<MutableBaseMatrix>(mode));
     }
 };
 

--- a/plugins/sparse_matrix_dataset.h
+++ b/plugins/sparse_matrix_dataset.h
@@ -1,7 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
-/** sparse_matrix.h                                                    -*- C++ -*-
+/** sparse_matrix.h                                                -*- C++ -*-
     SparseMatrix dataset for MLDB.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Each row holds a coordinate vector.
 */

--- a/sql/coord.cc
+++ b/sql/coord.cc
@@ -179,11 +179,45 @@ Coord
 Coord::
 operator + (const Coord & other) const
 {
-    if (empty())
-        return std::move(other);
-    if (other.empty())
+    size_t l1 = dataLength();
+    size_t l2 = other.dataLength();
+
+    if (l1 == 0)
+        return other;
+    if (l2 == 0)
         return *this;
-    return toUtf8String() + "." + other.toUtf8String();
+
+    size_t len = 1 + l1 + l2;
+
+    Coord result;
+
+    if (len <= 31) {
+        // We can construct in-place
+        result.complex_ = 0;
+        result.simpleLen_ = len;
+        auto d = data();
+        std::copy(d, d + l1, result.bytes + 1);
+        result.bytes[l1 + 1] = '.';
+        d = other.data();
+        std::copy(d, d + l2, result.bytes + l1 + 2);
+    }
+    else if (len < 4096) {
+        // Construct on the stack and do just one allocation
+        char str[4096];
+        result.complex_ = 1;
+        auto d = data();
+        std::copy(d, d + l1, str);
+        str[l1] = '.';
+        d = other.data();
+        std::copy(d, d + l2, str + l1 + 1);
+        new (&result.str.str) Utf8String(str, len);
+    }
+    else {
+        // It's long; just use the Utf8String
+        result = toUtf8String() + "." + other.toUtf8String();
+    }
+
+    return result;
 }
 
 Coord
@@ -192,9 +226,7 @@ operator + (Coord && other) const
 {
     if (empty())
         return std::move(other);
-    if (other.empty())
-        return *this;
-    return toUtf8String() + "." + other.toUtf8String();
+    return operator + ((const Coord &)other);
 }
 
 Coord::

--- a/testing/MLDB-1360-sparse-mutable-multithreaded-insert.cc
+++ b/testing/MLDB-1360-sparse-mutable-multithreaded-insert.cc
@@ -1,0 +1,98 @@
+/* MLDB-1360-sparse-mutable-multithreaded-insert.cc
+   Jeremy Barnes, 20 March 2015
+   Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+
+*/
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/algorithm/string.hpp>
+#include <boost/test/unit_test.hpp>
+#include "mldb/plugins/sparse_matrix_dataset.h"
+#include "mldb/server/mldb_server.h"
+#include "mldb/arch/timers.h"
+
+using namespace std;
+using namespace Datacratic;
+using namespace Datacratic::MLDB;
+
+void testMtInsert(MutableSparseMatrixDatasetConfig config)
+{
+    MldbServer server;
+    
+    server.init();
+
+    PolyConfig pconfig;
+    pconfig.params = config;
+    MutableSparseMatrixDataset dataset(&server, pconfig, nullptr);
+
+    std::atomic<size_t> done(0);
+
+    constexpr int niter = 2000;
+    constexpr int nthreads = 16;
+
+    Date start = Date::now();
+
+    auto insertThread = [&] ()
+        {
+            int base = random();
+            for (unsigned i = 0;  i < niter;  ++i) {
+                std::vector<std::tuple<ColumnName, CellValue, Date> > vals;
+                dataset.recordRow(base + i, vals);
+
+                if (done.fetch_add(1) % 1000 == 0)
+                    cerr << "done " << done << " insertions" << endl;
+
+                if (i % 10 == 0 && Date::now().secondsSince(start) > 5)
+                    break;
+            }
+        };
+
+    cerr << "testing " << jsonEncode(config) << endl;
+
+    ML::Timer timer;
+
+    std::vector<std::thread> threads;
+    for (unsigned i = 0;  i < nthreads;  ++i)
+        threads.emplace_back(insertThread);
+
+    for (auto & t: threads)
+        t.join();
+
+    cerr << "did " << done << " commits in " << timer.elapsed()
+         << " at " << done / timer.elapsed_wall() << " commits/second"
+         << endl;
+}
+
+BOOST_AUTO_TEST_CASE( test_multithreaded_insert_rr )
+{
+    MutableSparseMatrixDatasetConfig config;
+    config.consistencyLevel = WT_READ_AFTER_WRITE;
+    config.favor = TF_FAVOR_READS;
+    testMtInsert(config);
+}
+
+BOOST_AUTO_TEST_CASE( test_multithreaded_insert_rw )
+{
+    MutableSparseMatrixDatasetConfig config;
+    config.consistencyLevel = WT_READ_AFTER_WRITE;
+    config.favor = TF_FAVOR_WRITES;
+    testMtInsert(config);
+}
+
+BOOST_AUTO_TEST_CASE( test_multithreaded_insert_wr )
+{
+    MutableSparseMatrixDatasetConfig config;
+    config.consistencyLevel = WT_READ_AFTER_COMMIT;
+    config.favor = TF_FAVOR_READS;
+    testMtInsert(config);
+}
+
+BOOST_AUTO_TEST_CASE( test_multithreaded_insert_ww )
+{
+    MutableSparseMatrixDatasetConfig config;
+    config.consistencyLevel = WT_READ_AFTER_COMMIT;
+    config.favor = TF_FAVOR_WRITES;
+    testMtInsert(config);
+}

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -337,3 +337,6 @@ $(eval $(call mldb_unit_test,MLDB-1491-get-all-not-implemented-for-datasets.js,,
 # Tensorflow plugins
 $(eval $(call include_sub_make,MLDB-1398-plugin))
 $(eval $(call mldb_unit_test,MLDB-1398-plugin-library-dependency.js,MLDB-1398-plugin))
+
+$(eval $(call test,MLDB-1360-sparse-mutable-multithreaded-insert,mldb,boost))
+


### PR DESCRIPTION
This adds a test-case and fixes the multithreading issues for the sparse mutable dataset.

It also removes mutexes in the import procedures, and fixes a few other small-ish bottlenecks.  As part of doing that, the indentation of the import text producedure was fixed.

Effect is that bid request importation goes from 2,000 bid requests per second to 20,000.