### PR TITLE
MLDB-1508 json import improvements

### DIFF
--- a/sql/cell_value.cc
+++ b/sql/cell_value.cc
@@ -1053,6 +1053,115 @@ CellValue::printInterval() const
 
 }
 
+void
+CellValue::
+extractStructuredJson(JsonPrintingContext & context) const
+{
+    switch (cellType()) {
+    case CellValue::EMPTY:
+        context.writeNull();
+        return;
+    case CellValue::INTEGER:
+        if (isInt64())
+            context.writeLong(toInt());
+        else
+            context.writeUnsignedLongLong(toUInt());
+        return;
+    case CellValue::FLOAT:
+        {
+            double floatVal = toDouble();
+            if (std::isnan(floatVal))
+                {
+                    Json::Value v;
+                    v["num"] = std::signbit(floatVal) ? "-NaN" : "NaN";
+                    context.writeJson(v);
+                }
+            else if (std::isinf(floatVal))
+                {
+                    Json::Value v;
+                    v["num"] = std::signbit(floatVal) ? "-Inf" : "Inf";
+                    context.writeJson(v);
+                }
+            else
+                {
+                    context.writeDouble(toDouble());
+                }
+                
+            return;
+        }           
+    case CellValue::UTF8_STRING:
+    case CellValue::ASCII_STRING:
+        switch (type) {
+        case ST_UTF8_SHORT_STRING:
+            context.writeStringUtf8((const char *)shortString, (size_t)strLength);
+            return;
+        case ST_ASCII_SHORT_STRING:
+            context.writeString((const char *)shortString, (size_t)strLength);
+            return;
+        case ST_UTF8_LONG_STRING:
+            context.writeStringUtf8(longString->repr, (size_t)strLength);
+            return;
+        case ST_ASCII_LONG_STRING:
+            context.writeString(longString->repr, (size_t)strLength);
+            return;
+        default:
+            throw HttpReturnException(400, "unknown string cell type");
+            return;
+        }
+    case CellValue::TIMESTAMP: {
+        context.startObject();
+        context.startMember("ts");
+        context.writeString(toString());
+        context.endObject();
+        return;    
+    }
+    case CellValue::TIMEINTERVAL: {
+        context.startObject();
+        context.startMember("interval");
+        context.writeString(toString());
+        context.endObject();
+        return;         
+    }
+    case CellValue::BLOB: {
+        context.startObject();
+        context.startMember("blob");
+        context.startArray();
+            
+        // Chunks of ASCII are written as a string; non-ASCII is
+        // as integers.
+        const unsigned char * p = blobData();
+        const unsigned char * e = p + blobLength();
+
+        while (p < e) {
+            const unsigned char * s = p;
+            while (p < e && *p >= ' ' && *p < 127 && isascii(*p))
+                ++p;
+            size_t len = p - s;
+            //cerr << "len = " << len << endl;
+            if (len == 1) {
+                context.newArrayElement();
+                context.writeInt(*s);
+            }
+            else if (len >= 2) {
+                context.newArrayElement();
+                context.writeString((const char *)s, len);
+            }
+                
+            while (p < e && (*p <= ' ' || *p >= 127 || !isascii(*p))) {
+                context.newArrayElement();
+                context.writeInt(*p++);
+            }
+        }
+        context.endArray();
+        context.endObject();
+        return;
+    }
+    default:
+        throw HttpReturnException(400, "unknown cell type");
+        return;
+    }
+}
+
 struct CellValueDescription: public ValueDescriptionT<CellValue> {
     virtual void parseJsonTyped(CellValue * val,
                                 JsonParsingContext & context) const
@@ -1150,95 +1259,7 @@ struct CellValueDescription: public ValueDescriptionT<CellValue> {
     virtual void printJsonTyped(const CellValue * val,
                                 JsonPrintingContext & context) const
     {
-
-        switch (val->cellType()) {
-        case CellValue::EMPTY:
-            context.writeNull();
-            return;
-        case CellValue::INTEGER:
-            if (val->isInt64())
-                context.writeLong(val->toInt());
-            else
-                context.writeUnsignedLongLong(val->toUInt());
-            return;
-        case CellValue::FLOAT:
-            {
-                double floatVal = val->toDouble();
-                if (std::isnan(floatVal))
-                {
-                    Json::Value v;
-                    v["num"] = std::signbit(floatVal) ? "-NaN" : "NaN";
-                    context.writeJson(v);
-                }
-                else if (std::isinf(floatVal))
-                {
-                    Json::Value v;
-                    v["num"] = std::signbit(floatVal) ? "-Inf" : "Inf";
-                    context.writeJson(v);
-                }
-                else
-                {
-                    context.writeDouble(val->toDouble());
-                }
-                
-                return;
-            }           
-        case CellValue::UTF8_STRING:
-            context.writeStringUtf8(val->toUtf8String());
-            return;
-        case CellValue::ASCII_STRING:
-            context.writeString(val->toString());
-            return;
-        case CellValue::TIMESTAMP: {
-            Json::Value v;
-            v["ts"] = val->toString();
-            context.writeJson(v);
-            return;    
-        }
-        case CellValue::TIMEINTERVAL: {
-            Json::Value v2;
-            v2["interval"] = val->toString();
-            context.writeJson(v2);
-            return;         
-        }
-        case CellValue::BLOB: {
-            context.startObject();
-            context.startMember("blob");
-            context.startArray();
-            
-            // Chunks of ASCII are written as a string; non-ASCII is
-            // as integers.
-            const unsigned char * p = val->blobData();
-            const unsigned char * e = p + val->blobLength();
-
-            while (p < e) {
-                const unsigned char * s = p;
-                while (p < e && *p >= ' ' && *p < 127 && isascii(*p))
-                    ++p;
-                size_t len = p - s;
-                //cerr << "len = " << len << endl;
-                if (len == 1) {
-                    context.newArrayElement();
-                    context.writeInt(*s);
-                }
-                else if (len >= 2) {
-                    context.newArrayElement();
-                    context.writeString(string(s, p));
-                }
-                
-                while (p < e && (*p <= ' ' || *p >= 127 || !isascii(*p))) {
-                    context.newArrayElement();
-                    context.writeInt(*p++);
-                }
-            }
-            context.endArray();
-            context.endObject();
-            return;
-        }
-        default:
-            throw HttpReturnException(400, "unknown cell type");
-            return;
-        }
+        val->extractStructuredJson(context);
     }
 
     virtual bool isDefaultTyped(const CellValue * val) const

--- a/sql/cell_value.cc
+++ b/sql/cell_value.cc
@@ -12,6 +12,7 @@
 #include "mldb/http/http_exception.h"
 #include "mldb/types/structure_description.h"
 #include "mldb/types/enum_description.h"
+#include "mldb/types/itoa.h"
 #include "cell_value_impl.h"
 #include "mldb/base/parse_context.h"
 #include "interval.h"
@@ -304,45 +305,6 @@ toWideString() const
     }
 }
 
