### PR TITLE
Join sort optims

### DIFF
--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -138,8 +138,6 @@ struct JoinedDataset::Itl
 
     Itl(MldbServer * server, JoinedDatasetConfig joinConfig)
     {
-        STACK_PROFILE(JoinDataset_itl_constructor);
-
         SqlExpressionMldbContext context(server);
 
         // Create a context to get our datasets from
@@ -248,7 +246,6 @@ struct JoinedDataset::Itl
         }
 
         // Finally, the column indexes
-        STACK_PROFILE(JoinDataset_itl_make_column_indexes);
         for (auto & c: left.dataset->getColumnNames()) {
             ColumnName newColumnName(quotedLeftName.empty()
                                      ? c.toUtf8String()
@@ -326,7 +323,6 @@ struct JoinedDataset::Itl
                                BoundTableExpression& right,
                                JoinQualification qualification)
     {
-        STACK_PROFILE(makeJoinConstantWhere);
         bool debug = false;
         bool outerLeft = qualification == JOIN_LEFT || qualification == JOIN_FULL;
         bool outerRight = qualification == JOIN_RIGHT || qualification == JOIN_FULL;
@@ -338,7 +334,6 @@ struct JoinedDataset::Itl
                             const std::function<void (const RowName&, const RowHash& )> & recordOuterRow)
             -> std::vector<std::tuple<ExpressionValue, RowName, RowHash> >
             {
-                STACK_PROFILE(makeJoinConstantWhere_runSide);
                 auto sideCondition = side.where;
 
                 std::vector<std::shared_ptr<SqlExpression> > clauses = { side.selectExpression };
@@ -379,8 +374,6 @@ struct JoinedDataset::Itl
                 // Now we extract all values 
                 std::vector<std::tuple<ExpressionValue, RowName, RowHash> > sorted;
 
-                {
-                STACK_PROFILE(makeJoinConstantWhere_build);
                 for (auto & r: rows) {
                     ExcAssertEqual(r.columns.size(), 1);
 
@@ -398,12 +391,8 @@ struct JoinedDataset::Itl
                     const ExpressionValue & value = embedding.getField(0);
                     sorted.emplace_back(value, r.rowName, r.rowHash);
                 }
-                }
 
-                {
-                STACK_PROFILE(makeJoinConstantWhere_sort);
                 parallelQuickSortRecursive<std::tuple<ExpressionValue, RowName, RowHash> >(sorted.begin(), sorted.end());
-                }
 
                 return sorted;
             };

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -21,7 +21,6 @@
 #include "mldb/server/bucket.h"
 #include "mldb/server/parallel_merge_sort.h"
 #include "mldb/jml/utils/environment.h"
-#include "mldb/jml/utils/profile.h"
 #include "mldb/ml/jml/buckets.h"
 #include "mldb/base/parallel.h"
 #include "mldb/types/any_impl.h"

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -1491,14 +1491,7 @@ queryBasic(const SqlBindingScope & scope,
                         return boundOrderBy.less(std::get<0>(row1), std::get<0>(row2));
                     };
 
-                //std::sort(rowsSorted.begin(), rowsSorted.end(), compareRows);
-               {
-                    STACK_PROFILE(Querybasic_orderby);
-                    //std::sort(rowsSorted.begin(), rowsSorted.end(), compareRows);
-                    parallelQuickSortRecursive<SortedRow>(rowsSorted.begin(), rowsSorted.end(), compareRows);
-               } 
-
-                //std::erase(rowsSorted.begin(), rowsSorted.begin() + offset);
+                parallelQuickSortRecursive<SortedRow>(rowsSorted.begin(), rowsSorted.end(), compareRows);
 
                 ssize_t realLimit = -1;
                 if (realLimit == -1)
@@ -1517,7 +1510,7 @@ queryBasic(const SqlBindingScope & scope,
                 for (unsigned i = begin;  i < end;  ++i) {
                     result.emplace_back(std::move(std::get<1>(rowsSorted[i])));
                 }
-                return std::move(result);
+                return result;
             }
         };
 

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -343,6 +343,7 @@ ColumnIndex::
 getColumnDense(const ColumnName & column) const
 {
     auto columnValues = getColumn(column);
+    // getRowNames can return row names in an arbitrary order as long as it is deterministic.
     std::vector<RowName> rowNames = getRowNames();
     std::vector<CellValue> result;
     result.reserve(rowNames.size());
@@ -844,6 +845,8 @@ generateRownameIsConstant(const Dataset & dataset,
     Must return the *exact* set of rows or a stream that will do the same
     because the where expression will not be evaluated outside of this method
     if this method is called.
+
+    Ordering can be arbitrary but need to be deterministic
 */    
 GenerateRowsWhereFunction
 Dataset::
@@ -1130,6 +1133,7 @@ generateRowsWhere(const SqlBindingScope & scope,
                         {
                             std::vector<RowName> filtered;
 
+                            // getRowNames can return row names in an arbitrary order as long as it is deterministic.
                             for (const RowName & n: this->getMatrixView()
                                      ->getRowNames()) {
                                 uint64_t hash = RowHash(n).hash();
@@ -1189,6 +1193,7 @@ generateRowsWhere(const SqlBindingScope & scope,
                         if (!token.empty())
                             start = token.convert<size_t>();
 
+                        //Row names can be returned in an arbitrary order as long as it is deterministic.
                         auto rows = this->getMatrixView()
                             ->getRowNames(start, limit);
 
@@ -1249,6 +1254,7 @@ generateRowsWhere(const SqlBindingScope & scope,
 
                 auto matrix = this->getMatrixView();
 
+                //Row names can be returned in an arbitrary order as long as it is deterministic.
                 auto rows = matrix->getRowNames(start, limit);
 
                 std::vector<RowName> rowsToKeep;

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -60,7 +60,7 @@ typedef EntityType<Dataset> DatasetType;
 struct MatrixView {
     virtual ~MatrixView();
 
-    /*
+    /**
     Return a list of all rownames.
     Rownames are always unique.
 
@@ -437,7 +437,8 @@ struct Dataset: public MldbEntity {
         because the where expression will not be evaluated outside of this method
         if this method is called.
 
-        Ordering can be arbitrary but need to be deterministic
+        Ordering can be arbitrary but needs to be deterministic, and there must not
+        be duplicated rows.
     */    
 
     virtual GenerateRowsWhereFunction

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -60,6 +60,18 @@ typedef EntityType<Dataset> DatasetType;
 struct MatrixView {
     virtual ~MatrixView();
 
+    /*
+    Return a list of all rownames.
+    Rownames are always unique.
+
+    The sorting criteria is the same as with RowStream:
+
+    Row names can be returned in an arbitrary order as long as it is deterministic.
+    I.e. Calling getRowNames several times on the same (unchanged) dataset should return rownames
+    in the same (arbitrary) order.
+
+    The ordering needs to be preserved regardless of start and limit.
+    */
     virtual std::vector<RowName>
     getRowNames(ssize_t start = 0, ssize_t limit = -1) const = 0;
 
@@ -210,6 +222,10 @@ struct ColumnIndex {
 
 /** This structure is used for streaming queries to generate a set of
     matching row names one at a time.
+
+    Row names can be streamed in an arbitrary order as long as it is deterministic.
+    I.e. using different rowstreams on the same (unchanged) dataset should return rownames
+    in the same (arbitrary) order.
 */
 
 struct RowStream {
@@ -420,6 +436,8 @@ struct Dataset: public MldbEntity {
         Must return the *exact* set of rows or a stream that will do the same
         because the where expression will not be evaluated outside of this method
         if this method is called.
+
+        Ordering can be arbitrary but need to be deterministic
     */    
 
     virtual GenerateRowsWhereFunction

--- a/plugins/svd.cc
+++ b/plugins/svd.cc
@@ -810,6 +810,7 @@ run(const ProcedureRunConfig & run,
 
         auto output = createDataset(server, rowOutput, onProgress2, true /*overwrite*/);
 
+        // getRowNames can return row names in an arbitrary order as long as it is deterministic.
         auto rows = dataset->getMatrixView()->getRowNames(0, -1);
         
         //cerr << "writing embeddings for " << rows.size() << " rows to dataset "

--- a/plugins/tabular_dataset.cc
+++ b/plugins/tabular_dataset.cc
@@ -11,6 +11,7 @@
 #include "mldb/ml/jml/training_index_entry.h"
 #include "mldb/jml/utils/smart_ptr_utils.h"
 #include "mldb/server/bucket.h"
+#include "mldb/jml/utils/profile.h"
 
 #include <mutex>
 
@@ -256,13 +257,6 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
         for (auto & c: chunks) {
             result.insert(result.end(), c.rowNames.begin(), c.rowNames.end());
         }
-
-        std::sort(result.begin(), result.end(),
-                  [] (const RowName & n1,
-                      const RowName & n2)
-                  {
-                      return n1.hash() < n2.hash();
-                  });
 
         return result;
     }

--- a/plugins/tabular_dataset.cc
+++ b/plugins/tabular_dataset.cc
@@ -11,7 +11,6 @@
 #include "mldb/ml/jml/training_index_entry.h"
 #include "mldb/jml/utils/smart_ptr_utils.h"
 #include "mldb/server/bucket.h"
-#include "mldb/jml/utils/profile.h"
 
 #include <mutex>
 

--- a/server/analytics.cc
+++ b/server/analytics.cc
@@ -140,6 +140,7 @@ void iterateDense(const SelectExpression & select,
     }
     
     // Get a list of rows that we run over
+    // getRowNames can return row names in an arbitrary order as long as it is deterministic.
     auto rows = matrix->getRowNames();
 
     auto doRow = [&] (int rowNum) -> bool

--- a/server/bound_queries.cc
+++ b/server/bound_queries.cc
@@ -115,7 +115,8 @@ struct UnorderedExecutor: public BoundSelectQuery::Executor {
         //cerr << "bound query unordered num buckets: " << numBuckets << endl;
         QueryThreadTracker parentTracker;
 
-        // Get a list of rows that we run over        
+        // Get a list of rows that we run over
+        // Ordering is arbitrary but deterministic
         auto rows = whereGenerator(-1, Any()).first;
 
         //cerr << "ROWS MEMORY SIZE " << rows.size() * sizeof(RowName) << endl;
@@ -326,6 +327,7 @@ struct OrderedExecutor: public BoundSelectQuery::Executor {
         QueryThreadTracker parentTracker;
 
         // Get a list of rows that we run over
+        // Ordering is arbitrary but deterministic
         auto rows = whereGenerator(-1, Any()).first;
 
         // cerr << "doing " << rows.size() << " rows with order by" << endl;
@@ -522,6 +524,7 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
         ML::Timer rowsTimer;
 
         // Get a list of rows that we run over
+        // Ordering is arbitrary but deterministic
         auto rows = whereGenerator(-1, Any()).first;
 
         if (!std::is_sorted(rows.begin(), rows.end(), SortByRowHash()))

--- a/server/dataset_collection.cc
+++ b/server/dataset_collection.cc
@@ -380,6 +380,7 @@ initRoutes(RouteManager & manager)
                 int start = getParam(req, "start", 0);
                 int limit = getParam(req, "limit", -1);
 
+                // getRowNames can return row names in an arbitrary order as long as it is deterministic.
                 auto result = dataset->getMatrixView()->getRowNames(start, limit);
 
                 connection.sendHttpResponse(200, jsonEncodeStr(result),

--- a/server/parallel_merge_sort.h
+++ b/server/parallel_merge_sort.h
@@ -170,7 +170,7 @@ parallelQuickSortRecursive(typename std::vector<T>::iterator begin, typename std
     auto p = std::partition(begin, end, [&](const T& a) { return less(a, pivotValue); } );
     std::swap(*p, *(end - 1));
 
-    if (numElements > 1024) { //todo: better heuristic
+    if (numElements > 1024) {
 
         auto runLeft = [&] () { parallelQuickSortRecursive<T, Compare>(begin, p, less, depth+1); };
         ThreadPool tp;


### PR DESCRIPTION
Added a new algo to perform a quicksort in multithread.

On fmaillet's test case of a left join on 41M+ rows (on one side, less on the other), with this PR we save:

About 60 seconds by sorting in parallel in join_dataset
About 173 seconds (3 minutes!) by sorting in parallel in QueryBasic
About 20 seconds by not sorting in TabularDataset::getrownames

In total we cut the time necessary to perform this large outer join by more than half. There may be a larger refactoring to make it much faster but those were the low-hanging apples.
