### PR TITLE
Mldb 1384 where in outer join

### DIFF
--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -723,22 +723,32 @@ executeFilteredColumnExpression(const Dataset & dataset,
                                 const ColumnName & columnName,
                                 const Filter & filter)
 {
-    auto col = (*dataset.getColumnIndex()).getColumnValues(columnName, filter);
+    auto columnIndex = dataset.getColumnIndex();
+
+    if (columnIndex->knownColumn(columnName))
+    {
+        auto col = (*dataset.getColumnIndex()).getColumnValues(columnName, filter);
     
-    std::vector<RowName> rows;
+        std::vector<RowName> rows;
 
-    auto matrix = dataset.getMatrixView();
+        auto matrix = dataset.getMatrixView();
 
-    for (auto & r: col) {
-        RowName & rh = std::get<0>(r);
-        rows.emplace_back(std::move(rh));
+        for (auto & r: col) {
+            RowName & rh = std::get<0>(r);
+            rows.emplace_back(std::move(rh));
+        }
+
+        std::sort(rows.begin(), rows.end(), SortByRowHash());
+        rows.erase(std::unique(rows.begin(), rows.end()),
+                   rows.end());
+
+        return std::pair<std::vector<RowName>, Any>(std::move(rows), std::move(Any()));
+    }
+    else
+    {
+        return {};
     }
     
-    std::sort(rows.begin(), rows.end(), SortByRowHash());
-    rows.erase(std::unique(rows.begin(), rows.end()),
-               rows.end());
- 
-    return std::pair<std::vector<RowName>, Any>(std::move(rows), std::move(Any()));
 }
 
 template<typename Filter>

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -725,8 +725,7 @@ executeFilteredColumnExpression(const Dataset & dataset,
 {
     auto columnIndex = dataset.getColumnIndex();
 
-    if (columnIndex->knownColumn(columnName))
-    {
+    if (columnIndex->knownColumn(columnName)) {
         auto col = (*dataset.getColumnIndex()).getColumnValues(columnName, filter);
     
         std::vector<RowName> rows;
@@ -744,8 +743,7 @@ executeFilteredColumnExpression(const Dataset & dataset,
 
         return std::pair<std::vector<RowName>, Any>(std::move(rows), std::move(Any()));
     }
-    else
-    {
+    else {
         return {};
     }
     

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -157,6 +157,7 @@ struct ColumnIndex {
     getColumnStats(const ColumnName & column, ColumnStats & toStoreResult) const;
 
     /** Return the value of the column for all rows and timestamps. */
+    /** Will throw if column is unknown                              */
     virtual MatrixColumn getColumn(const ColumnName & column) const = 0;
 
     /** Return a dense column, with one value for every row in the same order as
@@ -179,7 +180,10 @@ struct ColumnIndex {
     getColumnBuckets(const ColumnName & column,
                      int maxNumBuckets = -1) const;
 
-    /** Return the value of the column for all rows, ignoring timestamps. */
+    /** Return the value of the column for all rows, ignoring timestamps. 
+        Default implementation is based on getColumn
+        Will throw if column is unknown
+    */
     virtual std::vector<std::tuple<RowName, CellValue> >
     getColumnValues(const ColumnName & column,
                     const std::function<bool (const CellValue &)> & filter = nullptr) const;

--- a/testing/MLDB-180-basic-join.js
+++ b/testing/MLDB-180-basic-join.js
@@ -455,4 +455,11 @@ expected = [
 testQuery('SELECT * FROM test3 OUTER JOIN test4 ON test3.rowName() = test4.rowName() OUTER JOIN test5 on test3.rowName() = test5.rowName() OUTER JOIN test6 on test3.rowName() = test6.rowName()',
           expected);
 
+//MLDB-1384
+//asking for unknow column in the WHERE should not throw.
+expected = [[ "_rowName" ]];
+
+testQuery('SELECT 1 FROM (SELECT 2) as a OUTER JOIN (SELECT 2) as b WHERE x',
+          expected);
+
 "success"


### PR DESCRIPTION
…tcolumn.

getcolumn, getcolumnvalues and the like all assume an existing column and will throw if it doesnt exist, so if the column is user-provided, we need to check that its a valid column so that we can return 0 rows instead of a 404/500 http.