### PR TITLE
Test and fix for thread jobs disappearing with thread exit (MLDB-1579)

### DIFF
--- a/base/thread_pool.cc
+++ b/base/thread_pool.cc
@@ -569,6 +569,11 @@ struct ThreadPool::Itl: public std::enable_shared_from_this<ThreadPool::Itl> {
     {
         if (shutdown)
             return;
+
+        // Finish all the jobs first, otherwise they will simply
+        // disappear.
+        while (runMine(*thread)) ;
+
         ExcAssert(thread);
         std::unique_lock<std::mutex> guard(queuesMutex);
         if (shutdown)


### PR DESCRIPTION
If we created a thread, submitted jobs, and then the thread exited before we had a chance to run the jobs, those jobs would be lost.  Instead, when a thread exits we wait for its queue to empty before doing so.

This fixes the issue with some tests in pro hanging on exit.

The test failed before the fix was made.