### PR TITLE
Fixed tabular dataset getRowXXX limit/offset (MLDB-1619)

### DIFF
--- a/plugins/tabular_dataset.cc
+++ b/plugins/tabular_dataset.cc
@@ -368,13 +368,15 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
     virtual std::vector<RowName>
     getRowNames(ssize_t start = 0, ssize_t limit = -1) const
     {
-        ExcAssertEqual(start, 0);
-        ExcAssertEqual(limit, -1);
-
         std::vector<RowName> result;
         result.reserve(rowCount);
 
+        size_t n = 0;
         for (auto & c: chunks) {
+            if (n++ < start)
+                continue;
+            if (limit != -1 && n > start + limit)
+                break;
             result.insert(result.end(), c.rowNames.begin(), c.rowNames.end());
         }
 
@@ -384,12 +386,14 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
     virtual std::vector<RowHash>
     getRowHashes(ssize_t start = 0, ssize_t limit = -1) const
     {
-        ExcAssertEqual(start, 0);
-        ExcAssertEqual(limit, -1);
-
         std::vector<RowHash> result;
 
+        size_t n = 0;
         for (auto & i: rowIndex) {
+            if (n++ < start)
+                continue;
+            if (limit != -1 && n > start + limit)
+                break;
             result.emplace_back(i.first);
         }
 

--- a/testing/MLDB-1597-regression.py
+++ b/testing/MLDB-1597-regression.py
@@ -176,7 +176,7 @@ class Mldb1597Test(MldbUnitTest):
 
 
         # all of these permutations should either work or have clear error messages
-        for l in ["ds.c", "ds.d", "ds.e", "ds.r", "ds.p"]:
+        for l in ["idonotexist", "ds.c", "ds.d", "ds.e", "ds.r", "ds.p"]:
             for a in ["dt", "bdt", "glz_linear"]:
                 for f in [
                     ["ds.b_ratio"],


### PR DESCRIPTION
Fixes the issue identified in MLDB-1619, which was caused by the tabular dataset assuming that offset=0 and limit=-1 for all queries.