### PR TITLE
Allow joining on table expressions (eg, row_table) (MLDB-1616)

### DIFF
--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -119,12 +119,11 @@ struct JoinedDataset::Itl
     /// Mapping from the table column hash to output column name
     std::unordered_map<ColumnHash, ColumnName> leftColumns, rightColumns;
 
-    /// Datasets that were actually joined.  There will be a maximum of 31
-    /// of them, as any more will be sub-joined
-    std::vector<std::shared_ptr<Dataset> > datasets;
+    /// Structure used to implement operations from each table
+    TableOperations leftOps, rightOps;
 
-    /// Matrix view.  Length is the same as that of datasets.
-    std::vector<std::shared_ptr<MatrixView> > matrices;
+    /// Datasets on the left and right side
+    std::shared_ptr<Dataset> leftDataset, rightDataset;
 
     // is the dataset on the left a join too?
     bool isChainedJoin;
@@ -135,43 +134,79 @@ struct JoinedDataset::Itl
     Utf8String childAliases[JOIN_SIDE_MAX]; //Alias of the (direct) joined tables left and right
     std::vector<Utf8String> tableNames; //sub tables from both side + direct childs left and right
 
-    Itl(MldbServer * server, JoinedDatasetConfig joinConfig)
+    Itl(SqlBindingScope & scope,
+        std::shared_ptr<TableExpression> leftExpr,
+        BoundTableExpression left,
+        std::shared_ptr<TableExpression> rightExpr,
+        BoundTableExpression right,
+        std::shared_ptr<SqlExpression> on,
+        JoinQualification qualification)
     {
-        SqlExpressionMldbScope context(server);
-
-        // Create a context to get our datasets from
-        SqlExpressionMldbScope mldbContext(server);
-
-        // Obtain our datasets
-        BoundTableExpression left = joinConfig.left->bind(mldbContext);
-        BoundTableExpression right = joinConfig.right->bind(mldbContext);
-
         bool debug = false;
 
-        std::set<Utf8String> leftTables = joinConfig.left->getTableNames();
-        std::set<Utf8String> rightTables = joinConfig.right->getTableNames();
+        // vector to set
+        auto v2s = [] (std::vector<Utf8String> vec)
+            {
+                return std::set<Utf8String>(std::make_move_iterator(vec.begin()),
+                                            std::make_move_iterator(vec.end()));
+            };
+
+        std::set<Utf8String> leftTables = v2s(left.table.getChildAliases());
+        std::set<Utf8String> rightTables = v2s(right.table.getChildAliases());
 
         isChainedJoin = dynamic_cast<JoinedDataset*>(left.dataset.get()) != nullptr;
-        
-        datasets.emplace_back(left.dataset);
-        datasets.emplace_back(right.dataset);
 
-        matrices.emplace_back(left.dataset->getMatrixView());
-        matrices.emplace_back(right.dataset->getMatrixView());
+        if (!left.dataset) {
+            throw HttpReturnException
+                (400, "A materialized join must be between materialized "
+                 "datasets on both the left and the right side.  In practice, "
+                 "this means it must be a subselect, a transpose, a join or a "
+                 "dataset.  The dataset "
+                 "expression on the left side of the join ('"
+                 + leftExpr->surface
+                 + "') is not materialized.  You can make it so by using the "
+                 "transform procedure to record the output of the query into a "
+                 "dataset, and then using this dataset in the join");
+        }
+
+        if (!right.dataset) {
+            throw HttpReturnException
+                (400, "A materialized join must be between materialized "
+                 "datasets on both the left and the right side.  In practice, "
+                 "this means it must be a subselect, a transpose, a join or a "
+                 "dataset.  The dataset "
+                 "expression on the right side of the join ('"
+                 + rightExpr->surface
+                 + "') is not materialized.  You can make it so by using the "
+                 "transform procedure to record the output of the query into a "
+                 "dataset, and then using this dataset in the join");
+        }
+
+        leftOps = left.table;
+        rightOps = right.table;
+
+        leftDataset = left.dataset;
+        rightDataset = right.dataset;
 
         childAliases[JOIN_SIDE_LEFT] = left.asName;
         childAliases[JOIN_SIDE_RIGHT] = right.asName;
 
         tableNames = {left.asName, right.asName};
 
-        left.dataset->getChildAliases(tableNames);
-        right.dataset->getChildAliases(tableNames);
+        auto addAliases = [&] (std::vector<Utf8String> aliases)
+            {
+                tableNames.insert(tableNames.end(),
+                                  std::make_move_iterator(aliases.begin()),
+                                  std::make_move_iterator(aliases.end()));
+            };
 
-        left.dataset->getChildAliases(sideChildNames[JOIN_SIDE_LEFT]);
-        right.dataset->getChildAliases(sideChildNames[JOIN_SIDE_RIGHT]);
+        addAliases(leftOps.getChildAliases());
+        addAliases(rightOps.getChildAliases());
+
+        sideChildNames[JOIN_SIDE_LEFT]  = leftOps.getChildAliases();
+        sideChildNames[JOIN_SIDE_RIGHT] = rightOps.getChildAliases();
       
-        AnnotatedJoinCondition condition(joinConfig.left, joinConfig.right,
-                                         joinConfig.on, 
+        AnnotatedJoinCondition condition(leftExpr, rightExpr, on, 
                                          nullptr, //where
                                          debug);
 
@@ -179,10 +214,8 @@ struct JoinedDataset::Itl
             cerr << "Analyzed join condition: " << jsonEncode(condition) << endl;
 
         // Run the constant expression
-        auto boundConstant = condition.constantWhere->bind(context);
-        SqlRowScope scope;
-        ExpressionValue storage;
-        if (!boundConstant(scope, storage, GET_LATEST).isTrue())
+        ExpressionValue k = condition.constantWhere->constantValue();
+        if (!k.isTrue())
             return;
 
         if (!condition.crossWhere || condition.crossWhere->isConstant()) {
@@ -193,8 +226,8 @@ struct JoinedDataset::Itl
             
             // We can use a fast path, since we have simple non-filtered
             // equijoin
-            makeJoinConstantWhere(condition, context, left, right,
-                                  joinConfig.qualification);            
+            makeJoinConstantWhere(condition, scope, left, right,
+                                  qualification);            
 
         } else {
             // Complex join condition.  We need to generate the full set of
@@ -208,7 +241,7 @@ struct JoinedDataset::Itl
                     {
                         leftNameUtf8 += "-" + res->values.at(i).toUtf8String();
                     }                        
-
+                    
                     RowName leftName;
                     if (leftNameUtf8 != "")
                         leftName = RowName(leftNameUtf8);
@@ -229,15 +262,15 @@ struct JoinedDataset::Itl
                     throw HttpReturnException(400, "No parameters bound in");
                 };
 
-            PipelineElement::root(context)
-                ->join(joinConfig.left, joinConfig.right, joinConfig.on, joinConfig.qualification)
+            PipelineElement::root(scope)
+                ->join(leftExpr, left, rightExpr, right, on, qualification)
                 ->bind()
                 ->start(getParam)
                 ->takeAll(gotElement);
         }
 
         // Finally, the column indexes
-        for (auto & c: left.dataset->getColumnNames()) {
+        for (auto & c: leftDataset->getColumnNames()) {
             ColumnName newColumnName;
             if (!left.asName.empty())
                 newColumnName = ColumnName(left.asName) + c;
@@ -255,7 +288,7 @@ struct JoinedDataset::Itl
         }
 
         // Finally, the column indexes
-        for (auto & c: right.dataset->getColumnNames()) {
+        for (auto & c: rightDataset->getColumnNames()) {
             ColumnName newColumnName;
 
             if (!right.asName.empty())
@@ -314,7 +347,7 @@ struct JoinedDataset::Itl
 
     //Easiest case with constant Where
     void makeJoinConstantWhere(AnnotatedJoinCondition& condition,
-                               SqlExpressionMldbScope& context,
+                               SqlBindingScope& scope,
                                BoundTableExpression& left,
                                BoundTableExpression& right,
                                JoinQualification qualification)
@@ -360,10 +393,10 @@ struct JoinedDataset::Itl
                 queryExpression.clauses.push_back(rowExpression);
 
                 auto generator = dataset.queryBasic
-                (context, queryExpression, side.when, *sideCondition, side.orderBy,
+                (scope, queryExpression, side.when, *sideCondition, side.orderBy,
                  0, -1);
 
-                // Because we know that our outer context is an
+                // Because we know that our outer scope is an
                 // SqlExpressionMldbScope, we know that it takes an
                 // empty rowScope with nothing that depends on the current
                 // row.
@@ -596,32 +629,33 @@ struct JoinedDataset::Itl
         result.rowName = rowName;
         result.rowHash = rowName;
 
-        MatrixNamedRow leftRow, rightRow;
-
-        if (!row.leftName.empty())
-            leftRow = matrices[0]->getRow(row.leftName);
-
-        if (!row.rightName.empty())
-            rightRow = matrices[1]->getRow(row.rightName);
-        
-        /// This function copies columns from a sub-row to the result of
-        /// the function.
-        auto copyColumns = [&] (const MatrixNamedRow & row,
-                                const std::unordered_map<ColumnHash, ColumnName> & mapping)
+        auto doRow = [&] (const Dataset & dataset,
+                          const RowName & rowName,
+                          const std::unordered_map<ColumnHash, ColumnName> & mapping)
             {
-                for (auto & c: row.columns) {
-                    ColumnHash colHash = std::get<0>(c);
-                    auto it = mapping.find(colHash);
-                    if (it == mapping.end())
-                        continue;
-                    result.columns.emplace_back(it->second,
-                                                std::move(std::get<1>(c)),
-                                                std::get<2>(c));
-                }
-            };
+                ExpressionValue rowValue;
+                if (!rowName.empty())
+                    rowValue = dataset.getRowExpr(rowName);
 
-        copyColumns(leftRow, leftColumns);
-        copyColumns(rightRow, rightColumns);
+                auto onAtom = [&] (RowName & rowName,
+                                   CellValue & val,
+                                   Date ts)
+                {
+                    ColumnHash colHash = rowName;
+                    auto it = mapping.find(colHash);
+                    if (it != mapping.end()) {
+                        result.columns.emplace_back(it->second,
+                                                    std::move(val),
+                                                    ts);
+                    }
+                    return true;
+                };
+                
+                rowValue.forEachAtomDestructive(onAtom);
+            };                          
+
+        doRow(*leftDataset, row.leftName, leftColumns);
+        doRow(*rightDataset, row.rightName, rightColumns);
 
         return result;
 
@@ -685,7 +719,8 @@ struct JoinedDataset::Itl
                 MatrixColumn result;
 
                 // First, get the column
-                MatrixColumn column = std::move(dataset.getColumnIndex()->getColumn(columnName));
+                MatrixColumn column
+                    = dataset.getColumnIndex()->getColumn(columnName);
 
                 // Now for each row, find which index it's in
                 for (auto & r: column.rows) {
@@ -718,10 +753,10 @@ struct JoinedDataset::Itl
 
         if (it->second.bitmap == 1) {
             // on the left
-            result = doGetColumn(*datasets[0], leftRowIndex, it->second.childColumnName);
+            result = doGetColumn(*leftDataset, leftRowIndex, it->second.childColumnName);
         }
         else {
-            result = doGetColumn(*datasets[1], rightRowIndex, it->second.childColumnName);
+            result = doGetColumn(*rightDataset, rightRowIndex, it->second.childColumnName);
         }
 
         result.columnHash = result.columnName = it->second.columnName;
@@ -755,7 +790,8 @@ struct JoinedDataset::Itl
     //Query the original row name down the tree of joined datasets on that side
     //The alternative would be to store a variable-size list of <alias,rowName> tuples for each row entry
     RowName
-    getSubRowNameFromChildTable(const Utf8String& tableName, const RowName & name, JoinSide side) const
+    getSubRowNameFromChildTable(const Utf8String& tableName,
+                                const RowName & name, JoinSide side) const
     {
         ExcAssert(side < JOIN_SIDE_MAX);
         RowHash rowHash(name);
@@ -768,7 +804,8 @@ struct JoinedDataset::Itl
 
         RowName subRowName = JOIN_SIDE_LEFT == side ? entry.leftName : entry.rightName;
 
-        return datasets[side]->getOriginalRowName(tableName, subRowName);
+        return (JOIN_SIDE_LEFT == side ? *leftDataset : *rightDataset)
+            .getOriginalRowName(tableName, subRowName);
     }
 
     //As getSubRowNameFromChildTable, but we dont know which side, or whether is a direct child or not.
@@ -827,16 +864,37 @@ JoinedDataset(MldbServer * owner,
     : Dataset(owner)
 {
     auto joinConfig = config.params.convert<JoinedDatasetConfig>();
+
+    SqlExpressionMldbScope scope(owner);
+
+    // Create a scope to get our datasets from
+    SqlExpressionMldbScope mldbScope(server);
+
+    // Obtain our datasets
+    BoundTableExpression left = joinConfig.left->bind(mldbScope);
+    BoundTableExpression right = joinConfig.right->bind(mldbScope);
     
-    itl.reset(new Itl(server, joinConfig));
+    
+    itl.reset(new Itl(scope,
+                      joinConfig.left, std::move(left),
+                      joinConfig.right, std::move(right),
+                      joinConfig.on, joinConfig.qualification));
 }
 
 JoinedDataset::
-JoinedDataset(MldbServer * owner,
-              JoinedDatasetConfig config)
-    : Dataset(owner)
+JoinedDataset(SqlBindingScope & scope,
+              std::shared_ptr<TableExpression> leftExpr,
+              BoundTableExpression left,
+              std::shared_ptr<TableExpression> rightExpr,
+              BoundTableExpression right,
+              std::shared_ptr<SqlExpression> on,
+              JoinQualification qualification)
+    : Dataset(scope.getMldbServer())
 {
-    itl.reset(new Itl(server, config));
+    itl.reset(new Itl(scope,
+                      leftExpr, std::move(left),
+                      rightExpr, std::move(right),
+                      on, qualification));
 }
 
 JoinedDataset::
@@ -883,7 +941,7 @@ BoundFunction
 JoinedDataset::
 overrideFunction(const Utf8String & tableName,
                  const Utf8String & functionName,
-                 SqlBindingScope & context) const
+                 SqlBindingScope & scope) const
 {
     //cerr << "JoinedDataset function name: " << functionName << " from table: " << tableName << endl;
     if (functionName == "rowName") {
@@ -903,9 +961,9 @@ overrideFunction(const Utf8String & tableName,
         if (tableSide != JoinedDataset::Itl::JOIN_SIDE_MAX)
         {
             return {[&, tableSide] (const std::vector<ExpressionValue> & args,
-                     const SqlRowScope & context)
+                     const SqlRowScope & scope)
                 { 
-                    auto & row = context.as<SqlExpressionDatasetScope::RowScope>();
+                    auto & row = scope.as<SqlExpressionDatasetScope::RowScope>();
                     return ExpressionValue(itl->getSubRowName(row.row.rowName, tableSide).toUtf8String(), Date::negativeInfinity());
                 },
                 std::make_shared<Utf8StringValueInfo>()
@@ -920,9 +978,9 @@ overrideFunction(const Utf8String & tableName,
         if (tableSide != JoinedDataset::Itl::JOIN_SIDE_MAX)
         {
             return {[&, tableName, tableSide] (const std::vector<ExpressionValue> & args,
-                     const SqlRowScope & context)
+                     const SqlRowScope & scope)
                 {
-                    auto & row = context.as<SqlExpressionDatasetScope::RowScope>();
+                    auto & row = scope.as<SqlExpressionDatasetScope::RowScope>();
                     return ExpressionValue(itl->getSubRowNameFromChildTable(tableName, row.row.rowName, tableSide).toUtf8String(), Date::negativeInfinity());
                 },
                 std::make_shared<Utf8StringValueInfo>()
@@ -934,7 +992,7 @@ overrideFunction(const Utf8String & tableName,
         const Utf8String newFunctionName("rowName");
         Utf8String newTableName = functionName;
         newTableName.removeSuffix(".rowName");
-        return overrideFunction(newTableName, newFunctionName, context);
+        return overrideFunction(newTableName, newFunctionName, scope);
     }
 
     return BoundFunction();
@@ -956,11 +1014,26 @@ regJoined(builtinPackage(),
           nullptr,
           {MldbEntity::INTERNAL_ENTITY});
 
-extern std::shared_ptr<Dataset> (*createJoinedDatasetFn) (MldbServer *, const JoinedDatasetConfig &);
+extern std::shared_ptr<Dataset>
+(*createJoinedDatasetFn) (SqlBindingScope &,
+                          std::shared_ptr<TableExpression>,
+                          BoundTableExpression,
+                          std::shared_ptr<TableExpression>,
+                          BoundTableExpression,
+                          std::shared_ptr<SqlExpression>,
+                          JoinQualification);
 
-std::shared_ptr<Dataset> createJoinedDataset(MldbServer * server, const JoinedDatasetConfig & config)
+std::shared_ptr<Dataset>
+createJoinedDataset(SqlBindingScope & scope,
+                    std::shared_ptr<TableExpression> left,
+                    BoundTableExpression boundLeft,
+                    std::shared_ptr<TableExpression> right,
+                    BoundTableExpression boundRight,
+                    std::shared_ptr<SqlExpression> on,
+                    JoinQualification q)
 {
-    return std::make_shared<JoinedDataset>(server, config);
+    return std::make_shared<JoinedDataset>
+        (scope, left, boundLeft, right, boundRight, on, q);
 }
 
 namespace {

--- a/builtin/joined_dataset.h
+++ b/builtin/joined_dataset.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** joined_dataset.h                                               -*- C++ -*-
     Jeremy Barnes, 27 July 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Dataset that is the joined product of multiple underlying datasets.
 */
@@ -42,9 +41,16 @@ struct JoinedDataset: public Dataset {
                   PolyConfig config,
                   const std::function<bool (const Json::Value &)> & onProgress);
     
-    /** Constructor used internally when creating a tree of joined datasets */
-    JoinedDataset(MldbServer * owner,
-                  JoinedDatasetConfig config);
+    /** Constructor used internally when creating a tree of joined datasets
+        where some are already bound.
+    */
+    JoinedDataset(SqlBindingScope & scope,
+                  std::shared_ptr<TableExpression> leftExpr,
+                  BoundTableExpression left,
+                  std::shared_ptr<TableExpression> rightExpr,
+                  BoundTableExpression right,
+                  std::shared_ptr<SqlExpression> on,
+                  JoinQualification qualification);
 
     virtual ~JoinedDataset();
 
@@ -56,9 +62,13 @@ struct JoinedDataset: public Dataset {
 
     virtual void getChildAliases(std::vector<Utf8String>&) const;
 
-    virtual BoundFunction overrideFunction(const Utf8String & tableName, const Utf8String & functionName, SqlBindingScope & context) const;
+    virtual BoundFunction
+    overrideFunction(const Utf8String & tableName,
+                     const Utf8String & functionName,
+                     SqlBindingScope & scope) const;
 
-    virtual RowName getOriginalRowName(const Utf8String& tableName, const RowName & name) const;
+    virtual RowName getOriginalRowName(const Utf8String& tableName,
+                                       const RowName & name) const;
 
 private:
     JoinedDatasetConfig datasetConfig;

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -659,6 +659,14 @@ getRowInfo() const
                                           SCHEMA_CLOSED);
 }
 
+ExpressionValue
+Dataset::
+getRowExpr(const RowName & row) const
+{
+    MatrixNamedRow flattened = getMatrixView()->getRow(row);
+    return std::move(flattened.columns);
+}
+
 std::vector<MatrixNamedRow>
 Dataset::
 queryStructured(const SelectExpression & select,

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -417,6 +417,12 @@ struct Dataset: public MldbEntity {
     */
     virtual std::shared_ptr<RowValueInfo> getRowInfo() const;
 
+    /** Return a row as an expression value.  Default forwards to the matrix
+        view's getRow() function.
+    */
+    virtual ExpressionValue getRowExpr(const RowName & row) const;
+
+
     /** Commit changes to the database.  Default is a no-op.
 
         This function must be thread safe with respect to concurrent calls to
@@ -570,7 +576,8 @@ struct Dataset: public MldbEntity {
 
     /* In the case of a dataset with rows composed from other datasets (i.e., joins)
        This will return the name that the row has in the table with this alias*/
-    virtual RowName getOriginalRowName(const Utf8String& tableName, const RowName & name) const;
+    virtual RowName getOriginalRowName(const Utf8String& tableName,
+                                       const RowName & name) const;
 };
 
 

--- a/sql/execution_pipeline.cc
+++ b/sql/execution_pipeline.cc
@@ -251,6 +251,29 @@ doResolveTableName(const ColumnName & fullVariableName,
     return fullVariableName;
 }
 
+std::vector<Utf8String>
+PipelineExpressionScope::
+getTableNames() const
+{
+    std::vector<Utf8String> result;
+    for (auto & t: defaultTables) {
+        if (!t.scope)
+            continue;
+        std::set<Utf8String> n = t.scope->tableNames();
+        result.insert(result.end(), n.begin(), n.end());
+    }
+
+    for (auto & t: tables) {
+        result.push_back(t.first);
+    }
+
+    std::sort(result.begin(), result.end());
+    result.erase(std::unique(result.begin(), result.end()),
+                 result.end());
+
+    return result;
+}
+
 MldbServer * 
 PipelineExpressionScope::
 getMldbServer() const
@@ -357,8 +380,23 @@ from(std::shared_ptr<TableExpression> from,
      std::shared_ptr<SqlExpression> where,
      OrderByExpression orderBy)
 {
-    return std::make_shared<FromElement>(shared_from_this(), from, when,
+    return std::make_shared<FromElement>(shared_from_this(), from,
+                                         BoundTableExpression(),
+                                         when,
                                          select, where, orderBy);
+}
+
+std::shared_ptr<PipelineElement>
+PipelineElement::
+from(std::shared_ptr<TableExpression> from,
+     BoundTableExpression boundFrom,
+     WhenExpression when,
+     SelectExpression select,
+     std::shared_ptr<SqlExpression> where,
+     OrderByExpression orderBy)
+{
+    return std::make_shared<FromElement>(shared_from_this(), from, boundFrom,
+                                         when, select, where, orderBy);
 }
 
 std::shared_ptr<PipelineElement>
@@ -373,7 +411,33 @@ join(std::shared_ptr<TableExpression> left,
 {
     return std::make_shared<JoinElement>(shared_from_this(),
                                          std::move(left),
+                                         BoundTableExpression(),
                                          std::move(right),
+                                         BoundTableExpression(),
+                                         std::move(on),
+                                         joinQualification,
+                                         std::move(select),
+                                         std::move(where),
+                                         std::move(orderBy));
+}
+
+std::shared_ptr<PipelineElement>
+PipelineElement::
+join(std::shared_ptr<TableExpression> left,
+     BoundTableExpression boundLeft,
+     std::shared_ptr<TableExpression> right,
+     BoundTableExpression boundRight,
+     std::shared_ptr<SqlExpression> on,
+     JoinQualification joinQualification,
+     SelectExpression select,
+     std::shared_ptr<SqlExpression> where,
+     OrderByExpression orderBy)
+{
+    return std::make_shared<JoinElement>(shared_from_this(),
+                                         std::move(left),
+                                         std::move(boundLeft),
+                                         std::move(right),
+                                         std::move(boundRight),
                                          std::move(on),
                                          joinQualification,
                                          std::move(select),

--- a/sql/execution_pipeline.h
+++ b/sql/execution_pipeline.h
@@ -14,6 +14,8 @@
 namespace Datacratic {
 namespace MLDB {
 
+struct BoundTableExpression;
+
 
 /*****************************************************************************/
 /* PIPELINE RESULTS                                                          */
@@ -141,6 +143,8 @@ struct PipelineExpressionScope:
     virtual ColumnName
     doResolveTableName(const ColumnName & fullColumnName,
                        Utf8String &tableName) const;
+
+    std::vector<Utf8String> getTableNames() const;
 
     bool inLexicalScope() const
     {
@@ -321,10 +325,35 @@ struct PipelineElement: public std::enable_shared_from_this<PipelineElement> {
          std::shared_ptr<SqlExpression> where = SqlExpression::TRUE,
          OrderByExpression orderBy = OrderByExpression());
 
+    /** Add a from expression which has already been bound into the
+        immediate outer scope.
+    */
+    std::shared_ptr<PipelineElement>
+    from(std::shared_ptr<TableExpression> from,
+         BoundTableExpression boundFrom,
+         WhenExpression when,
+         SelectExpression select = SelectExpression::STAR,
+         std::shared_ptr<SqlExpression> where = SqlExpression::TRUE,
+         OrderByExpression orderBy = OrderByExpression());
+
     /** Add a join to the pipeline. */
     std::shared_ptr<PipelineElement>
     join(std::shared_ptr<TableExpression> left,
          std::shared_ptr<TableExpression> right,
+         std::shared_ptr<SqlExpression> on,
+         JoinQualification joinQualification,
+         SelectExpression select = SelectExpression(),
+         std::shared_ptr<SqlExpression> where = SqlExpression::TRUE,
+         OrderByExpression orderBy = OrderByExpression());
+    
+    /** Add a join to the pipeline that is pre-bound into the immediate outer
+        scope.
+    */
+    std::shared_ptr<PipelineElement>
+    join(std::shared_ptr<TableExpression> left,
+         BoundTableExpression boundLeft,
+         std::shared_ptr<TableExpression> right,
+         BoundTableExpression boundRight,
          std::shared_ptr<SqlExpression> on,
          JoinQualification joinQualification,
          SelectExpression select = SelectExpression(),

--- a/sql/execution_pipeline_impl.cc
+++ b/sql/execution_pipeline_impl.cc
@@ -430,9 +430,13 @@ doGetAllColumns(std::function<ColumnName (const ColumnName &)> keep,
 {
     //cerr << "doGetAllColums for join with field offset " << fieldOffset << endl;
 
-    PathElement leftPrefix(left->as());
-    PathElement rightPrefix(right->as());
-
+    PathElement leftPrefix;
+    if (!left->as().empty())
+        leftPrefix = left->as();
+    PathElement rightPrefix;
+    if (!right->as().empty())
+        rightPrefix = right->as();
+    
     auto leftOutput = left->doGetAllColumns(keep, leftFieldOffset(fieldOffset));
     auto rightOutput = right->doGetAllColumns(keep, rightFieldOffset(fieldOffset));
 
@@ -545,14 +549,17 @@ outputAdded() const
 JoinElement::
 JoinElement(std::shared_ptr<PipelineElement> root,
             std::shared_ptr<TableExpression> left,
+            BoundTableExpression boundLeft,
             std::shared_ptr<TableExpression> right,
+            BoundTableExpression boundRight,
             std::shared_ptr<SqlExpression> on,
             JoinQualification joinQualification,
             SelectExpression select,
             std::shared_ptr<SqlExpression> where,
             OrderByExpression orderBy)
-    : root(root), left(left), right(right), on(on),
-      select(select), where(where), orderBy(orderBy),
+    : root(root),
+      left(left), boundLeft(boundLeft), right(right), boundRight(boundRight),
+      on(on), select(select), where(where), orderBy(orderBy),
       condition(left, right, on, where), joinQualification(joinQualification)
 {
     switch (condition.style) {
@@ -617,13 +624,13 @@ JoinElement(std::shared_ptr<PipelineElement> root,
 
     leftImpl= root
         ->where(constantWhere)
-        ->from(left, when, selectAll, leftCondition,
+        ->from(left, boundLeft, when, selectAll, leftCondition,
                condition.left.orderBy)
         ->select(leftEmbedding);
 
     rightImpl = root
         ->where(constantWhere)
-        ->from(right, when, selectAll, rightCondition,
+        ->from(right, boundRight, when, selectAll, rightCondition,
                condition.right.orderBy)
         ->select(rightEmbedding);
 }
@@ -1069,11 +1076,13 @@ outputScope() const
 FromElement::
 FromElement(std::shared_ptr<PipelineElement> root_,
             std::shared_ptr<TableExpression> from_,
+            BoundTableExpression boundFrom_,
             WhenExpression when_,
             SelectExpression select_,
             std::shared_ptr<SqlExpression> where_,
             OrderByExpression orderBy_)
-    : root(std::move(root_)), from(std::move(from_)),
+    : root(std::move(root_)),
+      from(std::move(from_)), boundFrom(std::move(boundFrom_)),
       select(std::move(select_)), when(std::move(when_)), where(std::move(where_)),
       orderBy(std::move(orderBy_))
 {
@@ -1095,14 +1104,15 @@ FromElement(std::shared_ptr<PipelineElement> root_,
             = std::dynamic_pointer_cast<JoinExpression>(from);
         ExcAssert(join);
 
-        impl.reset(new JoinElement(root, join->left, join->right, join->on, join->qualification, select, where, orderBy_));
+        impl.reset(new JoinElement(root,
+                                   join->left, BoundTableExpression(),
+                                   join->right, BoundTableExpression(),
+                                   join->on, join->qualification,
+                                   select, where, orderBy_));
         // TODO: order by for join output
             
     }
     else {
-        auto rootBound = root->bind();
-        auto scope = rootBound->outputScope();
-
 #if 0
         if (!unbound.params.empty())
             throw HttpReturnException(400, "Can't deal with from expression "
@@ -1111,16 +1121,30 @@ FromElement(std::shared_ptr<PipelineElement> root_,
                                       "unbound", unbound);
 #endif
             
+        if (!!boundFrom) {
+            // We have a pre-bound version of the dataset; use that
+            impl.reset(new GenerateRowsElement(root,
+                                               select,
+                                               boundFrom.table,
+                                               boundFrom.asName,
+                                               when, 
+                                               where,
+                                               orderBy));
+        }
+        else { 
+            // Need to bound here to get the dataset
+            auto rootBound = root->bind();
+            auto scope = rootBound->outputScope();
 
-        // Need to bound here to get the dataset
-        BoundTableExpression bound = from->bind(*scope);
-        impl.reset(new GenerateRowsElement(root,
-                                           select,
-                                           bound.table,
-                                           bound.asName,
-                                           when, 
-                                           where,
-                                           orderBy));
+            BoundTableExpression bound = from->bind(*scope);
+            impl.reset(new GenerateRowsElement(root,
+                                               select,
+                                               bound.table,
+                                               bound.asName,
+                                               when, 
+                                               where,
+                                               orderBy));
+        }
     }
 }
 

--- a/sql/execution_pipeline_impl.h
+++ b/sql/execution_pipeline_impl.h
@@ -193,9 +193,12 @@ struct JoinLexicalScope: public LexicalScope {
 */
 
 struct JoinElement: public PipelineElement {
+    /** Constructor for when the element is pre-bound. */
     JoinElement(std::shared_ptr<PipelineElement> root,
                 std::shared_ptr<TableExpression> left,
+                BoundTableExpression boundLeft,
                 std::shared_ptr<TableExpression> right,
+                BoundTableExpression boundRight,
                 std::shared_ptr<SqlExpression> on,
                 JoinQualification joinQualification,
                 SelectExpression select,
@@ -204,7 +207,9 @@ struct JoinElement: public PipelineElement {
     
     std::shared_ptr<PipelineElement> root;
     std::shared_ptr<TableExpression> left;
+    BoundTableExpression boundLeft;
     std::shared_ptr<TableExpression> right;
+    BoundTableExpression boundRight;
     std::shared_ptr<SqlExpression> on;
     SelectExpression select;
     std::shared_ptr<SqlExpression> where;
@@ -351,15 +356,25 @@ struct RootElement: public PipelineElement {
 /** Element that generates rows according to the FROM clause. */
 
 struct FromElement: public PipelineElement {
+
+    /** Create the from clause, which will forward a query to the executor
+        of the given table.  The table may be pre-bound (if boundFrom is
+        filled in), or otherwise will be bound by this element (if a default
+        constructed, or empty,  BoundTableExpression is passed in to
+        boundFrom).
+    */
     FromElement(std::shared_ptr<PipelineElement> root_,
                 std::shared_ptr<TableExpression> from_,
+                BoundTableExpression boundFrom_,
                 WhenExpression when_,
                 SelectExpression select_ = SelectExpression::parse("*"),
-                std::shared_ptr<SqlExpression> where_ = SqlExpression::parse("true"),
+                std::shared_ptr<SqlExpression> where_
+                    = SqlExpression::parse("true"),
                 OrderByExpression orderBy_ = OrderByExpression());
     
     std::shared_ptr<PipelineElement> root;
     std::shared_ptr<TableExpression> from;
+    BoundTableExpression boundFrom;
     SelectExpression select;
     WhenExpression when;
     std::shared_ptr<SqlExpression> where;

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -233,7 +233,15 @@ struct TableOperations {
                                      ssize_t limit)>
     runQuery;
 
-    bool operator ! () const {return !getRowInfo && !getFunction  && !runQuery; }
+    /// What aliases (sub-dataset names) does this dataset contain?
+    /// Normally used in a join
+    std::function<std::vector<Utf8String> () > getChildAliases;
+
+    bool operator ! () const
+    {
+        return !getRowInfo && !getFunction && !runQuery
+            && !getChildAliases;
+    }
 };
 
 /*****************************************************************************/

--- a/sql/table_expression_operations.cc
+++ b/sql/table_expression_operations.cc
@@ -5,9 +5,9 @@
 */
 
 #include "table_expression_operations.h"
-#include "mldb/builtin/joined_dataset.h"
 #include "mldb/builtin/sub_dataset.h"
 #include "mldb/http/http_exception.h"
+#include "mldb/sql/execution_pipeline.h"
 
 using namespace std;
 
@@ -23,6 +23,9 @@ bindDataset(std::shared_ptr<Dataset> dataset, Utf8String asName)
     BoundTableExpression result;
     result.dataset = dataset;
     result.asName = asName;
+
+    auto cols = dataset->getColumnIndex();
+    auto matrix = dataset->getMatrixView();
 
     // Allow us to query row information from the dataset
     result.table.getRowInfo = [=] () { return dataset->getRowInfo(); };
@@ -51,6 +54,13 @@ bindDataset(std::shared_ptr<Dataset> dataset, Utf8String asName)
                                        offset, limit);
         };
 
+    result.table.getChildAliases = [=] ()
+        {
+            std::vector<Utf8String> aliases;
+            dataset->getChildAliases(aliases);
+            return aliases;
+        };
+
     return result;
 }
 
@@ -59,7 +69,7 @@ bindDataset(std::shared_ptr<Dataset> dataset, Utf8String asName)
 /*****************************************************************************/
 
 NamedDatasetExpression::
-    NamedDatasetExpression(const Utf8String& asName) : asName(asName)
+NamedDatasetExpression(const Utf8String& asName) : asName(asName)
 {
 
 }
@@ -169,21 +179,133 @@ JoinExpression::
 
 // Overridden by libmldb.so when it loads up to break circular link dependency
 // and allow expression parsing to be in a separate library
-std::shared_ptr<Dataset> (*createJoinedDatasetFn) (MldbServer *, const JoinedDatasetConfig &);
+std::shared_ptr<Dataset>
+(*createJoinedDatasetFn) (SqlBindingScope &,
+                          std::shared_ptr<TableExpression>,
+                          BoundTableExpression,
+                          std::shared_ptr<TableExpression>,
+                          BoundTableExpression,
+                          std::shared_ptr<SqlExpression>,
+                          JoinQualification);
 
 BoundTableExpression
 JoinExpression::
-bind(SqlBindingScope & context) const
+bind(SqlBindingScope & scope) const
 {
-    JoinedDatasetConfig config;
-    config.left = left;
-    config.right = right;
-    config.on = on;
+    BoundTableExpression boundLeft = left->bind(scope);
+    BoundTableExpression boundRight = right->bind(scope);
 
-    config.qualification = qualification;
-    auto ds = createJoinedDatasetFn(context.getMldbServer(), config);
+    if (boundLeft.dataset && boundRight.dataset) {
+        auto ds = createJoinedDatasetFn(scope,
+                                        left,
+                                        std::move(boundLeft),
+                                        right,
+                                        std::move(boundRight),
+                                        on, qualification);
+        return bindDataset(ds, Utf8String());
+    }
+    else {
+        if (boundLeft.asName.empty()
+            && boundLeft.table.getChildAliases().empty()) {
+            throw HttpReturnException
+                (400, "Tables in joins that don't have a natural name like a "
+                 "dataset name must have an AS expression (consider replacing '"
+                 + left->surface + "' with '" + left->surface + " AS lhs'");
+        }
 
-    return bindDataset(ds, Utf8String());
+        if (boundRight.asName.empty()
+            && boundRight.table.getChildAliases().empty()) {
+            throw HttpReturnException
+                (400, "Tables in joins that don't have a natural name like a "
+                 "dataset name must have an AS expression (consider replacing '"
+                 + right->surface + "' with '" + right->surface + " AS rhs'");
+        }
+
+        // Use the new executor for the join
+        auto pipeline = 
+            PipelineElement::root(scope)
+            ->join(left, std::move(boundLeft),
+                   right, std::move(boundRight),
+                   on, qualification, SelectExpression::STAR)
+            ->bind();
+   
+        BoundTableExpression result;
+
+        // Allow us to query row information from the dataset
+        result.table.getRowInfo = [=] () -> std::shared_ptr<RowValueInfo>
+            {
+                return ExpressionValueInfo::toRow(pipeline->outputScope()->outputInfo().back());
+            };
+    
+        // Allow the dataset to override functions
+        result.table.getFunction = [=] (SqlBindingScope & context,
+                                        const Utf8String & tableName,
+                                        const Utf8String & functionName,
+                                        const std::vector<std::shared_ptr<ExpressionValueInfo> > & args)
+            -> BoundFunction 
+            {
+                return BoundFunction();
+            };
+
+        // Allow the dataset to run queries
+        result.table.runQuery = [=] (const SqlBindingScope & context,
+                                     const SelectExpression & select,
+                                     const WhenExpression & when,
+                                     const SqlExpression & where_,
+                                     const OrderByExpression & orderBy,
+                                     ssize_t offset,
+                                     ssize_t limit)
+            -> BasicRowGenerator
+            {
+                // Joins are detected in the outer query logic and intercepted.
+                // As a result, counter-intuitively, this function is currently
+                // never called.  The commented-out partial implementation is
+                // kept as a starting point for whenever we use the table
+                // operations for more than implementing joins, and we will need
+                // to use it.
+                throw HttpReturnException
+                (500, "Internal logic error: joins should not require runQuery");
+#if 0
+                // Copy the where expression
+                std::shared_ptr<SqlExpression> where = where_.shallowCopy();
+
+                auto getRowName
+                    = SqlExpression::parse("rowName()")->bind(...);
+
+                auto exec = [=] (ssize_t numToGenerate,
+                                 SqlRowScope & rowScope,
+                                 const BoundParameters & params)
+                -> std::vector<NamedRowValue>
+                {
+                    std::vector<NamedRowValue> result;
+
+                    auto gotElement = [&] (std::shared_ptr<PipelineResults> & res)
+                        -> bool
+                    {
+                        auto rowName = ...;
+
+                        // extract the rowName and the row
+                        // ...
+                        return true;
+                    };
+
+                    pipeline->start(params)->takeAll(gotElement);
+                    
+                    return result;
+                };
+
+                BasicRowGenerator result(exec, "join generator on-demand");
+                return result;
+#endif
+            };
+
+        result.table.getChildAliases = [=] ()
+            {
+                return pipeline->outputScope()->getTableNames();
+            };
+
+        return result;
+    }
 }
 
 Utf8String
@@ -475,12 +597,8 @@ getUnbound() const
 {
     UnboundEntities result;
     for (auto & a: args) {
-        cerr << "getting unbound for arg " << a->print() << endl;
         result.merge(a->getUnbound());
     }
-
-    cerr << "unbound is " << jsonEncode(result) << endl;
-
     return result;
 }
 
@@ -619,6 +737,12 @@ bind(SqlBindingScope & context) const
 
             BasicRowGenerator result(exec, "row table expression generator");
             return result;
+        };
+
+    result.table.getChildAliases = [=] ()
+        {
+            std::vector<Utf8String> aliases;
+            return aliases;
         };
 
     return result;

--- a/testing/MLDB-1616-row-dataset-segfault.js
+++ b/testing/MLDB-1616-row-dataset-segfault.js
@@ -1,0 +1,48 @@
+// This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+var resp = mldb.query('select * from (select 1) as x join row_dataset({x:1}) as y');
+mldb.log(resp);
+
+var expected = [
+   {
+      "columns" : [
+         [ "x.1", 1, "-Inf" ],
+         [ "y.column", "x", "-Inf" ],
+         [ "y.value", 1, "-Inf" ]
+      ],
+      "rowName" : "result-0"
+   }
+];
+
+assertEqual(resp, expected);
+
+var resp = mldb.query('select * from (select 1) as x join row_dataset({x:1}) as y join row_dataset({z:2}) as z');
+mldb.log(resp);
+
+var expected = [
+   {
+      "columns" : [
+         [ "x.1", 1, "-Inf" ],
+         [ "y.column", "x", "-Inf" ],
+         [ "y.value", 1, "-Inf" ],
+         [ "z.column", "z", "-Inf" ],
+         [ "z.value", 2, "-Inf" ]
+      ],
+      "rowName" : "result-0-0"
+   }
+];
+
+assertEqual(resp, expected);
+
+"success"

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -348,6 +348,7 @@ $(eval $(call mldb_unit_test,MLDB-1554-string-agg.js))
 $(eval $(call mldb_unit_test,MLDB-1567-empty-literal.js))
 $(eval $(call mldb_unit_test,MLDB-1563-keys-values-of.js))
 $(eval $(call mldb_unit_test,MLDB-1468-credentials-test.py))
+$(eval $(call mldb_unit_test,MLDB-1616-row-dataset-segfault.js))
 
 $(eval $(call test,MLDB-1360-sparse-mutable-multithreaded-insert,mldb,boost))
 $(eval $(call mldb_unit_test,MLDBFB-440_error_on_ds_wo_cols.py))


### PR DESCRIPTION
This allows for joins on things that aren't backed by a dataset, for example row_table(), also fixing a segfault when it was attempted.

The implementation will detect when there is no materialized dataset behind one or both sides of a join, and fall back to the new executor instead.

It also lays the groundwork for correlated subselects.