### PR TITLE
Row names

### DIFF
--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -648,7 +648,7 @@ struct JoinedDataset::Itl
         auto it = columnIndex.find(columnName);
 
         if (it == columnIndex.end())
-            throw HttpReturnException(400, "Joined dataset did not find column ",
+            throw HttpReturnException(500, "Joined dataset did not find column ",
                                       "columnName", columnName);
         
         auto doGetColumn = [&] (const Dataset & dataset,

--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -648,7 +648,7 @@ struct JoinedDataset::Itl
         auto it = columnIndex.find(columnName);
 
         if (it == columnIndex.end())
-            throw HttpReturnException(500, "Joined dataset did not find column with given hash",
+            throw HttpReturnException(400, "Joined dataset did not find column ",
                                       "columnName", columnName);
         
         auto doGetColumn = [&] (const Dataset & dataset,

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -674,7 +674,21 @@ queryStructured(const SelectExpression & select,
                                const std::vector<ExpressionValue> & calc)
             {
                 MatrixNamedRow row = row_.flattenDestructive();
-                row.rowName = RowName(calc.at(0).toUtf8String());
+
+                const ExpressionValue& rowNameEV = calc.at(0);
+
+                if (rowNameEV.empty())
+                    throw HttpReturnException(400, "Can't create a row with a null or empty name.");
+
+                if (!rowNameEV.isAtom())
+                    throw HttpReturnException(400, "NAMED expression must evaluate to a single value");
+
+                Utf8String rowName = rowNameEV.toUtf8String();
+
+                if (rowName.empty())
+                    throw HttpReturnException(400, "Can't create a row with an empty name.");
+
+                row.rowName = RowName(rowName);
                 row.rowHash = row.rowName;
                 std::unique_lock<std::mutex> guard(lock);
                 output.emplace_back(std::move(row));

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -674,21 +674,7 @@ queryStructured(const SelectExpression & select,
                                const std::vector<ExpressionValue> & calc)
             {
                 MatrixNamedRow row = row_.flattenDestructive();
-
-                const ExpressionValue& rowNameEV = calc.at(0);
-
-                if (rowNameEV.empty())
-                    throw HttpReturnException(400, "Can't create a row with a null or empty name.");
-
-                if (!rowNameEV.isAtom())
-                    throw HttpReturnException(400, "NAMED expression must evaluate to a single value");
-
-                Utf8String rowName = rowNameEV.toUtf8String();
-
-                if (rowName.empty())
-                    throw HttpReturnException(400, "Can't create a row with an empty name.");
-
-                row.rowName = RowName(rowName);
+                row.rowName = GetValidatedRowName(calc.at(0));
                 row.rowHash = row.rowName;
                 std::unique_lock<std::mutex> guard(lock);
                 output.emplace_back(std::move(row));

--- a/server/analytics.cc
+++ b/server/analytics.cc
@@ -324,7 +324,9 @@ queryWithoutDataset(SelectStatement& stm, SqlBindingScope& scope)
     SqlRowScope context;
     ExpressionValue val = boundSelect(context, GET_ALL);
     MatrixNamedRow row;
-    row.rowName = RowName("result"); //todo: allow NAMED
+    auto boundRowName = stm.rowName->bind(scope);
+
+    row.rowName = GetValidatedRowName(boundRowName(context, GET_ALL));
     row.rowHash = row.rowName;
     val.mergeToRowDestructive(row.columns);
 
@@ -434,6 +436,22 @@ queryFromStatement(SelectStatement & stm,
         // No from at all
         return queryWithoutDataset(stm, scope);
     }
+}
+
+RowName GetValidatedRowName(const ExpressionValue& rowNameEV)
+{
+    if (rowNameEV.empty())
+        throw HttpReturnException(400, "Can't create a row with a null or empty name.");
+
+    if (!rowNameEV.isAtom())
+        throw HttpReturnException(400, "NAMED expression must evaluate to a single value");
+
+    Utf8String rowName = rowNameEV.toUtf8String();
+
+    if (rowName.empty())
+        throw HttpReturnException(400, "Can't create a row with an empty name.");
+
+    return std::move(RowName(rowName));
 }
 
 } // namespace MLDB

--- a/server/analytics.cc
+++ b/server/analytics.cc
@@ -324,7 +324,7 @@ queryWithoutDataset(SelectStatement& stm, SqlBindingScope& scope)
     SqlRowScope context;
     ExpressionValue val = boundSelect(context, GET_ALL);
     MatrixNamedRow row;
-    //row.rowName = RowName(stm.select.surface); //TO BE REVIEWED AS PART OF MLDBFB-264
+    row.rowName = RowName("result"); //todo: allow NAMED
     row.rowHash = row.rowName;
     val.mergeToRowDestructive(row.columns);
 

--- a/server/analytics.h
+++ b/server/analytics.h
@@ -136,6 +136,11 @@ queryFromStatement(SelectStatement & stm,
                    SqlBindingScope & scope,
                    BoundParameters params = nullptr);
 
+/** Build a RowName from an expression value and throw if
+    it is not valid (row, empty, etc)
+*/
+RowName GetValidatedRowName(const ExpressionValue& rowNameEV);
+
 } // namespace MLDB
 } // namespace Datacratic
 

--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -3626,7 +3626,7 @@ SelectStatement::parse(ML::Parse_Context& context, bool acceptUtf8)
     }
     else {
         //default name is "rowName()" if there is a dataset and "result" if there is none
-        //wo we need to check if there is a FROM first.
+        //we need to check if there is a FROM first.
         needDefaultRowName = true;
     }
 

--- a/testing/MLDB-1190_segfault_sqlexpr_jseval.py
+++ b/testing/MLDB-1190_segfault_sqlexpr_jseval.py
@@ -40,6 +40,8 @@ for i in range(25):
              preProcessed: 'I really loved this party!!!'}) as *""")
 
 expected_response = [{
+    "rowName": "result",
+    "rowHash": "d54892b736cac3ab",
     "columns" : [
         ["msgStats.msgLen", 28, "-Inf"],
         ["words.party", 1, "-Inf"],

--- a/testing/MLDB-1315-row-table-expressions.js
+++ b/testing/MLDB-1315-row-table-expressions.js
@@ -39,7 +39,7 @@ assertEqual(resp.responseCode, 201);
 
 var expected = [
     [ "_rowName", "Z" ],
-    [ "", "three" ]
+    [ "result", "three" ]
 ];
 
 testQuery("SELECT poil({input: {x: 1, y: 2, z: 'three'}})[output] as *", expected);
@@ -70,7 +70,7 @@ assertEqual(resp.responseCode, 201);
 
 expected = [
    [ "_rowName", "output.a", "output.b" ],
-   [ "", 1, 2 ]
+   [ "result", 1, 2 ]
 ];
 
 testQuery("SELECT x({1}) AS *", expected);

--- a/testing/MLDB-1317-tensor-datatype.js
+++ b/testing/MLDB-1317-tensor-datatype.js
@@ -24,6 +24,7 @@ var expected = [
          [ "1.0", 3, "-Inf" ],
          [ "1.1", 4, "-Inf" ]
       ]
+      ,"rowHash":"d54892b736cac3ab","rowName":"result"
    }
 ];
 
@@ -41,6 +42,7 @@ var expected = [
          [ "1.0", 0.30000000000000004, "-Inf" ],
          [ "1.1", 0.4, "-Inf" ]
       ]
+      ,"rowHash":"d54892b736cac3ab","rowName":"result"
    }
 ];
 
@@ -56,6 +58,7 @@ var expected = [
          [ "0.0", 4, "-Inf" ],
          [ "1.0", 6, "-Inf" ]
       ]
+      ,"rowHash":"d54892b736cac3ab","rowName":"result"
    }
 ];
 
@@ -71,6 +74,7 @@ var expected = [
          [ "0.0", "1three", "-Inf" ],
          [ "1.0", "2four", "-Inf" ]
       ]
+      ,"rowHash":"d54892b736cac3ab","rowName":"result"
    }
 ];
 
@@ -86,6 +90,7 @@ var expected = [
          [ "x", 2, "-Inf" ],
          [ "y", 3, "-Inf" ]
       ]
+      ,"rowHash":"d54892b736cac3ab","rowName":"result"
    }
 ];
 
@@ -107,6 +112,7 @@ var expected = [
          [ "x", 3, "-Inf" ],
          [ "y", 8, "-Inf" ]
       ]
+      ,"rowHash":"d54892b736cac3ab","rowName":"result"
    }
 ];
 
@@ -123,6 +129,7 @@ var expected = [
          [ "y", 8, "-Inf" ],
          [ "z", null, "-Inf" ]
       ]
+      ,"rowHash":"d54892b736cac3ab","rowName":"result"
    }
 ];
 

--- a/testing/MLDB-1319-new-executor-function-binding.js
+++ b/testing/MLDB-1319-new-executor-function-binding.js
@@ -68,7 +68,7 @@ assertEqual(resp.responseCode, 201);
 
 var expected = [
     [ "_rowName", "test1.x", "test1.y", "test1.z", "test2.x", "test2.z" ],
-    [ "", 1, 2, null, 1, 2 ]
+    [ "result", 1, 2, null, 1, 2 ]
 ];
 
 testQuery('SELECT poil() as *', expected);
@@ -76,7 +76,7 @@ testQuery('SELECT poil2() as *', expected);
 
 var expected2 = [
     [ "_rowName", "test1.x", "test1.y", "test1.z", "test2.x", "test2.z" ],
-    [ "", 2, null, 4, 1, 2 ]
+    [ "result", 2, null, 4, 1, 2 ]
 ];
 
 testQuery('SELECT poil3({n:1}) as *', expected2);

--- a/testing/MLDB-1320-sql-query-whole-table.js
+++ b/testing/MLDB-1320-sql-query-whole-table.js
@@ -47,7 +47,7 @@ assertEqual(resp.responseCode, 201);
 
 var expected = [
     [ "_rowName", "all systems", "hello" ],
-    [ "", "GO", "world" ]
+    [ "result", "GO", "world" ]
 ];
 
 testQuery('SELECT poil()[output] as *', expected);
@@ -69,7 +69,7 @@ assertEqual(resp.responseCode, 201);
 
 var expected = [
     [ "_rowName", "all systems" ],
-    [ "", "GO" ]
+    [ "result", "GO" ]
 ];
 
 testQuery('SELECT poil()[output] as *', expected);
@@ -92,7 +92,7 @@ assertEqual(resp.responseCode, 201);
 
 var expected = [
     [ "_rowName", "hello" ],
-    [ "", "world" ]
+    [ "result", "world" ]
 ];
 
 testQuery('SELECT poil()[output] as *', expected);

--- a/testing/MLDB-1440_sqlexpr_ignore_unknown_param.py
+++ b/testing/MLDB-1440_sqlexpr_ignore_unknown_param.py
@@ -24,7 +24,7 @@ class Mldb1440Test(MldbUnitTest):
             mldb.query("select noIgnore({a:1, b:2}) as *"),
             [
                 ["_rowName", "rez"],
-                [       "",  3 ]
+                ["result",  3 ]
             ]
         )
 
@@ -33,7 +33,7 @@ class Mldb1440Test(MldbUnitTest):
             mldb.query("select noIgnore({a:1, b:2, c:5}) as *"),
             [
                 ["_rowName", "rez"],
-                [       "",  3 ]
+                ["result",  3 ]
             ]
         )
     
@@ -44,7 +44,7 @@ class Mldb1440Test(MldbUnitTest):
             mldb.query("select noIgnore({a:1, b:2, c:5}) as *"),
             [
                 ["_rowName", "rez"],
-                [       "",  3 ]
+                ["result",  3 ]
             ]
         )
 

--- a/testing/MLDB-180-basic-join.js
+++ b/testing/MLDB-180-basic-join.js
@@ -155,14 +155,14 @@ testQuery(
     'SELECT poil() as *',
     [
         [ "_rowName", "test1.x", "test1.y", "test1.z", "test2.x", "test2.z" ],
-        [ "", 1, 2, null, 1, 2 ]
+        [ "result", 1, 2, null, 1, 2 ]
     ]);
 
 testQuery(
     'SELECT poil_as() as *',
     [
         [ "_rowName", "t1.x", "t1.y", "t1.z", "t2.x", "t2.z" ],
-        [ "", 1, 2, null, 1, 2 ]
+        [ "result", 1, 2, null, 1, 2 ]
     ]);
 
 // almost same again but with a groupBy
@@ -186,7 +186,7 @@ testQuery(
     'SELECT poil_group() as *',
     [
         [ "_rowName", "max(t1.y)", "min(t3.x)", "rn", "t1.x" ],
-        [ "", 2, 1, "ex1-ex4-ex4", 1 ]
+        [ "result", 2, 1, "ex1-ex4-ex4", 1 ]
     ]);
 
 // big example with where and groupby
@@ -251,7 +251,7 @@ for (var i in funcs) {
         "({1 AS a, 1 AS b}) AS *",
         [
             [ "_rowName", "max(t1.y)", "min(t3.x)", "t1.x" ],
-            [ "", 2, 1, 1 ]
+            [ "result", 2, 1, 1 ]
         ]);
 }
 

--- a/testing/MLDB-724-time-arithmetic.py
+++ b/testing/MLDB-724-time-arithmetic.py
@@ -32,7 +32,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '10 s' = INTERVAL '10second' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -41,7 +41,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '22S' = INTERVAL '22 SECOND' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -50,7 +50,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '60 MINUTE' = INTERVAL '1H' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -59,7 +59,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '10 minute' = INTERVAL '600second' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -68,7 +68,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '2H' = INTERVAL '120m' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -77,7 +77,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '2 hour' = INTERVAL '2 HOUR' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -85,7 +85,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '24 H' = INTERVAL '1440 m' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -93,7 +93,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '24 H' = INTERVAL '86400 s' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -102,7 +102,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1 d' = INTERVAL '1day' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -110,7 +110,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1 D' = INTERVAL '1 DAY' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -119,7 +119,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1 w' = INTERVAL '7day' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -127,7 +127,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1week' = INTERVAL '1 WEEK' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -136,7 +136,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1MONTH' = INTERVAL '1 month' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -145,7 +145,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1 year' = INTERVAL '12month' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -153,7 +153,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1YEAR' = INTERVAL '1 Y' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -162,7 +162,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1Y2W' = INTERVAL '12MONTH14d' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -170,7 +170,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1 day 5H' = INTERVAL '1d 18000 second' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -179,7 +179,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1 day' = INTERVAL '24H' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  False ] # because of daylight saving
+                ["result",  False ] # because of daylight saving
             ]
         )
 
@@ -187,7 +187,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1 month' = INTERVAL '30day' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  False ] # because months were not all created equal
+                ["result",  False ] # because months were not all created equal
             ]
         )
 
@@ -195,7 +195,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1 month' = INTERVAL '4 week' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  False ] # because months were not all created equal
+                ["result",  False ] # because months were not all created equal
             ]
         )
 
@@ -203,7 +203,7 @@ class TimeArithmeticTest(MldbUnitTest):
             mldb.query("select INTERVAL '1 year' = INTERVAL '365 day' as equal"),
             [
                 ["_rowName", "equal"],
-                [       "",  False ] # because of leap years
+                ["result",  False ] # because of leap years
             ]
         )
 
@@ -326,56 +326,56 @@ class TimeArithmeticTest(MldbUnitTest):
         self.assertTableResultEquals(mldb.query("select interval '1d' + interval '2d' < interval '20d' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select interval '1d' > - interval '1d' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select - interval '1d' > - - interval '1d' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  False ]
+                ["result",  False ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select interval '3d' - interval '1d' < interval '3d' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select interval '1d' * 3 = interval '3d' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select 3 * interval '1d' >=interval '2d' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select 0.5 * interval '4d' = interval '2d' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select interval '4d' / 2 = interval '2d' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
@@ -494,14 +494,14 @@ class TimeArithmeticTest(MldbUnitTest):
         self.assertTableResultEquals(mldb.query("select timestamp 60 = timestamp '1970-01-01T00:01:00' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select timestamp 61 = timestamp '1970-01-01T00:01:00' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  False ]
+                ["result",  False ]
             ]
         )
 
@@ -509,42 +509,42 @@ class TimeArithmeticTest(MldbUnitTest):
         self.assertTableResultEquals(mldb.query("select timestamp timestamp 123 = timestamp 123 as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select 1 @ timestamp 123 = 1 @ '1970-01-01T00:02:03' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select 2 @ timestamp 123 != 1 @ '1970-01-01T00:02:03' as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select latest_timestamp(2 @ timestamp 123) = latest_timestamp(1 @ '1970-01-01T00:02:03') as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select latest_timestamp(1) = TIMESTAMP -Inf as result"),
              [
                 ["_rowName", "result"],
-                [       "",  True ]
+                ["result",  True ]
             ]
         )
 
         self.assertTableResultEquals(mldb.query("select latest_timestamp(1) = TIMESTAMP Inf as result"),
              [
                 ["_rowName", "result"],
-                [       "",  False ]
+                ["result",  False ]
             ]
         )
     def test_MLDB_1453(self):

--- a/testing/MLDB-871-json-non-ascii-keys.js
+++ b/testing/MLDB-871-json-non-ascii-keys.js
@@ -23,7 +23,7 @@ assertEqual(res.responseCode, 200);
 var expected = [
     {
         "'ç'" : "ç",
-        "_rowName" : ""
+        "_rowName" : "result"
     }
 ];
 

--- a/testing/MLDBFB-345_improve_error_message_named_on_null.py
+++ b/testing/MLDBFB-345_improve_error_message_named_on_null.py
@@ -39,5 +39,10 @@ class ImproveErrorMessageNamedOnNullTest(MldbUnitTest): # noqa
         with self.assertMldbRaises(expected_regexp=expect) as re:
            mldb.query("SELECT * NAMED {1} FROM ds")
 
+    def test_named_without_dataset(self):
+        expect = [["_rowName","1"],["the one", 1 ]]
+        res = mldb.query("SELECT 1 NAMED 'the one'")
+        self.assertEqual(expect, res);
+
 if __name__ == '__main__':
     mldb.run_tests()

--- a/testing/MLDBFB-345_improve_error_message_named_on_null.py
+++ b/testing/MLDBFB-345_improve_error_message_named_on_null.py
@@ -24,13 +24,20 @@ class ImproveErrorMessageNamedOnNullTest(MldbUnitTest): # noqa
         # works because we only work on the row where behA != null
         mldb.query('SELECT * NAMED behA FROM ds WHERE behA IS NOT NULL')
 
-    @unittest.expectedFailure
     def test_non_working_case(self):
-        # FIXME: It's ok to fail, but the error message should be helpful
-        # currently returns "Can't convert from empty to string"
         expect = "Can't create a row with a null or empty name."
-        with self.assertMldbRaises(expected_regexp=expect):
-            mldb.query('SELECT * NAMED behA FROM ds')
+        with self.assertMldbRaises(expected_regexp=expect) as re:
+           mldb.query('SELECT * NAMED behA FROM ds')
+
+    def test_non_working_case_2(self):
+        expect = "Can't create a row with an empty name."
+        with self.assertMldbRaises(expected_regexp=expect) as re:
+           mldb.query("SELECT * NAMED '' FROM ds")
+
+    def test_non_working_case_3(self):
+        expect = "NAMED expression must evaluate to a single value"
+        with self.assertMldbRaises(expected_regexp=expect) as re:
+           mldb.query("SELECT * NAMED {1} FROM ds")
 
 if __name__ == '__main__':
     mldb.run_tests()


### PR DESCRIPTION
MLDB-1505: 
default rowname for queries without from is 'result'
queries without from can use 'NAMED'
MLDB-1381
better error message when providing illegal row name