-static std::string
-u64toa(uint64_t i)
-{
-    // NOTE: std::to_string is SLOOOOW in GCC 4.8
-    char buf[64]; // longer than any 64 bit integer
-    char * p = buf + 63;
-    while (0ULL != i || p == buf + 63) {
-        *p-- = '0' + (i % 10);
-        i /= 10;
-    }
-
-    return string(p + 1, buf + 64);
-}
-
-static std::string
-i64toa(int64_t i)
-{
-    // NOTE: std::to_string is SLOOOOW in GCC 4.8
-    char buf[64]; // longer than any 64 bit integer
-    char * p = buf + 63;
-    bool neg = false;
-    if (i < 0) {
-        if (i == std::numeric_limits<int64_t>::min()) {
-            // Can't represent; special case this one
-            return std::to_string(i);
-        }
-        neg = true;
-        i = -i;
-    }
-    while (0 != i || p == buf + 63) {
-        *p-- = '0' + (i % 10);
-        i /= 10;
-    }
-    if (neg)
-        *p-- = '-';
-
-    return string(p + 1, buf + 64);
-}
-
 std::string
 CellValue::
 toString() const
@@ -351,9 +313,9 @@ toString() const
     case ST_EMPTY:
         return "";
     case ST_INTEGER:
-        return i64toa(intVal);
+        return Datacratic::itoa(intVal);
     case ST_UNSIGNED:
-        return u64toa(uintVal);
+        return Datacratic::itoa(uintVal);
     case ST_FLOAT: {
         return Datacratic::dtoa(floatVal);
     }

