### PR TITLE
Fixed empty literal parsing; improved error message for table expressions (MLDB-1567)

### DIFF
--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -960,17 +960,6 @@ bool matchConstant(ML::Parse_Context & context, ExpressionValue & result,
     }
 
     else return false;
-
-#if 0
-    else if (context.match_literal('[')) {
-        throw HttpReturnException(400, "TODO: array literal");
-        // Array literal
-    }
-    else if (context.match_literal('{')) {
-        throw HttpReturnException(400, "TODO: object literal");
-        // Object literal
-    }
-#endif
 }
 
 
@@ -1148,29 +1137,30 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
         skip_whitespace(context);
 
         vector<std::shared_ptr<SqlRowExpression> > clauses;
-        do {
-            skip_whitespace(context);
-            auto expr = SqlRowExpression::parse(context, allowUtf8);
-            skip_whitespace(context);
-            clauses.emplace_back(std::move(expr));
-        } while (context.match_literal(','));
 
-        if (clauses.size() > 1)
-        {
+        if (!context.match_literal('}')) {
+            do {
+                skip_whitespace(context);
+                auto expr = SqlRowExpression::parse(context, allowUtf8);
+                skip_whitespace(context);
+                clauses.emplace_back(std::move(expr));
+            } while (context.match_literal(','));
+
+            skip_whitespace(context);
+            context.expect_literal('}');
+        }
+
+        if (clauses.size() != 1) {
             auto select = std::make_shared<SelectExpression>(clauses);
             auto arg = std::make_shared<SelectWithinExpression>(select);
             lhs = arg;
         }
-        else
-        {
+        else {
             ExcAssertEqual(1, clauses.size());
             auto arg = std::make_shared<SelectWithinExpression>(clauses[0]);
             lhs = arg;  
         }
 
-        skip_whitespace(context);
-        context.expect_literal('}');
-        
         lhs->surface = ML::trim(token.captured());
     }
 
@@ -1179,17 +1169,19 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
         skip_whitespace(context);
 
         vector<std::shared_ptr<SqlExpression> > clauses;
-        do {
-            context.skip_whitespace();
-            auto expr = SqlExpression::parse(context, 10, allowUtf8);
-            context.skip_whitespace();
-            clauses.emplace_back(std::move(expr));
-        } while (context.match_literal(','));
+        if (!context.match_literal(']')) {
+            do {
+                context.skip_whitespace();
+                auto expr = SqlExpression::parse(context, 10, allowUtf8);
+                context.skip_whitespace();
+                clauses.emplace_back(std::move(expr));
+            } while (context.match_literal(','));
+
+            skip_whitespace(context);
+            context.expect_literal(']');
+        }
 
         lhs = std::make_shared<EmbeddingLiteralExpression>(clauses);
-
-        skip_whitespace(context);
-        context.expect_literal(']');
         
         lhs->surface = ML::trim(token.captured());
     }
@@ -2958,7 +2950,7 @@ bind(SqlBindingScope & context) const
             StructValue result;
 
             for (auto & c: boundClauses) {
-                ExpressionValue v = c(context, filter); 
+                ExpressionValue v = c(context, filter);
                 v.mergeToRowDestructive(result);
             }
             
@@ -3111,6 +3103,18 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
 
     std::shared_ptr<TableExpression> result;
 
+    auto expectCloseParanthesis = [&] ()
+        {
+            if (!context.match_literal(')')) {
+                context.exception("Expected to find a ')' parsing a table "
+                                  "expression.  This is normally because of "
+                                  "not putting a sub-SELECT within '()' "
+                                  "characters; eg transpose(select 1,2) should "
+                                  "be transpose((select 1,2)) so that multiple "
+                                  "arguments aren't ambiguous.");
+            }
+        };
+
     if (context.match_literal('(')) {
 
         skip_whitespace(context);
@@ -3119,7 +3123,8 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
             //sub-table
             auto statement = SelectStatement::parse(context, allowUtf8);
             skip_whitespace(context);
-            context.expect_literal(')');
+
+            expectCloseParanthesis();
 
             skip_whitespace(context);
             Utf8String asName;
@@ -3139,7 +3144,7 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
         {
             result = TableExpression::parse(context, currentPrecedence, allowUtf8);
             skip_whitespace(context);
-            context.expect_literal(')');
+            expectCloseParanthesis();
             result->surface = ML::trim(token.captured());
         }
     }
@@ -3153,7 +3158,7 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
         // Row expression, presented as a table
         auto statement = SqlExpression::parse(context, allowUtf8, 10 /* precedence */);
         skip_whitespace(context);
