### PR TITLE
Explain std::bad_alloc message (MLDB-1355)

### DIFF
--- a/arch/exception.cc
+++ b/arch/exception.cc
@@ -80,6 +80,9 @@ std::string getExceptionString()
         JML_TRACE_EXCEPTIONS(false);
         throw;
     }
+    catch (const std::bad_alloc & exc) {
+        return "Out of memory (std::bad_alloc)";
+    }
     catch (const std::exception & exc) {
         return exc.what();
     }

--- a/http/http_exception.cc
+++ b/http/http_exception.cc
@@ -24,6 +24,14 @@ void rethrowHttpException(int httpCode, const Utf8String & message, Any details)
         details2["context"]["details"] = jsonEncode(http.details);
         details2["context"]["error"] = http.message;
         throw HttpReturnException(httpCode == -1 ? http.httpCode : httpCode, message, details2);
+    } catch (const std::bad_alloc & exc) {
+        Json::Value details2 = jsonEncode(details);
+        details2["context"]["error"]
+            = "Out of memory.  A memory allocation failed when performing "
+            "the operation.  Consider retrying with a smaller amount of data "
+            "or running on a machine with more memory.  "
+            "(std::bad_alloc)";
+        throw HttpReturnException(httpCode == -1 ? 400 : httpCode, message, details2);
     } catch (const std::exception & exc) {
         Json::Value details2 = jsonEncode(details);
         details2["context"]["error"] = exc.what();

--- a/rest/rest_request_router.cc
+++ b/rest/rest_request_router.cc
@@ -1007,6 +1007,8 @@ Json::Value extractException(const std::exception & exc, int defaultCode)
 {
     const HttpReturnException * http
         = dynamic_cast<const HttpReturnException *>(&exc);
+    const std::bad_alloc * balloc
+        = dynamic_cast<const std::bad_alloc *>(&exc);
 
     Json::Value val;
     val["error"] = exc.what();
@@ -1015,7 +1017,13 @@ Json::Value extractException(const std::exception & exc, int defaultCode)
         val["httpCode"] = http->httpCode;
         if (!http->details.empty())
             val["details"] = jsonEncode(http->details);
-    } else {
+    } else if (balloc) {
+        val["error"] = "Out of memory.  A memory allocation failed when performing "
+            "the operation.  Consider retrying with a smaller amount of data "
+            "or running on a machine with more memory.  "
+            "(std::bad_alloc)";
+    }
+    else {
         val["httpCode"] = defaultCode;
     }
     

--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -2432,6 +2432,24 @@ BoundFunction flatten(const std::vector<BoundSqlExpression> & args)
 
 static RegisterBuiltin registerFlatten(flatten, "flatten");
 
+// Test function that fails due to a std::bad_alloc on memory allocation
+BoundFunction fail_memory_allocation(const std::vector<BoundSqlExpression> & args)
+{
+    // Return the result indexed on a single dimension
+    auto outputInfo = std::make_shared<UnknownRowValueInfo>();
+
+    return {[=] (const std::vector<ExpressionValue> & args,
+                 const SqlRowScope & scope) -> ExpressionValue
+            {
+                throw std::bad_alloc();
+            },
+            outputInfo
+        };
+}
+
+static RegisterBuiltin
+registerFailMemoryAllocation(fail_memory_allocation, "_fail_memory_allocation");
+
 
 } // namespace Builtins
 } // namespace MLDB

--- a/testing/MLDB-1355-explain-bad-alloc.js
+++ b/testing/MLDB-1355-explain-bad-alloc.js
@@ -1,0 +1,78 @@
+// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+// MLDB-1010
+// Check the error message for std::bad_alloc
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    plugin.log("expected", val);
+    plugin.log("received", expr);
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+function assertContains(str, val, msg)
+{
+    if (str.indexOf(val) != -1)
+        return;
+
+    plugin.log("expected", val);
+    plugin.log("received", str);
+
+    throw "Assertion failure: " + msg + ": string '"
+        + str + "' does not contain '" + val + "'";
+}
+
+var dataset = mldb.createDataset({type:'sparse.mutable',id:'test'});
+
+var ts = new Date("2015-01-01");
+
+var row = 0;
+
+function recordExample(who, what, how)
+{
+    dataset.recordRow(row++, [ [ "who", who, ts ], ["what", what, ts], ["how", how, ts] ]);
+}
+
+recordExample("mustard", "moved", "kitchen");
+recordExample("plum", "moved", "kitchen");
+recordExample("mustard", "stabbed", "plum");
+recordExample("mustard", "killed", "plum");
+recordExample("plum", "died", "stabbed");
+
+dataset.commit()
+
+
+var resp = mldb.get("/v1/query", { q: 'select _fail_memory_allocation()' });
+
+mldb.log(resp.json);
+
+assertEqual(resp.responseCode, 400);
+assertContains(resp.json.details.context.error, "Out of memory");
+
+// Check it works in the context of a table query
+
+var resp = mldb.get("/v1/query", { q: 'select *, _fail_memory_allocation() from test' });
+
+mldb.log(resp.json);
+
+assertEqual(resp.responseCode, 400);
+assertContains(resp.json.details.context.error, "Out of memory");
+
+
+// Check that it also works when setting up a join
+var resp = mldb.get("/v1/query", { q: 'select * from test as x join test as y on _fail_memory_allocation()' });
+
+mldb.log(resp.json);
+
+assertEqual(resp.responseCode, 400);
+assertContains(resp.json.details.context.error, "Out of memory");
+
+
+"success"

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -348,4 +348,4 @@ $(eval $(call mldb_unit_test,MLDB-1563-keys-values-of.js))
 
 $(eval $(call test,MLDB-1360-sparse-mutable-multithreaded-insert,mldb,boost))
 $(eval $(call mldb_unit_test,MLDBFB-440_error_on_ds_wo_cols.py))
-
+$(eval $(call mldb_unit_test,MLDB-1355-explain-bad-alloc.js))


### PR DESCRIPTION
More friendly error messages when out of memory:

```javascript
--------------------------[Exception thrown]---------------------------
time:   2016-04-28T21:11:04Z
type:   std::bad_alloc
pid:    66164; tid: 66165
what:   std::bad_alloc

2016-04-28 17:11:04.096 javascript {
   "details" : {
      "context" : {
         "error" : "Out of memory.  A memory allocation failed when performing the operation.  Consider retrying with a smaller amount of data or running on a machine with more memory.  (std::bad_alloc)"
      },
      "functionArgs" : [],
      "functionName" : "_fail_memory_allocation"
   },
   "error" : "Executing builtin function _fail_memory_allocation: Out of memory (std::bad_alloc)",
   "httpCode" : 400
}
```