--- a/sql/cell_value.cc
+++ b/sql/cell_value.cc
@@ -304,6 +304,45 @@ toWideString() const
     }
 }
 
+static std::string
+u64toa(uint64_t i)
+{
+    // NOTE: std::to_string is SLOOOOW in GCC 4.8
+    char buf[64]; // longer than any 64 bit integer
+    char * p = buf + 63;
+    while (0ULL != i || p == buf + 63) {
+        *p-- = '0' + (i % 10);
+        i /= 10;
+    }
+
+    return string(p + 1, buf + 64);
+}
+
+static std::string
+i64toa(int64_t i)
+{
+    // NOTE: std::to_string is SLOOOOW in GCC 4.8
+    char buf[64]; // longer than any 64 bit integer
+    char * p = buf + 63;
+    bool neg = false;
+    if (i < 0) {
+        if (i == std::numeric_limits<int64_t>::min()) {
+            // Can't represent; special case this one
+            return std::to_string(i);
+        }
+        neg = true;
+        i = -i;
+    }
+    while (0 != i || p == buf + 63) {
+        *p-- = '0' + (i % 10);
+        i /= 10;
+    }
+    if (neg)
+        *p-- = '-';
+
+    return string(p + 1, buf + 64);
+}
+
 std::string
 CellValue::
 toString() const
@@ -312,12 +351,11 @@ toString() const
     case ST_EMPTY:
         return "";
     case ST_INTEGER:
-        return std::to_string(intVal);
+        return i64toa(intVal);
     case ST_UNSIGNED:
-        return std::to_string(uintVal);
+        return u64toa(uintVal);
     case ST_FLOAT: {
         return Datacratic::dtoa(floatVal);
-        //return std::to_string(floatVal);
     }
     case ST_ASCII_SHORT_STRING:
         return string(shortString, shortString + strLength);

