### PR TITLE
[MLDB-1551] added lock in the csv export callback to protect the ostream

### DIFF
--- a/plugins/csv_export_procedure.cc
+++ b/plugins/csv_export_procedure.cc
@@ -113,9 +113,12 @@ run(const ProcedureRunConfig & run,
     lineBuffer.resize(columnNames.size());
     const auto columnNamesEnd = columnNames.end();
     const auto columnNamesBegin = columnNames.begin();
+
+    std::mutex lineMutex;
     auto outputCsvLine = [&] (NamedRowValue & row_,
                               const vector<ExpressionValue> & calc)
     {
+        std::unique_lock<std::mutex> guard(lineMutex);
         MatrixNamedRow row = row_.flattenDestructive();
         ExcAssert(lineBuffer.size() == columnNames.size());
         size_t lineBufferIndex = 0; // position of the buffered value ready to

--- a/plugins/embedding.cc
+++ b/plugins/embedding.cc
@@ -295,6 +295,8 @@ struct EmbeddingDataset::Itl
         if (limit == -1)
             limit = repr->rows.size();
 
+        result.reserve(limit - start);
+
         for (unsigned i = start;  i < repr->rows.size() && i < start + limit;  ++i) {
             result.emplace_back(repr->rows[i].rowName);
         }


### PR DESCRIPTION
- csv.export is using the CsvWriter which is not thread-safe so I added a mutex on the csv.export's aggregator call
- reserving the memory in embedding dataset `getRowNames()` to avoid unnecessary re-alloc.