-        context.expect_literal(')');
+        expectCloseParanthesis();
         skip_whitespace(context);
 
         Utf8String asName;
@@ -3212,7 +3217,8 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
                     } while (context.match_literal(','));
                 }
 
-                context.expect_literal(')');
+                expectCloseParanthesis();
+
                 expr.reset(new DatasetFunctionExpression(identifier, args, options));
             }
             else

--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -2069,7 +2069,7 @@ parse(ML::Parse_Context & context, bool allowUtf8)
             // It can only be a wildcard if followed by:
             // - eof
             // - a comma
-            // - closing paranthesis, if used as an expression
+            // - closing parenthesis, if used as an expression
             // - AS
             // - EXCLUDING
             // - a keyword: FROM, WHERE, GROUP BY, HAVING, LIMIT, OFFSET
@@ -3103,7 +3103,7 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
 
     std::shared_ptr<TableExpression> result;
 
-    auto expectCloseParanthesis = [&] ()
+    auto expectCloseParenthesis = [&] ()
         {
             if (!context.match_literal(')')) {
                 context.exception("Expected to find a ')' parsing a table "
@@ -3124,7 +3124,7 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
             auto statement = SelectStatement::parse(context, allowUtf8);
             skip_whitespace(context);
 
-            expectCloseParanthesis();
+            expectCloseParenthesis();
 
             skip_whitespace(context);
             Utf8String asName;
@@ -3144,7 +3144,7 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
         {
             result = TableExpression::parse(context, currentPrecedence, allowUtf8);
             skip_whitespace(context);
-            expectCloseParanthesis();
+            expectCloseParenthesis();
             result->surface = ML::trim(token.captured());
         }
     }
@@ -3158,7 +3158,7 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
         // Row expression, presented as a table
         auto statement = SqlExpression::parse(context, allowUtf8, 10 /* precedence */);
         skip_whitespace(context);
-        expectCloseParanthesis();
+        expectCloseParenthesis();
         skip_whitespace(context);
 
         Utf8String asName;
@@ -3217,7 +3217,7 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
                     } while (context.match_literal(','));
                 }
 
-                expectCloseParanthesis();
+                expectCloseParenthesis();
 
                 expr.reset(new DatasetFunctionExpression(identifier, args, options));
             }

--- a/sql/sql_expression_operations.h
+++ b/sql/sql_expression_operations.h
@@ -199,7 +199,7 @@ struct SelectWithinExpression: public SqlExpression {
 };
 
 struct EmbeddingLiteralExpression: public SqlExpression {
-    EmbeddingLiteralExpression(std::vector<std::shared_ptr<SqlExpression> >& clauses);
+    EmbeddingLiteralExpression(std::vector<std::shared_ptr<SqlExpression> > clauses);
 
     virtual ~EmbeddingLiteralExpression();
 

--- a/testing/MLDB-1567-empty-literal.js
+++ b/testing/MLDB-1567-empty-literal.js
@@ -1,0 +1,42 @@
+/** MLDB-1562-join-with-in.js
+    Jeremy Barnes, 7 April 2016
+    Copyright (c) 2016 Datacratic Inc.  All rights reserved.
+
+*/
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+var expected = [
+    [ "x", null, "NaD" ]
+];
+
+var resp = mldb.query('select [] as x');
+
+mldb.log(resp);
+
+assertEqual(resp[0].columns, expected);
+
+resp = mldb.query('select {} as x')
+
+mldb.log(resp);
+
+assertEqual(resp[0].columns, undefined);
+
+resp = mldb.get('/v1/query', {q: 'select * from transpose(select 1)'});
+
+mldb.log(resp);
+
+assertEqual(resp.responseCode, 400);
+
+assertEqual(resp.json.error.indexOf("Expected to find a ')' parsing a table expression.  This is normally because of not putting a sub-SELECT within '()' characters") != -1, true, resp.json.error);
+
+"success"

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -339,6 +339,7 @@ $(eval $(call mldb_unit_test,MLDB-1500-transpose-query.js,,manual)) # awaiting f
 $(eval $(call include_sub_make,MLDB-1398-plugin))
 $(eval $(call mldb_unit_test,MLDB-1398-plugin-library-dependency.js,MLDB-1398-plugin))
 $(eval $(call mldb_unit_test,MLDB-1554-string-agg.js))
+$(eval $(call mldb_unit_test,MLDB-1567-empty-literal.js))
 
 $(eval $(call test,MLDB-1360-sparse-mutable-multithreaded-insert,mldb,boost))
 


### PR DESCRIPTION
This also improves the error message for when table expressions are mis-parsed to be more helpful to the user.
