### PR TITLE
Fixed use of context in optimization of IN (KEYS OF ...) (MLDB-1563)

### DIFF
--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -996,7 +996,8 @@ generateRowsWhere(const SqlBindingScope & scope,
                     && unbound.wildcards.empty()) {
                     //cerr << "*** rowName() IN (constant set expr)" << endl;
 
-                    SqlExpressionParamScope paramScope;
+                    SqlExpressionParamScope paramScope
+                        (const_cast<SqlBindingScope &>(scope));
 
                     auto boundSet = inExpression->setExpr->bind(paramScope);
                     auto matrixView = this->getMatrixView();

--- a/sql/binding_contexts.h
+++ b/sql/binding_contexts.h
@@ -184,11 +184,20 @@ struct SqlExpressionWhenScope: public ReadThroughBindingContext {
     are passed in after binding but are constant for each query execution.
 */
 
-struct SqlExpressionParamScope: public SqlBindingScope {
+struct SqlExpressionParamScope: public ReadThroughBindingContext {
 
-    struct RowScope: public SqlRowScope {
+    SqlExpressionParamScope(SqlBindingScope & outer)
+        : ReadThroughBindingContext(outer)
+    {
+    }
+
+    // This row scope initializes the inner scope with itself; it should
+    // never be used unless we are in a correlated sub-select in which
+    // case we will need to thread the outer scope through.
+    struct RowScope: public ReadThroughBindingContext::RowContext {
         RowScope(const BoundParameters & params)
-            : params(params)
+            : ReadThroughBindingContext::RowContext(*this),
+              params(params)
         {
         }
 

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -2236,10 +2236,29 @@ getChildren() const
 {   
     std::vector<std::shared_ptr<SqlExpression> > res = args;
    
-    if (extract)
-        res.push_back(extract);
+    // We don't include extract here as the variables referred to
+    // must be satisfied internally, so it's really an internal
+    // part of the expression not a child expression.
 
     return res;
+}
+
+std::map<ScopedName, UnboundVariable>
+FunctionCallWrapper::
+variableNames() const
+{
+    std::map<ScopedName, UnboundVariable> result;
+    
+    for (auto & c: args) {
+        auto childVars = (*c).variableNames();
+        for (auto & cv: childVars) {
+            result[cv.first].merge(std::move(cv.second));
+        }
+    }
+
+    // We don't include the extract values here
+    
+    return result;
 }
 
 std::map<ScopedName, UnboundFunction>

--- a/sql/sql_expression_operations.h
+++ b/sql/sql_expression_operations.h
@@ -493,7 +493,11 @@ struct FunctionCallWrapper: public SqlRowExpression {
     virtual std::vector<std::shared_ptr<SqlExpression> > getChildren() const;
     virtual bool isConstant() const { return false; } // TODO: not always
 
-    std::map<ScopedName, UnboundFunction> functionNames() const;
+    virtual std::map<ScopedName, UnboundVariable>
+    variableNames() const override;
+
+    virtual std::map<ScopedName, UnboundFunction>
+    functionNames() const override;
 
 private:
 

--- a/testing/MLDB-1563-keys-values-of.js
+++ b/testing/MLDB-1563-keys-values-of.js
@@ -1,0 +1,64 @@
+// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+var dataset = mldb.createDataset({type:'sparse.mutable',id:'test'});
+
+var ts = new Date("2015-01-01");
+
+var row = 0;
+
+function recordExample(who, what, how)
+{
+    dataset.recordRow(row++, [ [ "who", who, ts ], ["what", what, ts], ["how", how, ts] ]);
+}
+
+recordExample("mustard", "moved", "kitchen");
+recordExample("plum", "moved", "kitchen");
+recordExample("mustard", "stabbed", "plum");
+recordExample("mustard", "killed", "plum");
+recordExample("plum", "died", "stabbed");
+
+dataset.commit()
+
+var resp = mldb.put("/v1/functions/identity", {
+    "type": "sql.expression",
+    "params": {
+        "expression": "input"
+    }
+});
+
+mldb.log(resp);
+
+// If we can't find the identity() function, we still have the bug
+var resp = mldb.get("/v1/query", { q: 'SELECT * FROM test WHERE rowName() IN (KEYS OF identity({input: {"1": 1}})[input])' });
+
+plugin.log(resp.json);
+
+assertEqual(resp.responseCode, 200, "Error executing query");
+
+expected = [
+   {
+      "columns" : [
+         [ "who", "plum", "2015-01-01T00:00:00Z" ],
+         [ "what", "moved", "2015-01-01T00:00:00Z" ],
+         [ "how", "kitchen", "2015-01-01T00:00:00Z" ]
+      ],
+      "rowHash" : "b91445ce692f0ce5",
+      "rowName" : 1
+   }
+];
+
+assertEqual(mldb.diff(expected, resp.json, false /* strict */), {},
+            "Query 2 output was not the same as expected output");
+
+"success"

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -340,6 +340,7 @@ $(eval $(call include_sub_make,MLDB-1398-plugin))
 $(eval $(call mldb_unit_test,MLDB-1398-plugin-library-dependency.js,MLDB-1398-plugin))
 $(eval $(call mldb_unit_test,MLDB-1554-string-agg.js))
 $(eval $(call mldb_unit_test,MLDB-1567-empty-literal.js))
+$(eval $(call mldb_unit_test,MLDB-1563-keys-values-of.js))
 
 $(eval $(call test,MLDB-1360-sparse-mutable-multithreaded-insert,mldb,boost))
 


### PR DESCRIPTION
This fixes the issue whereby we couldn't find functions inside the rowName() IN (KEYS OF ...) expression when it hit the optimized path for rowName().