### PR TITLE
MLDB-1554 concat aggregator

### DIFF
--- a/container_files/public_html/doc/builtin/sql/ValueExpression.md
+++ b/container_files/public_html/doc/builtin/sql/ValueExpression.md
@@ -494,6 +494,11 @@ The following useful non-standard aggregation functions is also supported:
   column name and value given.  This can be used with a group by clause to
   transform a dense dataset of (actor,action,value) records into a sparse
   dataset with one sparse row per actor, for example to create one-hot feature vectors or term-document or cooccurrence matrices.
+- `string_agg(expr, separator)` will coerce the value of `expr` and that of
+  `separator` to a string, and produce a single string with the concatenation
+  of `expr` separated by `separators` at internal boundaries.  For example,
+  if `expr` is `"one"`, `"two"` and `"three"` in the group, and separator is
+  `', '` the output will be `"one, two, three"`.
 
 ### Aggregates of rows
 
@@ -526,6 +531,7 @@ The standard SQL aggregation functions operate 'vertically' down columns. MLDB d
 - Horizontal aggregation functions
   - `horizontal_count(<row>)` returns the number of non-null values in the row.
   - `horizontal_sum(<row>)` returns the sum of the non-null values in the row.
+  - `horizontal_string_agg(<row>, <separator>)` returns the string aggregator of the value of row, coerced to strings, separated by separator.
   - `horizontal_avg(<row>)` returns the average of the non-null values in the row.
   - `horizontal_min(<row>)` returns the minimum of the non-null values in the row.
   - `horizontal_max(<row>)` returns the maximum of the non-null value in the row.

--- a/server/bound_queries.cc
+++ b/server/bound_queries.cc
@@ -1150,31 +1150,30 @@ struct GroupContext: public SqlExpressionDatasetContext {
 
         //check aggregators
         auto aggFn = SqlBindingScope::doGetAggregator(resolvedFunctionName, args);
-        if (aggFn)
-        {
+        if (aggFn) {
             if (resolvedFunctionName == "count")
-            {
-                //count is *special*
-                evaluateEmptyGroups = true;
-            }
+                {
+                    //count is *special*
+                    evaluateEmptyGroups = true;
+                }
 
-            int aggIndex = argCounter;
-            OutputAggregator boundagg(aggIndex,
-                                    args.size(),
-                                    aggFn);
-              outputAgg.emplace_back(boundagg);              
+            int aggIndex = outputAgg.size();
+            OutputAggregator boundagg(argCounter,
+                                      args.size(),
+                                      aggFn);
+            outputAgg.emplace_back(boundagg);              
 
-               argCounter += args.size();
+            argCounter += args.size();
 
-              return {[&,aggIndex] (const std::vector<ExpressionValue> & args,
-                        const SqlRowScope & context)
+            return {[&,aggIndex] (const std::vector<ExpressionValue> & args,
+                                  const SqlRowScope & context)
                     {
                         return outputAgg[aggIndex].aggregate.extract(aggData[aggIndex].get());
                     },
                     // TODO: get it from the value info for the group keys...
                     std::make_shared<AnyValueInfo>()};
         }
-
+        
         return SqlBindingScope::doGetFunction(resolvedTableName, resolvedFunctionName, args, argScope);
     }
 

--- a/testing/MLDB-1554-string-agg.js
+++ b/testing/MLDB-1554-string-agg.js
@@ -1,0 +1,55 @@
+// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+var dataset = mldb.createDataset({type:'sparse.mutable',id:'test'});
+
+var ts = new Date("2015-01-01");
+
+var row = 0;
+
+function recordExample(who, what, how)
+{
+    dataset.recordRow(row++, [ [ "who", who, ts ], ["what", what, ts], ["how", how, ts] ]);
+}
+
+recordExample("mustard", "moved", "kitchen");
+recordExample("plum", "moved", "kitchen");
+recordExample("mustard", "stabbed", "plum");
+recordExample("mustard", "killed", "plum");
+recordExample("plum", "died", "stabbed");
+
+dataset.commit()
+
+var resp = mldb.get("/v1/datasets/test/query", {select: "string_agg(what, ', ') AS whats, string_agg(how, '') AS hows", groupBy: 'who', rowName: 'who', format: 'sparse', orderBy: 'who'});
+
+plugin.log(resp.json);
+
+assertEqual(resp.responseCode, 200, "Error executing query");
+
+expected = [
+   [
+      [ "_rowName", "mustard" ],
+      [ "hows", "kitchenplumplum" ],
+      [ "whats", "moved, stabbed, killed" ]
+   ],
+   [
+      [ "_rowName", "plum" ],
+      [ "hows", "stabbedkitchen" ],
+      [ "whats", "died, moved" ]
+   ]
+];
+
+assertEqual(mldb.diff(expected, resp.json, false /* strict */), {},
+            "Query 2 output was not the same as expected output");
+
+"success"

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -338,6 +338,7 @@ $(eval $(call mldb_unit_test,MLDB-1500-transpose-query.js,,manual)) # awaiting f
 # Tensorflow plugins
 $(eval $(call include_sub_make,MLDB-1398-plugin))
 $(eval $(call mldb_unit_test,MLDB-1398-plugin-library-dependency.js,MLDB-1398-plugin))
+$(eval $(call mldb_unit_test,MLDB-1554-string-agg.js))
 
 $(eval $(call test,MLDB-1360-sparse-mutable-multithreaded-insert,mldb,boost))
 


### PR DESCRIPTION
This PR adds the string_agg(), vertical_string_agg() and horizontal_string_agg() functions to MLDB.  They are equivalent to the Postgresql versions.

There is also a fix for an unrelated issue that was identified in testing, where the argument indexes weren't in sync with the aggregator indexes when analyzing the queries in a group by.
