### PR TITLE
Made RowStream destructor virtual (MLDB-1520) (TRIVIAL)

### DIFF
--- a/core/dataset.h
+++ b/core/dataset.h
@@ -210,6 +210,10 @@ struct ColumnIndex {
 
 struct RowStream {
 
+    virtual ~RowStream()
+    {
+    }
+
     /* Clone the stream with just enough information to use the initAt 
        clones streams should be un-initialized                        */
     virtual std::shared_ptr<RowStream> clone() const = 0;


### PR DESCRIPTION
Trivial addition of a virtual destructor, to allow subclasses to actually free their resources.