### PR TITLE
MLDBFB-545 missing filter in merge dataset getColumnValues

### DIFF
--- a/builtin/merged_dataset.cc
+++ b/builtin/merged_dataset.cc
@@ -410,16 +410,17 @@ struct MergedDataset::Itl
             while (bitmap) {
                 int bit = ML::lowest_bit(bitmap, -1);
                 auto column = datasets[bit]->getColumnIndex()->getColumnValues(columnName, filter);
-                if (column.empty())
-                    continue;
+                if (!column.empty())
+                {
+                    if (!result.empty())
+                        sorted = false;
 
-                if (!result.empty())
-                    sorted = false;
+                    result.insert(result.end(),
+                                  std::make_move_iterator(column.begin()),
+                                  std::make_move_iterator(column.end()));
 
-                result.insert(result.end(),
-                              std::make_move_iterator(column.begin()),
-                              std::make_move_iterator(column.end()));
-
+                }
+             
                 bitmap = bitmap & ~(1 << bit);
             }
 

--- a/builtin/merged_dataset.cc
+++ b/builtin/merged_dataset.cc
@@ -402,7 +402,7 @@ struct MergedDataset::Itl
         if (bitmap)
         {
             int bit = ML::lowest_bit(bitmap, -1);
-            result = std::move(datasets[bit]->getColumnIndex()->getColumnValues(columnName));
+            result = std::move(datasets[bit]->getColumnIndex()->getColumnValues(columnName, filter));
 
             bitmap = bitmap & ~(1 << bit);
             bool sorted = std::is_sorted(result.begin(), result.end());  // true


### PR DESCRIPTION
This will solve the issue of the WHERE not getting applied on the merged dataset in some cases.