### PR TITLE
Allow empty path elements (MLDB-1635)

### DIFF
--- a/sql/path.cc
+++ b/sql/path.cc
@@ -92,7 +92,7 @@ parsePartial(const char * & p, const char * e)
     ExcAssertLessEqual((void *)p, (void *)e);
 
     if (p == e) {
-        throw HttpReturnException(400, "Parsing empty string for path");
+        return PathElement();
     }
 
     if (*p == '\"') {
@@ -111,10 +111,6 @@ parsePartial(const char * & p, const char * e)
             if (c == '\"') {
                 if (ufirst == ulast || *ufirst != '\"') {
                     p = ufirst.base();
-                    if (result.empty()) {
-                        throw HttpReturnException(400, "Empty quoted path");
-                    }
-
                     return result;
                 }
                 result += '\"';
@@ -142,9 +138,8 @@ parsePartial(const char * & p, const char * e)
             }
         }
         size_t sz = start - p;
-        if (sz == 0) {
-            throw HttpReturnException(400, "Empty path");
-        }
+        if (sz == 0)
+            return PathElement();
         PathElement result(p, sz);
         p = start;
         return std::move(result);
@@ -279,6 +274,9 @@ Utf8String
 PathElement::
 toEscapedUtf8String() const
 {
+    if (empty())
+        return "\"\"";
+
     const char * d = data();
     size_t l = dataLength();
 
@@ -525,8 +523,6 @@ void
 PathElement::
 initString(T && str)
 {
-    if (str.empty())
-        throw HttpReturnException(400, "Attempt to create empty PathElement");
     ExcAssertEqual(strlen(rawData(str)), rawLength(str));
     initStringUnchecked(std::move(str));
 }
@@ -560,8 +556,6 @@ void
 PathElement::
 initChars(const char * str, size_t len)
 {
-    if (len == 0)
-        throw HttpReturnException(400, "Attempt to create empty PathElement");
     words[0] = words[1] = words[2] = 0;
     if (len <= INTERNAL_BYTES - 1) {
         complex_ = 0;
@@ -715,10 +709,12 @@ Path::
 toUtf8String() const
 {
     Utf8String result;
+    bool first = true;
     for (auto & c: *this) {
-        if (!result.empty())
+        if (!first)
             result += '.';
         result += c.toEscapedUtf8String(); 
+        first = false;
     }
     return result;
 }
@@ -751,8 +747,12 @@ parse(const char * str, size_t len)
         }
     }
 
+    if (str != e && e[-1] == '.') {
+        result.emplace_back();
+    }
+
     if (result.empty()) {
-        throw HttpReturnException(400, "Path were empty",
+        throw HttpReturnException(400, "Path was empty",
                                   "val", Utf8String(str, len));
     }
     

--- a/sql/path.h
+++ b/sql/path.h
@@ -354,9 +354,6 @@ struct Path: protected ML::compact_vector<PathElement, 2, uint32_t, false> {
     Path(It first, It last)
         : Base(first, last)
     {
-        for (PathElement & c: *this) {
-            ExcAssert(!c.empty());
-        }
     }
 
     static Path parse(const Utf8String & str);

--- a/sql/testing/path_test.cc
+++ b/sql/testing/path_test.cc
@@ -40,13 +40,6 @@ BOOST_AUTO_TEST_CASE(test_coord_constructor)
 
     vector<PathElement> coords2;
     coords2.push_back(coord1);
-
-    // Make sure we can't create a Path with an empty element
-    {
-        JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(auto coord = Path(coords2.begin(), coords2.end()),
-                          std::exception);
-    }
 }
 
 BOOST_AUTO_TEST_CASE(test_coord_printing)
@@ -91,11 +84,9 @@ BOOST_AUTO_TEST_CASE(test_coord_parsing)
 
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(PathElement::parse(""), ML::Exception);
         BOOST_CHECK_THROW(PathElement::parse("."), ML::Exception);
         BOOST_CHECK_THROW(PathElement::parse("\n"), ML::Exception);
         BOOST_CHECK_THROW(PathElement::parse("\""), ML::Exception);
-        BOOST_CHECK_THROW(PathElement::parse("\"\""), ML::Exception);
         BOOST_CHECK_THROW(PathElement::parse(".."), ML::Exception);
         BOOST_CHECK_THROW(PathElement::parse("\"x."), ML::Exception);
         BOOST_CHECK_THROW(PathElement::parse("\"x."), ML::Exception);
@@ -138,13 +129,34 @@ BOOST_AUTO_TEST_CASE(test_coords_parsing)
     }
 
     {
+        Path coords1 = Path::parse("..");
+        BOOST_CHECK_EQUAL(coords1.size(), 3);
+        BOOST_CHECK_EQUAL(coords1.toUtf8String(), "\"\".\"\".\"\"");
+    }
+
+    {
+        Path coords1 = Path::parse("\"\".\"\".\"\"");
+        BOOST_CHECK_EQUAL(coords1.size(), 3);
+        BOOST_CHECK_EQUAL(coords1.toUtf8String(), "\"\".\"\".\"\"");
+    }
+
+    {
+        Path coords1 = Path::parse(".");
+        BOOST_CHECK_EQUAL(coords1.size(), 2);
+        BOOST_CHECK_EQUAL(coords1.toUtf8String(), "\"\".\"\"");
+    }
+
+    {
+        Path coords1 = Path::parse("\"\".\"\"");
+        BOOST_CHECK_EQUAL(coords1.size(), 2);
+        BOOST_CHECK_EQUAL(coords1.toUtf8String(), "\"\".\"\"");
+    }
+
+    {
         JML_TRACE_EXCEPTIONS(false);
         BOOST_CHECK_THROW(Path::parse(""), ML::Exception);
-        BOOST_CHECK_THROW(Path::parse("."), ML::Exception);
         BOOST_CHECK_THROW(Path::parse("\n"), ML::Exception);
         BOOST_CHECK_THROW(Path::parse("\""), ML::Exception);
-        BOOST_CHECK_THROW(Path::parse("\"\""), ML::Exception);
-        BOOST_CHECK_THROW(Path::parse(".."), ML::Exception);
         BOOST_CHECK_THROW(Path::parse("\"x."), ML::Exception);
         BOOST_CHECK_THROW(Path::parse("\"x."), ML::Exception);
         BOOST_CHECK_THROW(Path::parse("x\"\""), ML::Exception);


### PR DESCRIPTION
Self explanatory... this allows for paths to contain empty elements, just like JSON (which allows empty keys).

