### PR TITLE
Mldb 1664 join with non-equijoin condition (e.g. inequality)

### DIFF
--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -142,7 +142,7 @@ struct JoinedDataset::Itl
         std::shared_ptr<SqlExpression> on,
         JoinQualification qualification)
     {
-        bool debug = true;
+        bool debug = false;
 
         // vector to set
         auto v2s = [] (std::vector<Utf8String> vec)

--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -142,7 +142,7 @@ struct JoinedDataset::Itl
         std::shared_ptr<SqlExpression> on,
         JoinQualification qualification)
     {
-        bool debug = false;
+        bool debug = true;
 
         // vector to set
         auto v2s = [] (std::vector<Utf8String> vec)

--- a/sql/join_utils.cc
+++ b/sql/join_utils.cc
@@ -403,8 +403,10 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
                     std::swap(leftAnnotated, rightAnnotated);
             
                 if (leftAnnotated.role != AnnotatedClause::LEFT
-                    || rightAnnotated.role != AnnotatedClause::RIGHT)
+                    || rightAnnotated.role != AnnotatedClause::RIGHT) {
+                    nonPivotWhere.push_back(c);
                     continue;
+                }
 
                 c.pivot = AnnotatedClause::POSSIBLE_PIVOT;
 

--- a/sql/join_utils.cc
+++ b/sql/join_utils.cc
@@ -346,8 +346,6 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
         checkAndClauses(andClauses.begin());
     }
 
-    size_t numOfCrossConditions = crossConditions.size();
-
     //If we do an outer join its important that the 'where' be applied *after* the join else we will be missing rows
     if (where && joinQualification == JOIN_INNER) {
         auto numOnClauses = andClauses.size();
@@ -382,6 +380,7 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
             = SqlExpression::parse("true");
     }
     else {
+        // check for a possibility to optimize with an equijoin
         for (auto & c: crossConditions) {
             // Look for an equality condition in the cross condition
             auto cmpExpr = std::dynamic_pointer_cast<ComparisonExpression>(c.expr);
@@ -425,20 +424,10 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
         }
 
         if (style != EQUIJOIN) {
-
-            if (numOfCrossConditions == 0) {
-                //this is a cross-join, the 'where' has some cross-conditions but no pivot
-                style = CROSS_JOIN;
-                left.equalExpression
-                    = right.equalExpression
-                    = SqlExpression::parse("true");
-            }
-            else {
-                throw HttpReturnException
-                (400, "Could not find join clause pivot: "
-                 "Join condition must have one clause of form left.var1 = right.var2",
-                 "conditions", *this);
-            }
+            style = CROSS_JOIN;
+            left.equalExpression
+                = right.equalExpression
+                = SqlExpression::parse("true");
         }
     }
 

--- a/sql/join_utils.h
+++ b/sql/join_utils.h
@@ -142,7 +142,7 @@ struct AnnotatedJoinCondition {
         // WHERE condition on rows on the left side
         std::vector<AnnotatedClause> whereClauses;
         
-        /// Left side of equality part of the join expression, for JOIN_EQUAL
+        /// Left side of equality part of the join expression, for EQUIJOIN
         std::shared_ptr<SqlExpression> equalExpression;
 
         /// Clause for the select expression

--- a/testing/MLDB-1624-more-join-test.py
+++ b/testing/MLDB-1624-more-join-test.py
@@ -1471,7 +1471,7 @@ class JoinTest(MldbUnitTest):
         )
 
 
-    @unittest.expectedFailure
+    @unittest.expectedFailure # MLDB-1672
     def test_left_outer_join(self):
         """
         row 11 on the left table should be outputted
@@ -1509,7 +1509,7 @@ class JoinTest(MldbUnitTest):
             ]
         )
 
-    @unittest.expectedFailure
+    @unittest.expectedFailure # MLDB-1672
     def test_right_outer_join(self):
         """
         row 9 on the right table should be outputted
@@ -1542,7 +1542,7 @@ class JoinTest(MldbUnitTest):
             ]
         )
 
-    @unittest.expectedFailure
+    @unittest.expectedFailure # MLDB-1672
     def test_full_outer_join(self):
         """
         row 11 on the left table should be outputted
@@ -1609,8 +1609,8 @@ class JoinTest(MldbUnitTest):
             ]
         )
 
-    @unittest.expectedFailure
-    def test_multiway_full_join(self):
+    @unittest.expectedFailure # MLDB-1671
+    def test_multiway_join(self):
         """
         the name of the row is incorrect
         - [u'[]-[03]', None, None, None, None, u'dd', 33]
@@ -1836,7 +1836,7 @@ class JoinTest(MldbUnitTest):
             ]
         )
 
