### PR TITLE
MLDB-1631 join transpose where rowname

### DIFF
--- a/container_files/public_html/doc/builtin/sql/ValueExpression.md
+++ b/container_files/public_html/doc/builtin/sql/ValueExpression.md
@@ -409,11 +409,19 @@ More details on the [Binomial proportion confidence interval Wikipedia page](htt
   system locale.
 - `regex_replace(string, regex, replacement)` will return the given string with
   matches of the `regex` replaced by the `replacement`.  Perl-style regular
-  expressions are supported.
+  expressions are supported.  It is normally preferable that the `regex` be a
+  constant string; performance will be very poor if not as the regular expression
+  will need to be recompiled on every application.
 - `regex_match(string, regex)` will return true if the *entire* string matches
   the regex, and false otherwise.  If `string` is null, then null will be returned.
+  It is normally preferable that the `regex` be a
+  constant string; performance will be very poor if not as the regular expression
+  will need to be recompiled on every application.
 - `regex_search(string, regex)` will return true if *any portion of * `string` matches
   the regex, and false otherwise.  If `string` is null, then null will be returned.
+  It is normally preferable that the `regex` be a
+  constant string; performance will be very poor if not as the regular expression
+  will need to be recompiled on every application.
 
 ### Timestamp functions
 

--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -979,97 +979,180 @@ BoundFunction implicit_cast(const std::vector<BoundSqlExpression> & args)
 
 static RegisterBuiltin registerImplicitCast(implicit_cast, "implicit_cast");
 
+/** Helper class that takes care of regular expression application whether
+    it's a constant value or not.
+*/
+struct RegexHelper {
+    RegexHelper(BoundSqlExpression expr_)
+        : expr(std::move(expr_))
+    {
+        if (expr.metadata.isConstant) {
+            isPrecompiled = true;
+            precompiled = compile(expr.constantValue());
+        }
+        else isPrecompiled = false;
+    }
+
+    boost::u32regex compile(const ExpressionValue & val) const
+    {
+        Utf8String regexStr;
+        try {
+            regexStr = val.toUtf8String();
+        } JML_CATCH_ALL {
+            rethrowHttpException
+                (400, "Error when extracting regex from argument '"
+                 + expr.expr->surface + "': " + ML::getExceptionString()
+                 + ".  Regular expressions need to be strings.",
+                 "expr", expr,
+                 "value", val);
+        }
+        try {
+            return boost::make_u32regex(regexStr.rawData());
+        } JML_CATCH_ALL {
+            rethrowHttpException
+                (400, "Error when compiling regex '"
+                 + regexStr + "' from expression " + expr.expr->surface + "': "
+                 + ML::getExceptionString()
+                 + ".  Regular expressions must adhere to Perl-style "
+                 + "regular expression syntax.",
+                 "expr", expr,
+                 "value", val);
+        }
+    }
+
+    /// The expression that the regex came from, to help with error messages
+    BoundSqlExpression expr;
+
+    /// The pre-compiled version of that expression, when it's constant
+    boost::u32regex precompiled;
+
+    /// Is it actually constant (and precompiled), or computed on the fly?
+    bool isPrecompiled;
+
+    virtual ExpressionValue apply(const std::vector<ExpressionValue> & args,
+                                  const SqlRowScope & scope,
+                                  const boost::u32regex & regex) const = 0;
+
+    ExpressionValue operator () (const std::vector<ExpressionValue> & args,
+                                 const SqlRowScope & scope)
+    {
+        if (isPrecompiled) {
+            return apply(args, scope, precompiled);
+        }
+        else {
+            return apply(args, scope, compile(args.at(1)));
+        }
+    }
+};
+
+struct ApplyRegexReplace: public RegexHelper {
+    ApplyRegexReplace(BoundSqlExpression e)
+        : RegexHelper(std::move(e))
+    {
+    }
+
+    virtual ExpressionValue apply(const std::vector<ExpressionValue> & args,
+                                  const SqlRowScope & scope,
+                                  const boost::u32regex & regex) const
+    {
+        ExcAssertEqual(args.size(), 3);
+
+        if (args[0].empty() || args[1].empty() || args[2].empty())
+            return ExpressionValue::null(calcTs(args[0], args[1], args[2]));
+
+        std::basic_string<char32_t> matchStr = args[0].toWideString();
+        std::basic_string<char32_t> replacementStr = args[2].toWideString();
+
+        std::basic_string<int32_t>
+            matchStr2(matchStr.begin(), matchStr.end());
+        std::basic_string<int32_t>
+            replacementStr2(replacementStr.begin(), replacementStr.end());
+
+        auto result = boost::u32regex_replace(matchStr2, regex, replacementStr2);
+        std::basic_string<char32_t> result2(result.begin(), result.end());
+
+        return ExpressionValue(result2, calcTs(args[0], args[1], args[2]));
+    }
+};
+
 BoundFunction regex_replace(const std::vector<BoundSqlExpression> & args)
 {
     // regex_replace(string, regex, replacement)
     checkArgsSize(args.size(), 3);
 
-    Utf8String regexStr = args[1].constantValue().toUtf8String();
-
-    boost::u32regex regex = boost::make_u32regex(regexStr.rawData());
-
-    return {[=] (const std::vector<ExpressionValue> & args,
-                 const SqlRowScope & scope) -> ExpressionValue
-            {
-                ExcAssertEqual(args.size(), 3);
-
-                if (args[0].empty() || args[2].empty())
-                    return ExpressionValue::null(calcTs(args[0], args[1], args[2]));
-
-                std::basic_string<char32_t> matchStr = args[0].toWideString();
-                std::basic_string<char32_t> replacementStr = args[2].toWideString();
-
-                std::basic_string<int32_t>
-                    matchStr2(matchStr.begin(), matchStr.end());
-                std::basic_string<int32_t>
-                    replacementStr2(replacementStr.begin(), replacementStr.end());
-
-                auto result = boost::u32regex_replace(matchStr2, regex, replacementStr2);
-                std::basic_string<char32_t> result2(result.begin(), result.end());
-
-                return ExpressionValue(result2, calcTs(args[0], args[1], args[2]));
-            },
+    return {ApplyRegexReplace(args[1]),
             std::make_shared<Utf8StringValueInfo>()};
 }
 
 static RegisterBuiltin registerRegexReplace(regex_replace, "regex_replace");
 
+struct ApplyRegexMatch: public RegexHelper {
+    ApplyRegexMatch(BoundSqlExpression e)
+        : RegexHelper(std::move(e))
+    {
+    }
+
+    virtual ExpressionValue apply(const std::vector<ExpressionValue> & args,
+                                  const SqlRowScope & scope,
+                                  const boost::u32regex & regex) const
+    {
+        // TODO: should be able to pass utf-8 string directly in
+
+        ExcAssertEqual(args.size(), 2);
+
+        if (args[0].empty() || args[1].empty())
+            return ExpressionValue::null(calcTs(args[0], args[1]));
+
+        std::basic_string<char32_t> matchStr = args[0].toWideString();
+        
+        auto result = boost::u32regex_match(matchStr.begin(), matchStr.end(),
+                                            regex);
+        return ExpressionValue(result, calcTs(args[0], args[1]));
+    }
+};
+                     
 BoundFunction regex_match(const std::vector<BoundSqlExpression> & args)
 {
     // regex_match(string, regex)
     checkArgsSize(args.size(), 2);
 
-    Utf8String regexStr = args[1].constantValue().toUtf8String();
-
-    boost::u32regex regex = boost::make_u32regex(regexStr.rawData());
-
-    return {[=] (const std::vector<ExpressionValue> & args,
-                 const SqlRowScope & scope) -> ExpressionValue
-            {
-                // TODO: should be able to pass utf-8 string directly in
-
-                ExcAssertEqual(args.size(), 2);
-
-                if (args[0].empty())
-                    return ExpressionValue::null(calcTs(args[0], args[1]));
-
-                std::basic_string<char32_t> matchStr = args[0].toWideString();
-
-                auto result = boost::u32regex_match(matchStr.begin(), matchStr.end(),
-                                                    regex);
-                return ExpressionValue(result, calcTs(args[0], args[1]));
-            },
+    return {ApplyRegexMatch(args[1]),
             std::make_shared<BooleanValueInfo>()};
 }
 
 static RegisterBuiltin registerRegexMatch(regex_match, "regex_match");
 
+struct ApplyRegexSearch: public RegexHelper {
+    ApplyRegexSearch(BoundSqlExpression e)
+        : RegexHelper(std::move(e))
+    {
+    }
+
+    virtual ExpressionValue apply(const std::vector<ExpressionValue> & args,
+                                  const SqlRowScope & scope,
+                                  const boost::u32regex & regex) const
+    {
+        // TODO: should be able to pass utf-8 string directly in
+
+        ExcAssertEqual(args.size(), 2);
+
+        if (args[0].empty() || args[1].empty())
+            return ExpressionValue::null(calcTs(args[0], args[1]));
+
+        std::basic_string<char32_t> searchStr = args[0].toWideString();
+        
+        auto result = boost::u32regex_search(searchStr.begin(), searchStr.end(),
+                                            regex);
+        return ExpressionValue(result, calcTs(args[0], args[1]));
+    }
+};
+                     
 BoundFunction regex_search(const std::vector<BoundSqlExpression> & args)
 {
     // regex_search(string, regex)
     checkArgsSize(args.size(), 2);
 
-    Utf8String regexStr = args[1].constantValue().toUtf8String();
-
-    boost::u32regex regex = boost::make_u32regex(regexStr.rawData());
-
-    return {[=] (const std::vector<ExpressionValue> & args,
-                 const SqlRowScope & scope) -> ExpressionValue
-            {
-                // TODO: should be able to pass utf-8 string directly in
-
-                ExcAssertEqual(args.size(), 2);
-
-                if (args[0].empty())
-                    return ExpressionValue::null(calcTs(args[0], args[1]));
-
-                std::basic_string<char32_t> searchStr = args[0].toWideString();
-
-                auto result
-                    = boost::u32regex_search(searchStr.begin(), searchStr.end(),
-                                             regex);
-                return ExpressionValue(result, calcTs(args[0], args[1]));
-            },
+    return {ApplyRegexSearch(args[1]),
             std::make_shared<BooleanValueInfo>()};
 }
 

--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -117,10 +117,16 @@ ExpressionValue
 BoundSqlExpression::
 constantValue() const
 {
-    if (!metadata.isConstant)
-        throw HttpReturnException(400, "Attempt to extract constant from non-constant expression",
-                                  "surface", expr->surface,
-                                  "ast", expr->print());
+    if (!metadata.isConstant) {
+        cerr << "surface = " << expr->surface << endl;
+        throw HttpReturnException
+            (400, "Attempt to extract constant from non-constant expression.  "
+             "One of the elements of the expression requires a constant "
+             "value, for example the text of a regular expression, but was "
+             "actually a non-constant expression: '" + expr->surface + "'",
+             "surface", expr->surface,
+             "ast", expr->print());
+    }
 
     // This is only OK to do here because by setting isConstant in its metadata,
     // the expression is guaranteeing it will never access its context.

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -814,6 +814,7 @@ struct BinaryOpHelper {
                                 std::placeholders::_1,
                                 std::placeholders::_2,
                                 GET_LATEST);
+        result.expr = expr->shared_from_this();
 
         return result;
     }

--- a/testing/MLDB-1631-join-transpose-where-rowname.js
+++ b/testing/MLDB-1631-join-transpose-where-rowname.js
@@ -1,0 +1,36 @@
+// This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+var resp = mldb.query('select * ' + 
+                      'from (select \'this is toy story time\' as title) as y ' +
+                      'join transpose((select {"toy story": 1, "terminator": 5} as * ' +
+                      'named \'rating\')) as x ' +
+                      'where regex_match(y.title, \'.*\'+x.rowName()+\'.*\')');
+
+mldb.log(resp);
+
+var expected = [
+   {
+      "columns" : [
+         [ "x.rating", 1, "-Inf" ],
+         [ "y.title", "this is toy story time", "-Inf" ]
+      ],
+      "rowHash" : "d6855a03c5f5789a",
+      "rowName" : "[result]-[toy story]"
+   }
+];
+
+assertEqual(resp, expected);
+
+"success"
+

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -353,3 +353,5 @@ $(eval $(call test,MLDB-1360-sparse-mutable-multithreaded-insert,mldb,boost))
 $(eval $(call mldb_unit_test,MLDBFB-440_error_on_ds_wo_cols.py))
 $(eval $(call mldb_unit_test,MLDBFB-509_pushed_non_printable_char_cant_query.py))
 $(eval $(call mldb_unit_test,MLDB-1355-explain-bad-alloc.js))
+$(eval $(call mldb_unit_test,MLDB-1631-join-transpose-where-rowname.js))
+


### PR DESCRIPTION
Fixes two things:
- Segfault caused by binary operations not filling in the expression that they came from
- Refactor of regex builtins to allow a non-constant regex string
