### PR TITLE
MLDB-1538 threadpool

### DIFF
--- a/base/testing/thread_pool_test.cc
+++ b/base/testing/thread_pool_test.cc
@@ -25,6 +25,21 @@
 using namespace std;
 using namespace Datacratic;
 
+BOOST_AUTO_TEST_CASE (thread_pool_idle_cpu_usage)
+{
+    ThreadPool threadPool(32);
+    // let it start up and settle down
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    ML::Timer timer;
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    double elapsedCpu = timer.elapsed_cpu();
+    double elapsedWall = timer.elapsed_wall();
+    double cores = elapsedCpu / elapsedWall;
+    cerr << "idle thread pool used " << cores * 100
+         << "% cores" << endl;
+    BOOST_CHECK_LE(cores, 0.01);
+}
+
 BOOST_AUTO_TEST_CASE (thread_pool_startup_shutdown_one_job)
 {
     ThreadPool threadPool(1);
@@ -468,3 +483,4 @@ BOOST_AUTO_TEST_CASE(PushPopSteal) {
 BOOST_AUTO_TEST_CASE(PushPopStealWithWraparound) {
     TestPushPopSteal(std::numeric_limits<uint_fast32_t>::max() - 10 /* top and bottom of empty queue */);
 }
+

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -15,7 +15,7 @@
 
 namespace Datacratic {
 
-typedef std::function<void ()> ThreadJob;
+typedef std::function<void () noexcept> ThreadJob;
 
 /** Return the number of CPUs in the system. */
 int numCpus();
@@ -34,6 +34,23 @@ struct ThreadPool {
     ThreadPool(int numThreads);
     ~ThreadPool();
 
+    /** Add the given job to the thread pool.
+
+        The job MUST NOT throw an exception; any exception thrown within the
+        job WILL CRASH THE PROGRAM.  (The lambda will be marked noexcept at
+        a later date).
+
+        The job may either:
+        1.  Be run before the add() function terminates
+        2.  Be enqueued and run later
+
+        If there is an exception setting the job up to run (eg, out of memory
+        allocating an object), then the exception will be returned from this
+        function and will NOT have run.
+
+        If this function returns, the job WILL be eventually run, or has
+        already been run.
+    */
     void add(ThreadJob job);
 
     void waitForAll() const;


### PR DESCRIPTION
Two improvements to the thread pool:

1.  We are more aggressive at backing off busy stealing of work when there is no more work to do, to reduce idle CPU usage (plus test): MLDB-1538
2.  We document, and enforce, a no job exception policy for jobs submitted to the thread pool: MLDB-1532.  Note that the abstractions built on the thread pool, like parallelMap, still return exceptions; it's just that the jobs they launch catch and track them internally.
