### PR TITLE
PLAT-1004: ensure the field names are stored using constant pointers …

### DIFF
--- a/types/structure_description.h
+++ b/types/structure_description.h
@@ -67,7 +67,16 @@ struct StructureDescriptionBase {
     typedef std::map<const char *, FieldDescription, StrCompare> Fields;
     Fields fields;
 
-    std::vector<std::string> fieldNames;
+    /* A deleter that works with buffers allocated with malloc */
+    struct FreeDeleter {
+        void operator () (void * p)
+            const
+        {
+            ::free(p);
+        }
+    };
+
+    std::vector<std::unique_ptr<char, FreeDeleter> > fieldNames;
 
     std::vector<Fields::const_iterator> orderedFields;
 
@@ -171,8 +180,8 @@ struct StructureDescription
         if (fields.count(name.c_str()))
             throw ML::Exception("field '" + name + "' added twice");
 
-        fieldNames.push_back(name);
-        const char * fieldName = fieldNames.back().c_str();
+        fieldNames.emplace_back(::strdup(name.c_str()));
+        const char * fieldName = fieldNames.back().get();
         
         auto it = fields.insert
             (Fields::value_type(fieldName, std::move(FieldDescription())))
@@ -203,8 +212,8 @@ struct StructureDescription
         if (fields.count(name.c_str()))
             throw ML::Exception("field '" + name + "' added twice");
 
-        fieldNames.push_back(name);
-        const char * fieldName = fieldNames.back().c_str();
+        fieldNames.emplace_back(::strdup(name.c_str()));
+        const char * fieldName = fieldNames.back().get();
         
         auto it = fields.insert
             (Fields::value_type(fieldName, std::move(FieldDescription())))
@@ -341,8 +350,8 @@ addParent(ValueDescriptionT<V> * description_)
         FieldDescription & ofd = const_cast<FieldDescription &>(oit->second);
         const std::string & name = ofd.fieldName;
 
-        fieldNames.push_back(name);
-        const char * fieldName = fieldNames.back().c_str();
+        fieldNames.emplace_back(::strdup(name.c_str()));
+        const char * fieldName = fieldNames.back().get();
 
         auto it = fields.insert(Fields::value_type(fieldName, std::move(FieldDescription()))).first;
         FieldDescription & fd = it->second;

--- a/types/value_description.cc
+++ b/types/value_description.cc
@@ -370,9 +370,9 @@ operator = (const StructureDescriptionBase & other)
 
     // Don't set owner
     for (auto & f: other.orderedFields) {
-        string s = f->first;
-        fieldNames.push_back(s);
-        auto it = fields.insert(make_pair(fieldNames.back().c_str(), f->second))
+        const char * s = f->first;
+        fieldNames.emplace_back(::strdup(s));
+        auto it = fields.insert(make_pair(fieldNames.back().get(), f->second))
             .first;
         orderedFields.push_back(it);
     }


### PR DESCRIPTION
This PR fixes the problem where the pointers returned by the std::string::c_str() are made invalid as field names are added to "fieldNames" on Ubuntu 16.04. This does not affect 14.04, even with g++ 5.3, which makes this PR nice but less urgent.