-    @unittest.expectedFailure
+    @unittest.expectedFailure # MLDB-1673
     def test_join_with_constant_expression_failing_on_get_variable(self):
         """
         {"details":{"columnName":"s2.n"},"error":"Get variable without table name with no default table in scope","httpCode":500}
@@ -1877,7 +1877,7 @@ class JoinTest(MldbUnitTest):
             ]
         )
 
-    @unittest.expectedFailure
+    @unittest.expectedFailure # MLDB-1674
     def test_join_with_constant_expression_failing_on_parsing(self):
         """
         confusing INNER JOIN with IN oeprator
@@ -1901,7 +1901,7 @@ class JoinTest(MldbUnitTest):
             ]
         )
 
-    @unittest.expectedFailure
+    @unittest.expectedFailure # MLDB-1671
     def test_join_with_constant_expression_failing_on_row_name(self):
         """
         - [u'[]-[03]', None, None, None, None, None, None, u'dd', 3, 33]

--- a/testing/MLDB-1624-more-join-test.py
+++ b/testing/MLDB-1624-more-join-test.py
@@ -1631,6 +1631,15 @@ class JoinTest(MldbUnitTest):
             ]
         )
 
+        res = mldb.query("""
+        select * from x left join y on (x.x1 = y.y1) left join x as xx
+        on (x.x1 = xx.xx1)
+        """)
+        pprint(res)
+        # number of columns
+        self.assertEqual(len(res[0]), 2 + 2 + 2 + 1)
+
+
     def test_join_with_subqueries(self):
         res = mldb.query("""
             SELECT * FROM
@@ -1937,14 +1946,20 @@ class JoinTest(MldbUnitTest):
         )
 
         res = mldb.query("""
-        select * from (x left join y on (x.x1 = y.y1)) left join x as xx
-        on (x.x1 = xx.xx1 and x.x2 is not null)
+        select * from x left join y left join x as xx
         """)
-        pprint(res)
-        self.assertTableResultEquals(res, 
-            [
-             
-            ]
-        )
+        # number of rows
+        self.assertEqual(len(res), 5 * 4 * 5 + 1)
+        # number of columns
+        self.assertEqual(len(res[0]), 2 + 2 + 2 + 1)
+
+        res = mldb.query("""
+        select * from x left join y on (x.x1 = y.y1) left join x as xx
+        """)
+        # number of rows
+        self.assertEqual(len(res), 5 * 5 + 1)
+        # number of columns
+        self.assertEqual(len(res[0]), 2 + 2 + 2 + 1)
+
 
 mldb.run_tests()

--- a/testing/MLDB-1624-more-join-test.py
+++ b/testing/MLDB-1624-more-join-test.py
@@ -1251,13 +1251,10 @@ class JoinTest(MldbUnitTest):
             ]
         )     
 
-    @unittest.expectedFailure
+    # MLDB-1664
     def test_non_equi_join(self):
-        """
-        Could not find join clause pivot: Join condition must have one clause of form left.var1 = right.var2
-        """
         res = mldb.query("""
-            SELECT '' AS "xxx", * FROM J1_TBL JOIN J2_TBL ON J1_TBL.i <= J2_TBL.k
+            SELECT '' AS "xxx", * FROM J1_TBL JOIN J2_TBL ON J1_TBL.i <= J2_TBL.k ORDER BY rowName()
         """)
 
         pprint(res)
@@ -1265,20 +1262,16 @@ class JoinTest(MldbUnitTest):
         # output should look like that
         self.assertTableResultEquals(res, 
             [   
-               """
-               xxx | i | j |   t   | i | k 
-               -----+---+---+-------+---+---
-               | 1 | 4 | one   | 2 | 2
-               | 2 | 3 | two   | 2 | 2
-               | 0 |   | zero  | 2 | 2
-               | 1 | 4 | one   | 2 | 4
-               | 2 | 3 | two   | 2 | 4
-               | 3 | 2 | three | 2 | 4
-               | 4 | 1 | four  | 2 | 4
-               | 0 |   | zero  | 2 | 4
-               | 0 |   | zero  |   | 0
-               (9 rows)
-               """
+                [u'_rowName', u'J1_TBL.i', u'J1_TBL.j', u'J1_TBL.t', u'J2_TBL.i', u'J2_TBL.k', u'xxx'] ,
+                [u'[01]-[02]', 1, 4, u'one', 2, 2, u''] ,
+                [u'[01]-[04]', 1, 4, u'one', 2, 4, u''] ,
+                [u'[02]-[02]', 2, 3, u'two', 2, 2, u''] ,
+                [u'[02]-[04]', 2, 3, u'two', 2, 4, u''] ,
+                [u'[03]-[04]', 3, 2, u'three', 2, 4, u''] ,
+                [u'[04]-[04]', 4, 1, u'four', 2, 4, u''] ,
+                [u'[09]-[02]', 0, None, u'zero', 2, 2, u''] ,
+                [u'[09]-[04]', 0, None, u'zero', 2, 4, u''] ,
+                [u'[09]-[09]', 0, None, u'zero', None, 0, u'']
             ]
         )
         


### PR DESCRIPTION
This is fixing one case where a join with cross conditions other than equality was not accepted.
