### PR TITLE
Fixed DT regression, classifier file saving (MLDB-1660)

### DIFF
--- a/ml/jml/decision_tree_generator.cc
+++ b/ml/jml/decision_tree_generator.cc
@@ -1253,13 +1253,10 @@ train_recursive_regression(Thread_Context & context,
     trainer.test_all_and_sort(features, data, model.predicted(), weights2,
                               in_class, accum);
     
-    //cerr << " decision tree training: best is "
-    //     << feature_space()->print(feature)
-    //     << " at value " << split_val << endl;
     //cerr << "z = " << accum.best_z << endl;
     //cerr << "w = " << endl << accum.best_w.print() << endl;
 
-    if (accum.best_z == 0.0) {
+    if (accum.best_z == 0.0 || accum.best_feature == MISSING_FEATURE) {
         Tree::Leaf * result = tree.new_leaf();
         *result = leaf;
         return result;

--- a/ml/jml/feature.h
+++ b/ml/jml/feature.h
@@ -1,14 +1,12 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* feature.h                                                       -*- C++ -*-
    Jeremy Barnes, 29 March 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Definition of a feature.
 */
 
-#ifndef __boosting__feature_h__
-#define __boosting__feature_h__
+#pragma once
 
 #include <ostream>
 #include "mldb/compiler/compiler.h"
@@ -106,6 +104,3 @@ extern const Feature MISSING_FEATURE;
 std::ostream & operator << (std::ostream & stream, const Feature & feature);
 
 } // namespace ML
-
-
-#endif /* __boosting__feature_h__ */

--- a/testing/MLDB-1597-regression.py
+++ b/testing/MLDB-1597-regression.py
@@ -219,7 +219,6 @@ class Mldb1597Test(MldbUnitTest):
         r2 = result.json()["status"]["firstRun"]["status"]["r2"]
         self.assertTrue( r2 is not None )
 
-    @unittest.skip("awaiting MLDB-1660")
     def test_function_creation_bug(self):
         mldb.post("/v1/procedures", {
             "type": "import.text",
@@ -244,7 +243,7 @@ class Mldb1597Test(MldbUnitTest):
                 "algorithm": "dt",
                 "mode": "regression",
                 "configurationFile": "./mldb/container_files/classifiers.json",
-                "modelFileUrlPattern": "file:///tmp/MLDB-1597-creation$runid.cls",
+                "modelFileUrlPattern": "file://tmp/MLDB-1597-creation$runid.cls",
                 "runOnCreation": True
             }
         })


### PR DESCRIPTION
Fixes two things:
1.  Classifier training silently ignored (with just a log message) when it couldn't save the file; this now will lead to failure
2.  Decision tree would not properly detect when there was no weight in a leaf, and continuously re-split.  This would lead to us trying to serialize a MISSING feature when serializing.
