### PR TITLE
MLDB-1629 fix nesting in column names within join

### DIFF
--- a/server/dataset_context.cc
+++ b/server/dataset_context.cc
@@ -311,9 +311,18 @@ doGetAllColumns(const Utf8String & tableName,
     auto filterColumnName = [&] (const ColumnName & inputColumnName)
         -> ColumnName
     {
-        if (!tableName.empty() && !childaliases.empty()
-            && !inputColumnName.startsWith(tableName)) {
-            return ColumnName();
+        if (!tableName.empty() && !childaliases.empty()) {
+            // We're in a join.  The columns will all be prefixed with their
+            // child table name, but we don't want to use that.
+            // eg, in x inner join y, we will have variables like
+            // x.a and y.b, but when we select them we want them to be
+            // like a and b.
+            if (!inputColumnName.startsWith(tableName)) {
+                return ColumnName();
+            }
+            // Otherwise, check if we need it
+            ColumnName result = keep(inputColumnName);
+            return std::move(result);
         }
 
         return keep(inputColumnName);

--- a/testing/MLDB-1235-temporal-aggregators.py
+++ b/testing/MLDB-1235-temporal-aggregators.py
@@ -439,11 +439,10 @@ class TemporalTest(MldbUnitTest):
                 ]
             )
 
-    @unittest.expectedFailure
     def test_mldbfb_516_aggregator_incorrect_with_join(self):
         ds = mldb.create_dataset({
-            'id' : 'ds_join',
-            'type' : 'beh.binary.mutable'
+            'id' : 'ds516',
+            'type' : 'sparse.mutable'
         })
         ds.record_row('user3', [['behA', 1, 11], ['conv', 1, 70],
                                 ['behB', 1, 14], ['behA', 1, 14]])
@@ -451,24 +450,26 @@ class TemporalTest(MldbUnitTest):
 
         ds = mldb.create_dataset({
             'id' : 'conv',
-            'type' : 'beh.mutable'
+            'type' : 'sparse.mutable'
         })
         ds.record_row('user3', [['ts', 70, 0]])
         ds.commit()
 
         res = mldb.query("""
-            SELECT temporal_count({ds_join.*}) AS *
-            FROM ds_join
+            SELECT temporal_count({ds516.*}) AS *
+            FROM ds516
         """)
+        mldb.log(res)
         self.assertTableResultEquals(res, [
             ['_rowName', 'behA', 'behB', 'conv'],
             ['user3', 2, 1, 1]
         ])
 
         res = mldb.query("""
-            SELECT temporal_count({ds_join.*}) AS *
-            FROM ds_join INNER JOIN conv ON ds_join.rowName() = conv.rowName()
+            SELECT temporal_count({ds516.* as *}) AS *
+            FROM ds516 INNER JOIN conv ON ds516.rowName() = conv.rowName()
         """)
+        mldb.log(res)
         self.assertTableResultEquals(res, [
             ['_rowName', 'behA', 'behB', 'conv'],
             ['[user3]-[user3]', 2, 1, 1]

--- a/testing/MLDB-180-basic-join.js
+++ b/testing/MLDB-180-basic-join.js
@@ -474,11 +474,29 @@ dataset7.recordRow("blah", [[ "k", 1, ts ]] );
 
 dataset7.commit()
 
+// Test that "table2.* as *" returns the right thing (non-prefixed names)
+expected = [
+   [ "_rowName", "x", "z" ],
+   [ "[blah]-[ex4]", 1, 2 ],
+   [ "[blah]-[ex5]", 2, 2 ],
+   [ "[blah]-[ex6]", null, 3 ],
+   [ "[x]-[ex4]", 1, 2 ],
+   [ "[x]-[ex5]", 2, 2 ],
+   [ "[x]-[ex6]", null, 3 ]
+];
+
+testQuery('SELECT table2.* as * FROM test7 as table1 JOIN test2 as table2',
+          expected);
+
 expected = [
    [ "_rowName", "table1.k", "table2.x", "table2.z" ],
    [ "[x]-[ex4]", 1, 1, 2 ],
    [ "[x]-[ex5]", 1, 2, 2 ],
    [ "[x]-[ex6]", 1, null, 3 ]];
+
+// This one matches nothing, because the keys of table2.* all start with table2.
+testQuery('SELECT * FROM test7 as table1 JOIN test2 as table2 where table1.rowName() IN (KEYS OF ({table2.*}))',
+          [["_rowName"]]);
 
 testQuery('SELECT * FROM test7 as table1 JOIN test2 as table2 where table1.rowName() IN (KEYS OF ({table2.* as *}))',
           expected);


### PR DESCRIPTION
Fixes problems with the wildcard matching and prefix replacement from MLDB-1486.
