### PR TITLE
MLDB-1513 fix issues with tabular dataset and row generation in queries

### DIFF
--- a/core/dataset.h
+++ b/core/dataset.h
@@ -412,7 +412,12 @@ struct Dataset: public MldbEntity {
 
         This is called by queryStructured and queryBasic, so cannot use those
         functions.
-    */
+
+        Must return the *exact* set of rows or a stream that will do the same
+        because the where expression will not be evaluated outside of this method
+        if this method is called.
+    */    
+
     virtual GenerateRowsWhereFunction
     generateRowsWhere(const SqlBindingScope & context,
                       const Utf8String& alias,

--- a/plugins/tabular_dataset.cc
+++ b/plugins/tabular_dataset.cc
@@ -304,7 +304,7 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
         int rowIndex;
 
         std::tie(chunkIndex, rowIndex) = tryLookupRow(rowName);
-        return chunkIndex > 0;
+        return chunkIndex >= 0;
     }
 
     virtual MatrixNamedRow getRow(const RowName & rowName) const

--- a/server/bound_queries.cc
+++ b/server/bound_queries.cc
@@ -769,7 +769,7 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
                          std::function<bool (const Json::Value &)> onProgress,
                          bool allowMT)
     {
-        STACK_PROFILE(RowHashOrderedExecutor_execute_iter);
+        //STACK_PROFILE(RowHashOrderedExecutor_execute_iter);
 
         QueryThreadTracker parentTracker;
 

--- a/testing/MLDB-1428-text-sparse-output.py
+++ b/testing/MLDB-1428-text-sparse-output.py
@@ -84,4 +84,39 @@ class ImportTextToSparseTest(unittest.TestCase):
                     ["471242",1]]
         self.assertEqual(res, expected)
 
+    # MLDB-1513
+    def test_missing_rows(self):
+        ds = mldb.create_dataset({
+            'type': 'tabular',
+            'id': 'onechunk'})
+
+        ds.record_row('1', [['x', 17, 0]])
+        ds.record_row('2', [['x', 18, 0]])
+        ds.record_row('3', [['x', 'banane', 0]])
+
+        ds.commit()
+
+        res = mldb.query("select * from onechunk where rowName() in ('1', '2', '3')")
+
+        expected = [["_rowName", "x"],["2",18],["1",17],["3","banane"]]
+
+        self.assertEqual(res, expected)
+
+    def test_missing_rows_order(self):
+
+        ds = mldb.create_dataset({
+            'type': 'sparse.mutable',
+            'id': 'onechunk2'})
+
+        ds.record_row('1', [['x', 17, 0]])
+        ds.record_row('2', [['x', 18, 0]])
+        ds.record_row('3', [['x', 'banane', 0]])
+
+        ds.commit()
+
+        res = mldb.query("select * from onechunk2 where rowName() in ('1', '2', '3') order by rowName()")
+        expected = [["_rowName", "x"],["1",17],["2",18],["3","banane"]]
+
+        self.assertEqual(res, expected)
+
 mldb.run_tests()


### PR DESCRIPTION
-Fix a off-by one error in tabular dataset

-Made clear that generateRowsWhere must return an exact set

-`where` expression no longer evaluated outside of generateRowsWhere when generateRowsWhere is called. Should have a positive performance impact on large, non-group-by queries.

-Dont allow generateRowsWhere to cast other values to string when comparing to rowName(). This is because we evaluated rowName() to a string type when we evaluated SQL, so if we allow generateRowsWhere to cast ints to rownames in an optimized path, it would give a different result than the non-optimized path.

-Currently all row names are stored as strings in Coord and all rowName() evaluated to a string.