--- a/sql/cell_value.h
+++ b/sql/cell_value.h
@@ -13,6 +13,9 @@
 
 
 namespace Datacratic {
+
+struct JsonPrintingContext;
+
 namespace MLDB {
 
 
@@ -320,6 +323,22 @@ struct CellValue {
     {
         return !operator < (other);
     }
+
+    /** Print the value to the given JSON context.  This allows for
+        JSON to be extracted without going through a Json::Value
+        object.  This version provides full fidelity in type conversion,
+        but the JSON returned is less natural.
+    */
+    void extractStructuredJson(JsonPrintingContext & context) const;
+
+    /** Print the value to the given JSON context.  This allows for
+        JSON to be extracted without going through a Json::Value
+        object.  This version provides a simplified JSON representation,
+        for example converting timestamps into strings, and as a result
+        will lose fidelity in the output for things that don't have a
+        natural JSON representation.
+    */
+    void extractSimplifiedJson(JsonPrintingContext & context) const;
 
 private:
     double toDoubleImpl() const;

--- a/sql/coord.cc
+++ b/sql/coord.cc
@@ -52,7 +52,15 @@ Coord(const char * str, size_t len)
 Coord::
 Coord(uint64_t i)
 {
-    initString(std::to_string(i));
+    // NOTE: std::to_string is SLOOOOW in GCC 4.8
+    char buf[64]; // longer than any 64 bit integer
+    char * p = buf + 63;
+    char * e = buf + 64;
+    while (0 != i || p == buf + 63) {
+        *p-- = '0' + (i % 10);
+        i /= 10;
+    }
+    initChars(p + 1, e - p - 1);
 }
 
 bool

--- a/sql/coord.cc
+++ b/sql/coord.cc
@@ -166,6 +166,20 @@ toString() const
     return toUtf8String().stealRawString();
 }
 
+bool
+Coord::
+hasStringView() const
+{
+    return true;  // currently we store as a string, so always true
+}
+
+std::pair<const char *, size_t>
+Coord::
+getStringView() const
+{
+    return { data(), dataLength() };
+}
+
 //constexpr HashSeed defaultSeedStable { .i64 = { 0x1958DF94340e7cbaULL, 0x8928Fc8B84a0ULL } };
 
 uint64_t

--- a/sql/coord.cc
+++ b/sql/coord.cc
@@ -11,6 +11,7 @@
 #include "mldb/types/value_description.h"
 #include "mldb/http/http_exception.h"
 #include "mldb/ext/siphash/csiphash.h"
+#include "mldb/types/itoa.h"
 #include "mldb/utils/json_utils.h"
 
 
@@ -52,15 +53,11 @@ Coord(const char * str, size_t len)
 Coord::
 Coord(uint64_t i)
 {
-    // NOTE: std::to_string is SLOOOOW in GCC 4.8
-    char buf[64]; // longer than any 64 bit integer
-    char * p = buf + 63;
-    char * e = buf + 64;
-    while (0 != i || p == buf + 63) {
-        *p-- = '0' + (i % 10);
-        i /= 10;
-    }
-    initChars(p + 1, e - p - 1);
+    ItoaBuf buf;
+    char * begin;
+    char * end;
+    std::tie(begin, end) = itoa(i, buf);
+    initChars(begin, end - begin);
 }
 
 bool

--- a/sql/coord.h
+++ b/sql/coord.h
@@ -116,6 +116,19 @@ struct Coord {
     Utf8String toUtf8String() const;
     std::string toString() const;  // TODO: will disappear
 
+    /** If true, we can return a const char * and length that will
+        live as long as this CellValue and can be used instead of
+        creating a new string when printing.
+    */
+    bool hasStringView() const;
+
+    /** Return a memory range that is a UTF-8 encoded version of
+        this object's string representation.  Should throw if
+        hasStringView() is false.
+    */
+    std::pair<const char *, size_t>
+    getStringView() const;
+
     uint64_t hash() const;
 
     bool empty() const;

--- a/testing/cell_value_test.cc
+++ b/testing/cell_value_test.cc
@@ -195,3 +195,19 @@ BOOST_AUTO_TEST_CASE(test_blob)
     BOOST_CHECK_EQUAL(jsonEncodeStr(jsonDecodeStr<CellValue>(jsonEncodeStr(blob))),
                       jsonEncodeStr(blob));
 }
+
+BOOST_AUTO_TEST_CASE (test_int_to_string)
+{
+    BOOST_CHECK_EQUAL(CellValue(0).toString(), "0");
+    BOOST_CHECK_EQUAL(CellValue(1).toString(), "1");
+    BOOST_CHECK_EQUAL(CellValue(10).toString(), "10");
+    BOOST_CHECK_EQUAL(CellValue(1000).toString(), "1000");
+    BOOST_CHECK_EQUAL(CellValue(-1).toString(), "-1");
+    BOOST_CHECK_EQUAL(CellValue(-10).toString(), "-10");
+    BOOST_CHECK_EQUAL(CellValue(std::numeric_limits<int64_t>::max()).toString(),
+                      std::to_string(std::numeric_limits<int64_t>::max()));
+    BOOST_CHECK_EQUAL(CellValue(std::numeric_limits<uint64_t>::max()).toString(),
+                      std::to_string(std::numeric_limits<uint64_t>::max()));
+    BOOST_CHECK_EQUAL(CellValue(std::numeric_limits<int64_t>::min()).toString(),
+                      std::to_string(std::numeric_limits<int64_t>::min()));
+}

--- a/types/itoa.h
+++ b/types/itoa.h
@@ -1,0 +1,84 @@
+/** itoa.h                                                         -*- C++ -*-
+    Jeremy Barnes, 23 March 2015
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+    Fast integer printing functions, since std::to_string(integral) uses
+    sprintf and is sloooooow in GCC 4.8.
+*/
+
+#pragma once
+
+#include <utility>
+#include <type_traits>
+#include <limits>
+#include <string>
+#include <iostream>
+
+namespace Datacratic {
+
+constexpr int ITOA_BUF_LENGTH = 64;  // long enough for any integral type
+
+// Buffer type for ITOA
+typedef char (ItoaBuf) [ITOA_BUF_LENGTH];
+
+/** Convert the given integer to a string representation, in the given
+    statically allocated buffer.  Returns the start and length of the
+    returned string; note that buf will be filled from the end, so it
+    cannot be used.
+*/
+template<typename T>
+std::pair<char *, char *>
+itoa(T i, ItoaBuf buf,
+     typename std::enable_if<std::is_unsigned<T>::value>::type * = 0)
+{
+    char * p = buf + ITOA_BUF_LENGTH;
+    do {
+        *(--p) = '0' + (i % 10);
+        i /= 10;
+    } while (i);
+
+    return { p, buf + ITOA_BUF_LENGTH };
+}
+
+template<typename T>
+std::pair<char *, char *>
+itoa(T i, ItoaBuf buf,
+     typename std::enable_if<std::is_signed<T>::value>::type * = 0)
+{
+    using namespace std;
+
+    bool neg = false;
+    if (i < 0) {
+        if (i == std::numeric_limits<T>::min()) {
+            // Can't represent; special case this one
+            std::string s = std::to_string(i);
+            std::copy(s.begin(), s.end(), buf);
+            return { buf, buf + s.length() };
+        }
+        neg = true;
+        i = -i;
+    }
+
+    char * p = buf + ITOA_BUF_LENGTH;
+    do {
+        *(--p) = '0' + (i % 10);
+        i /= 10;
+    } while (i);
+
+    if (neg)
+        *(--p) = '-';
+
+    return { p, buf + ITOA_BUF_LENGTH };
+}
+
+template<typename T>
+std::string itoa(T i)
+{
+    ItoaBuf buf;
+    char * begin;
+    char * end;
+    std::tie(begin, end) = itoa(i, buf);
+    return std::string(begin, end);
+}
+
+} // namespace Datacratic

--- a/types/json_printing.h
+++ b/types/json_printing.h
@@ -40,6 +40,7 @@ struct JsonPrintingContext {
 
     virtual void startObject() = 0;
     virtual void startMember(const Utf8String & memberName) = 0;
+    virtual void startMember(const char * memberNameStr, size_t memberNameLen) = 0;
     virtual void endObject() = 0;
 
     virtual void startArray(int knownSize = -1) = 0;
@@ -55,7 +56,9 @@ struct JsonPrintingContext {
     virtual void writeFloat(float f) = 0;
     virtual void writeDouble(double d) = 0;
     virtual void writeString(const std::string & s) = 0;
+    virtual void writeString(const char * start, size_t len) = 0;
     virtual void writeStringUtf8(const Utf8String & s) = 0;
+    virtual void writeStringUtf8(const char * start, size_t len) = 0;
     virtual void writeBool(bool b) = 0;
     virtual void writeNull() = 0;
 
@@ -92,6 +95,7 @@ struct StreamJsonPrintingContext
     virtual void startObject();
 
     virtual void startMember(const Utf8String & memberName);
+    virtual void startMember(const char * memberNameStr, size_t memberNameLen);
 
     virtual void endObject();
 
@@ -122,8 +126,10 @@ struct StreamJsonPrintingContext
     virtual void writeDouble(double d);
 
     virtual void writeString(const std::string & s);
+    virtual void writeString(const char * start, size_t len);
 
     virtual void writeStringUtf8(const Utf8String & s);
+    virtual void writeStringUtf8(const char * start, size_t len);
 
     virtual void writeJson(const Json::Value & val);
 
@@ -161,6 +167,7 @@ struct StringJsonPrintingContext
     virtual void startObject();
 
     virtual void startMember(const Utf8String & memberName);
+    virtual void startMember(const char * memberNameStr, size_t memberNameLen);
 
     virtual void endObject();
 
@@ -191,8 +198,10 @@ struct StringJsonPrintingContext
     virtual void writeDouble(double d);
 
     virtual void writeString(const std::string & s);
+    virtual void writeString(const char * start, size_t len);
 
     virtual void writeStringUtf8(const Utf8String & s);
+    virtual void writeStringUtf8(const char * start, size_t len);
 
     virtual void writeJson(const Json::Value & val);
 
@@ -226,6 +235,7 @@ struct StructuredJsonPrintingContext
     virtual void startObject();
 
     virtual void startMember(const Utf8String & memberName);
+    virtual void startMember(const char * memberNameStr, size_t memberNameLen);
 
     virtual void endObject();
 
@@ -256,8 +266,10 @@ struct StructuredJsonPrintingContext
     virtual void writeDouble(double d);
 
     virtual void writeString(const std::string & s);
+    virtual void writeString(const char * start, size_t len);
 
     virtual void writeStringUtf8(const Utf8String & s);
+    virtual void writeStringUtf8(const char * start, size_t len);
 
     virtual void writeJson(const Json::Value & val);
 


### PR DESCRIPTION
This removes many of the bottlenecks and inefficiencies in JSON importing.  It moves the speed up from parsing around 16,000 complex records per second to around 23,000.