### PR TITLE
Allow space between COLUMN EXPR and ( to be optional (MLDB-1590)

### DIFF
--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -1966,7 +1966,8 @@ parse(ML::Parse_Context & context, bool allowUtf8)
 {
     ML::Parse_Context::Hold_Token capture(context);
 
-    if (matchKeyword(context, "COLUMN EXPR (")) {
+    if (matchKeyword(context, "COLUMN EXPR (")
+        || matchKeyword(context, "COLUMN EXPR(")) {
         
         // Components
         // - select: value to select as column; row expression

--- a/testing/sql_expression_test.cc
+++ b/testing/sql_expression_test.cc
@@ -123,6 +123,25 @@ BOOST_AUTO_TEST_CASE(test_column_expression)
         cerr << parsed->print() << endl;
     }
 
+    {
+        // MLDB-1590
+        auto parsed = SqlRowExpression::parse
+            ("COLUMN EXPR(ORDER BY count(values()) DESC LIMIT 1000)");
+    
+        cerr << parsed->print() << endl;
+    }
+
+    {
+        auto parsed = SqlRowExpression::parse
+            ("COLUMN EXPR(WHERE (rowCount() > 100) ORDER BY rowCount()DESC LIMIT 1000)");
+        cerr << parsed->print() << endl;
+    }
+
+    {
+        auto parsed = SqlRowExpression::parse
+            ("COLUMN EXPR(WHERE rowCount() > 100 ORDER BY rowCount() DESC LIMIT 1000)");
+        cerr << parsed->print() << endl;
+    }
 }
 
 


### PR DESCRIPTION
Fixes issues with COLUMN EXPR(...) that users have encountered.
