### PR TITLE
MLDB-1632 path optimizations

### DIFF
--- a/mldb_macros.mk
+++ b/mldb_macros.mk
@@ -4,6 +4,7 @@
 # $(3) options for the test
 #      - manual: run the test manually
 #      - virtualenv: set up the Python virtualenv even for a non-python test
+#      - valgrind: run the test within valgrind
 
 define mldb_unit_test
 ifneq ($(PREMAKE),1)
@@ -16,7 +17,7 @@ TEST_$(1)_SETUP := $$(if $$(findstring .py,$(1))$$(findstring virtualenv,$(3)),.
 
 # Command to actually run for the test.  Constructs the call to mldb_runner and the
 # command line options to pass to it.
-TEST_$(1)_RAW_COMMAND := $$(BIN)/mldb_runner -h localhost -p '11700-12700' $$(foreach plugin,$(2),--plugin-directory file://$(PLUGINS)/$$(plugin)) --run-script $(CWD)/$(1) --mute-final-output
+TEST_$(1)_RAW_COMMAND := $(call TEST_PRE_OPTIONS,$(3)) $$(BIN)/mldb_runner -h localhost -p '11700-12700' $$(foreach plugin,$(2),--plugin-directory file://$(PLUGINS)/$$(plugin)) --run-script $(CWD)/$(1) --mute-final-output
 
 # Command that is run in the shell.  This takes care of printing the right message
 # out and capturing the output in the right place.

--- a/plugins/embedding.cc
+++ b/plugins/embedding.cc
@@ -1302,9 +1302,8 @@ bindT(SqlBindingScope & outerContext, const std::shared_ptr<RowValueInfo> & inpu
 
             for (auto & c: columnNames) {
                 if (!c.empty() || c.back().isIndex()) {
-                    ColumnName knownEmbedding = c;
-                    knownEmbedding.pop_back();
-                    knownEmbeddings.insert(c);
+                    ColumnName knownEmbedding(c.begin(), c.end() - 1);
+                    knownEmbeddings.insert(knownEmbedding);
                 }
             }
 

--- a/plugins/importtext_procedure.cc
+++ b/plugins/importtext_procedure.cc
@@ -205,6 +205,11 @@ struct SqlCsvScope: public SqlExpressionMldbScope {
             }
         }
 
+        // Fill out the offset so we know where it is in the input
+        for (size_t i = 0;  i < columnsWithInfo.size();  ++i) {
+            columnsWithInfo[i].offset = i;
+        }
+        
         auto exec = [=] (const SqlRowScope & scope, const VariableFilter & filter)
             {
                 /* 
@@ -218,7 +223,7 @@ struct SqlCsvScope: public SqlExpressionMldbScope {
                 RowValue result;
 
                 for (unsigned i = 0;  i < columnNames.size();  ++i) {
-                    if (toKeep[i] != ColumnName())
+                    if (!toKeep[i].empty())
                         result.emplace_back(columnNames[i], row.row[i], row.ts);
                 }
 
@@ -778,10 +783,6 @@ struct ImportTextProcedureWorkInstance
         // optimizations to avoid calling into the SQL layer
         SqlExpressionDatasetScope noContext(*dataset, ""); //needs a context because x.* is ambiguous
         isIdentitySelect = config.select.isIdentitySelect(noContext);  
-
-        // Is the name the lineNumber()?  If so, we can save on
-        // calculating it
-        //cerr << "name = " << config.named->print() << endl;
 
         // Figure out our output column names from the bound
         // select clause

--- a/server/dataset_collection.cc
+++ b/server/dataset_collection.cc
@@ -175,6 +175,13 @@ void runHttpQuery(std::function<std::vector<MatrixNamedRow> ()> runQuery,
             }
         }
 
+        if (sortColumns) {
+            std::sort(columns.begin(), columns.end());
+            for (size_t i = 0;  i < columns.size();  ++i) {
+                columnIndex[columns[i]] = i;
+            }
+        }
+
         // Now, send them back
         std::vector<std::vector<CellValue> > output;
         output.reserve(sparseOutput.size() + createHeaders);

--- a/sql/cell_value.cc
+++ b/sql/cell_value.cc
@@ -1235,7 +1235,7 @@ extractStructuredJson(JsonPrintingContext & context) const
         context.startMember("path");
         context.startArray();
 
-        for (auto & p: coerceToPath()) {
+        for (auto p: coerceToPath()) {
             context.newArrayElement();
             context.writeStringUtf8(p.toUtf8String());
         }

--- a/sql/execution_pipeline.cc
+++ b/sql/execution_pipeline.cc
@@ -10,6 +10,8 @@
 #include "mldb/http/http_exception.h"
 #include "mldb/types/basic_value_descriptions.h"
 #include "mldb/jml/utils/smart_ptr_utils.h"
+#include <algorithm>
+
 
 using namespace std;
 

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -21,6 +21,7 @@
 #include "mldb/types/hash_wrapper_description.h"
 #include "mldb/jml/utils/less.h"
 #include "mldb/jml/utils/lightweight_hash.h"
+#include "mldb/jml/utils/compact_vector.h"
 
 using namespace std;
 

--- a/sql/path.h
+++ b/sql/path.h
@@ -9,7 +9,6 @@
 #include "mldb/types/string.h"
 #include "mldb/types/value_description_fwd.h"
 #include "mldb/base/exc_assert.h"
-#include "mldb/jml/utils/compact_vector.h"
 #include <vector>
 #include <cstring>
 
@@ -147,6 +146,9 @@ struct PathElement {
 
     Utf8String toEscapedUtf8String() const;
 
+    std::string stealBytes();
+    std::string getBytes() const;
+    
     /** Returns if this is an index, that is a non-negative integer
         (possibly with leading zeros) that can be converted into an
         array index.
@@ -342,32 +344,365 @@ struct PathElementNewHasher
 
 
 /*****************************************************************************/
-/* PATHS                                                                    */
+/* INTERNED STRING                                                           */
+/*****************************************************************************/
+
+template<size_t Bytes, typename Char = char>
+struct InternedString {
+    InternedString()
+        : intIsExt_(0), intLength_(0)
+    {
+        //std::memset(this, 0, sizeof(*this));
+    }
+
+    InternedString(const InternedString & other)
+        : InternedString()
+    {
+        append(other.data(), other.length());
+    }
+
+    template<size_t OtherBytes>
+    InternedString(const InternedString<OtherBytes, Char> & other)
+        : InternedString()
+    {
+        append(other.data(), other.length());
+    }
+
+    template<size_t OtherBytes>
+    InternedString(InternedString<OtherBytes, Char> && other) noexcept
+        : InternedString()
+    {
+        if (other.length() > Bytes) {
+            // Can't fit internally.  If the other is external, steal it
+            if (other.isExt()) {
+                extIsExt_ = 1;
+                extLength_ = other.extLength_;
+                extCapacity_ = other.extCapacity_;
+                extBytes_ = other.extBytes_;
+                other.extIsExt_ = 0;
+                other.intLength_ = 0;
+                return;
+            }
+        }
+
+        // Otherwise, simply append it
+        append(other.data(), other.size());
+    }
+
+    InternedString(const std::basic_string<Char> & other)
+        : InternedString()
+    {
+        append(other.data(), other.length());
+    }
+
+    InternedString & operator = (const InternedString & other)
+    {
+        InternedString newMe(other);
+        swap(newMe);
+        return *this;
+    }
+
+    InternedString & operator = (InternedString && other) noexcept
+    {
+        InternedString newMe(std::move(other));
+        swap(newMe);
+        return *this;
+    }
+
+    ~InternedString()
+    {
+        if (isExt())
+            deleteExt();
+    }
+
+    const Char * data() const
+    {
+        return isExt() ? extBytes_ : intBytes_;
+    }
+
+    void swap(InternedString & other) noexcept
+    {
+        for (size_t i = 0;  i < NUM_WORDS;  ++i) {
+            std::swap(words[i], other.words[i]);
+        }
+    }
+
+    size_t size() const
+    {
+        return isExt() ? extLength_ : intLength_;
+    }
+
+    size_t length() const
+    {
+        return size();
+    }
+
+    bool empty() const
+    {
+        return size() == 0;
+    }
+
+    void reserve(size_t newCapacity)
+    {
+        if (newCapacity < capacity())
+            return;
+
+        bool wasExt = isExt();
+
+        char * newBytes = new Char[newCapacity];
+        size_t l = size();
+        std::memcpy(newBytes, data(), l);
+        extIsExt_ = 1;
+        extLength_ = l;
+        extCapacity_ = newCapacity;
+
+        if (wasExt)
+            delete[] extBytes_;
+
+        extBytes_ = newBytes;
+    }
+
+    size_t capacity() const
+    {
+        return isExt() ? extCapacity_ : Bytes;
+    }
+
+    void append(const Char * start, const Char * end)
+    {
+        append(start, end - start);
+    }
+
+    void append(const Char * bytes, size_t n)
+    {
+        if (n + size() > capacity()) {
+            reserve(std::max(capacity() * 2, capacity() + n));
+        }
+        ExcAssertGreaterEqual(capacity(), size() + n);
+        std::memcpy((Char *)(data() + size()), bytes, n);
+        if (isExt()) {
+            extLength_ += n;
+        }
+        else intLength_ += n;
+    }
+
+private:
+    template<size_t OtherBytes, typename OtherChar>
+    friend class InternedString;
+
+    bool isExt() const noexcept { return intIsExt_; }
+
+    void deleteExt()
+    {
+        delete[] extBytes_;
+    }
+
+    static constexpr size_t INTERNAL_BYTES = Bytes;
+    static constexpr size_t NUM_WORDS = (Bytes + 2) / 8;
+
+    union {
+        struct {
+            uint8_t intIsExt_;
+            uint8_t intLength_;
+            Char intBytes_[Bytes];
+        };
+        struct {
+            uint8_t extIsExt_;
+            uint8_t unused[3];
+            uint32_t extLength_;
+            uint32_t extCapacity_;
+            Char * extBytes_;
+        };
+        uint64_t words[NUM_WORDS];
+    };
+};
+
+
+/*****************************************************************************/
+/* PATH BUILDER                                                              */
+/*****************************************************************************/
+
+/** This structure is responsible for building paths in an optimal fashion. */
+
+struct PathBuilder {
+    PathBuilder();
+    PathBuilder & add(PathElement && element);
+    PathBuilder & add(const PathElement & element);
+    PathBuilder & addRange(const Path & path, size_t first, size_t last);
+    Path extract();
+
+private:
+    std::vector<uint32_t> indexes;
+    InternedString<244, char> bytes;
+};
+
+
+/*****************************************************************************/
+/* PATH                                                                      */
 /*****************************************************************************/
 
 /** A list of path elements points that gives a full path to an entity.
     Row and column names are paths.
 */
 
-struct Path: protected ML::compact_vector<PathElement, 2, uint32_t, false> {
-    typedef ML::compact_vector<PathElement, 2, uint32_t, false> Base;
+struct Path {
+    Path()
+        : length_(0), ofsPtr_(0)
+    {
+    }
 
-    Path();
     Path(PathElement && path);
     Path(const PathElement & path);
+
     template<typename T>
     Path(const std::initializer_list<T> & val)
         : Path(val.begin(), val.end())
     {
     }
 
+    Path(const PathElement * start, size_t len);
+
     template<typename It>
     Path(It first, It last)
-        : Base(first, last)
+        : Path()
     {
+        PathBuilder result;
+        while (first != last) {
+            result.add(std::move(*first++));
+        }
+        *this = result.extract();
     }
 
-    Path(const PathElement * path, size_t length);
+    Path(const Path & other)
+        : bytes_(other.bytes_),
+          length_(other.length_),
+          ofsBits_(other.ofsBits_)
+    {
+        if (JML_UNLIKELY(externalOfs())) {
+            ofsPtr_ = new uint32_t[length_ + 1];
+            ExcAssert(other.ofsPtr_);
+            for (size_t i = 0;  i <= length_;  ++i) {
+                ofsPtr_[i] = other.ofsPtr_[i];
+            }
+        }
+    }
+
+    Path(Path && other) noexcept
+        : Path()
+    {
+        swap(other);
+    }
+
+    void swap(Path & other) noexcept
+    {
+        using std::swap;
+        bytes_.swap(other.bytes_);
+        swap(ofsBits_, other.ofsBits_);
+        swap(length_, other.length_);
+    }
+
+    Path & operator = (Path && other) noexcept
+    {
+        swap(other);
+        return *this;
+    }
+
+    Path & operator = (const Path & other)
+    {
+        Path newMe(other);
+        swap(newMe);
+        return *this;
+    }
+
+    ~Path()
+    {
+        if (JML_UNLIKELY(externalOfs())) {
+            delete[] ofsPtr_;
+        }
+    }
+
+    struct Iterator
+        : public std::iterator<std::random_access_iterator_tag, const PathElement,
+                               std::ptrdiff_t, const PathElement*,
+                               const PathElement &> {
+        const Path * p;
+        size_t index;
+
+        Iterator(const Path * p = nullptr, size_t index = 0)
+            : p(p), index(index)
+        {
+        }
+
+        PathElement operator * () const
+        {
+            ExcAssert(p);
+            return p->at(index);
+        }
+
+        Iterator& operator ++ ()
+        {
+            ++index;
+            return *this;
+        }
+
+        Iterator operator ++ (int)
+        {
+            Iterator result = *this;
+            operator ++ ();
+            return result;
+        }
+
+        std::ptrdiff_t operator - (const Iterator & other) const
+        {
+            return index - other.index;
+        }
+
+        Iterator operator + (std::ptrdiff_t offset) const
+        {
+            Iterator result = *this;
+            result.index += offset;
+            return result;
+        }
+
+        Iterator operator - (std::ptrdiff_t offset) const
+        {
+            Iterator result = *this;
+            result.index -= offset;
+            return result;
+        }
+
+        Iterator & operator += (std::ptrdiff_t offset)
+        {
+            index += offset;
+            return *this;
+        }
+
+        bool operator == (const Iterator & other) const
+        {
+            return p == other.p && index == other.index;
+        }
+
+        bool operator != (const Iterator & other) const
+        {
+            return ! operator == (other);
+        }
+
+        bool operator < (const Iterator & other) const
+        {
+            // Not well defined if base pointers aren't the same
+            ExcAssert(p == other.p);
+            return index < other.index;
+        }
+    };
+
+    Iterator begin() const
+    {
+        return Iterator(this, 0);
+    }
+
+    Iterator end() const
+    {
+        return Iterator(this, length_);
+    }
 
     static Path parse(const Utf8String & str);
     static Path parse(const char * str, size_t len);
@@ -426,62 +761,91 @@ struct Path: protected ML::compact_vector<PathElement, 2, uint32_t, false> {
     /// with legacy hashes.
     uint64_t newHash() const;
 
-    using Base::size;
-    using Base::empty;
-    using Base::begin;
-    using Base::end;
-    using Base::at;
-    using Base::front;
-    using Base::back;
-    using Base::operator [];
-    using Base::pop_back;
+    size_t size() const
+    {
+        return length_;
+    }
 
-    PathElement head() const
+    bool empty() const
+    {
+        return length_ == 0;
+    }
+
+    PathElement operator [] (size_t el) const
+    {
+        return at(el);
+    }
+    
+    PathElement at(size_t el) const
+    {
+        const char * d = data();
+        const char * b = d + offset(el);
+        const char * e = d + offset(el + 1);
+        return PathElement(b, e - b);
+    }
+
+    PathElement front() const
     {
         return at(0);
     }
 
-    Path tail() const
+    PathElement back() const
     {
-        ExcAssert(!empty());
-        Path result;
-        result.insert(result.end(), begin() + 1, end());
-        return result;
+        return at(length_ - 1);
     }
 
-    bool operator == (const Path & other) const
+    PathElement head() const
     {
-        return static_cast<const Base &>(*this) == other;
+        return front();
     }
 
-    bool operator != (const Path & other) const
-    {
-        return ! operator == (other);
-    }
+    Path tail() const;
 
-    bool operator < (const Path & other) const
-    {
-        return static_cast<const Base &>(*this) < other;
-    }
+    bool operator == (const Path & other) const;
+    bool operator != (const Path & other) const;
+    bool operator < (const Path & other) const;
+    bool operator <= (const Path & other) const;
+    bool operator > (const Path & other) const;
+    bool operator >= (const Path & other) const;
 
-    bool operator <= (const Path & other) const
-    {
-        return static_cast<const Base &>(*this) <= other;
-    }
-
-    bool operator > (const Path & other) const
-    {
-        return static_cast<const Base &>(*this) > other;
-    }
-
-    bool operator >= (const Path & other) const
-    {
-        return static_cast<const Base &>(*this) >= other;
-    }
+    int compare(const Path & other) const;
 
     size_t memusage() const;
 
 private:
+    friend class PathBuilder;
+    bool equalElement(size_t el, const Path & other, size_t otherEl) const;
+    bool lessElement(size_t el, const Path & other, size_t otherEl) const;
+    int compareElement(size_t el, const Path & other, size_t otherEl) const;
+
+    bool externalOfs() const
+    {
+        return length_ >= 8 || bytes_.size() >= 256;
+    }
+    
+    const char * data() const
+    {
+        return bytes_.data();
+    }
+
+    /// Return the byte offsets of the begin and end of this element
+    size_t offset(size_t el) const
+    {
+        ExcAssertLessEqual(el, length_);
+        if (JML_LIKELY(!externalOfs())) {
+            return ofs_[el];
+        }
+        return ofsPtr_[el];
+    }
+    
+    /// Return the range of bytes for the given element
+    std::pair<const char *, size_t>
+    getStringView(size_t el) const
+    {
+        size_t o0 = offset(el), o1 = offset(el + 1);
+        return { data() + o0, o1 - o0 };
+    }
+
     /** Internal parsing method.  Will attempt to parse the given range
         which is assumed to contain valid UTF-8 data, and will return
         the parsed version and true if valid, or if invalid either throw
@@ -490,6 +854,20 @@ private:
     */
     static std::pair<Path, bool>
     parseImpl(const char * str, size_t len, bool exceptions);
+
+    /// Encoded version of the string, not including separators
+    InternedString<46, char> bytes_;
+
+    /// Number of elements in the path
+    uint32_t length_;
+    
+    /// Byte index of the first 8 components of the path, or a ptr to
+    /// an array with all the rest if length_ > 8
+    union {
+        uint8_t ofs_[8];
+        uint32_t * ofsPtr_;
+        uint64_t ofsBits_;
+    };
 };
 
 std::ostream & operator << (std::ostream & stream, const Path & id);

--- a/sql/testing/path_test.cc
+++ b/sql/testing/path_test.cc
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(test_coord_constructor)
 
     BOOST_CHECK_EQUAL(coords1.toUtf8String(), "");
 
-    BOOST_CHECK_EQUAL((coords1 + coord1).toUtf8String(), "");
+    BOOST_CHECK_EQUAL((coords1 + coord1).toUtf8String(), "\"\"");
     BOOST_CHECK_EQUAL(Path(coord1).toUtf8String(), "");
 
     vector<PathElement> coords2;
@@ -237,4 +237,80 @@ BOOST_AUTO_TEST_CASE(test_remove_prefix)
 
     BOOST_CHECK(test.startsWith(none));
     BOOST_CHECK_EQUAL(test.removePrefix(none), test);
+}
+
+void test_self_compare(const Path & p)
+{
+    BOOST_CHECK_EQUAL(p, p);
+    BOOST_CHECK(!(p != p));
+    BOOST_CHECK_LE(p, p);
+    BOOST_CHECK_GE(p, p);
+    BOOST_CHECK(!(p < p));
+    BOOST_CHECK(!(p > p));
+    BOOST_CHECK_EQUAL(p.compare(p), 0);
+}
+
+void test_compare_eq(const Path & p1, const Path & p2)
+{
+    BOOST_CHECK_EQUAL(p1, p2);
+    BOOST_CHECK_EQUAL(p1 < p2, false);
+    BOOST_CHECK_EQUAL(p1 > p2, false);
+    BOOST_CHECK_EQUAL(p1 <= p2, true);
+    BOOST_CHECK_EQUAL(p1 >= p2, true);
+    BOOST_CHECK_EQUAL(p1.compare(p2), 0);
+    BOOST_CHECK_EQUAL(p1.toUtf8String(), p2.toUtf8String());
+}
+
+void test_compare_ordered(const Path & p1, const Path & p2)
+{
+    BOOST_CHECK_NE(p1, p2);
+
+    BOOST_CHECK_EQUAL(p1 < p2, true);
+    BOOST_CHECK_EQUAL(p1 <= p2, true);
+    BOOST_CHECK_EQUAL(p1 > p2, false);
+    BOOST_CHECK_EQUAL(p1 >= p2, false);
+    BOOST_CHECK_LE(p1.compare(p2), -1);
+
+    BOOST_CHECK_EQUAL(p2 < p1, false);
+    BOOST_CHECK_EQUAL(p2 <= p1, false);
+    BOOST_CHECK_EQUAL(p2 > p1, true);
+    BOOST_CHECK_EQUAL(p2 >= p1, true);
+    BOOST_CHECK_GE(p2.compare(p1), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_compare)
+{
+    Path p0 {};
+    Path p1a { 1 };
+    Path p1b { 2 };
+    Path p2a { 1, 2 };
+    Path p2b { 1, 3 };
+    Path p2c { 2, 3 };
+    Path p3a { 1, 2, 3 };
+
+    vector<Path> ordered = { p0, p1a, p2a, p3a, p1b, p2c };
+
+    for (size_t i = 0;  i < ordered.size();  ++i) {
+
+        test_compare_eq(ordered[i], ordered[i]);
+        test_self_compare(ordered[i]);
+
+        for (size_t j = 0;  j < i;  ++j) {
+            test_compare_ordered(ordered[j], ordered[i]);
+        }
+
+        for (size_t j = i + 1;  j < ordered.size();  ++j) {
+            test_compare_ordered(ordered[i], ordered[j]);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_append)
+{
+    Path p0 {};
+    Path p1 { 1 };
+
+    BOOST_CHECK_EQUAL(p0 + p0, p0);
+    BOOST_CHECK_EQUAL(p0 + p1, p1);
+    BOOST_CHECK_EQUAL(p1 + p0, p1);
 }

--- a/testing/MLDB-180-basic-join.js
+++ b/testing/MLDB-180-basic-join.js
@@ -13,10 +13,12 @@ function assertEqual(expr, val)
 }
 
 
-function testQuery(query, expected) {
+function testQuery(query, expected, sortColumns) {
+    if (sortColumns === undefined)
+        sortColumns = false;
     mldb.log("testing query", query);
 
-    var resp = mldb.get('/v1/query', {q: query, format: 'table'});
+    var resp = mldb.get('/v1/query', {q: query, format: 'table', sortColumns: sortColumns});
 
     mldb.log("received", resp.json);
     mldb.log("expected", expected);
@@ -439,21 +441,21 @@ dataset6.recordRow("ex6", [ [ "x", null, ts ], ["z", 3, ts] ]);
 dataset6.commit()
 
 expected = [
-   [ "_rowName", "test4.x", "test4.z", "test5.x", "test5.z", "test3.x", "test3.y", "test3.z", "test6.x", "test6.z"],
-   [ "[]-[ex4]-[]-[]", 2, 2, null, null, null, null, null, null, null ],
-   [ "[]-[ex5]-[]", null, null, 1, 2, null, null, null, null, null ],
-   [ "[]-[ex5]-[]-[]", null, 3, null, null, null, null, null, null, null ],
-   [ "[]-[ex6]-[]", null, null, 2, 2, null, null, null, null, null ],
-   [ "[ex1]-[]-[ex1]-[]", null, null, null, 3, 1, 2, null, null, null ],
-   [ "[ex2]-[]-[]-[]", null, null, null, null, 2, null, 4, null, null ],
-   [ "[ex3]-[ex3]-[]-[ex3]", 1, 2, null, null, null, null, 3, 1, 2 ],
-   [ "[]-[ex4]", null, null, null, null, null, null, null, 2, 2 ],
-   [ "[]-[ex6]", null, null, null, null, null, null, null, null, 3 ]
+    [ "_rowName", "test3.x", "test3.y", "test3.z", "test4.x", "test4.z", "test5.x", "test5.z", "test6.x", "test6.z" ],
+    [ "[]-[ex4]", null, null, null, null, null, null, null, 2, 2 ],
+    [ "[]-[ex4]-[]-[]", null, null, null, 2, 2, null, null, null, null ],
+    [ "[]-[ex5]-[]", null, null, null, null, null, 1, 2, null, null ],
+    [ "[]-[ex5]-[]-[]", null, null, null, null, 3, null, null, null, null ],
+    [ "[]-[ex6]", null, null, null, null, null, null, null, null, 3 ],
+    [ "[]-[ex6]-[]", null, null, null, null, null, 2, 2, null, null ],
+    [ "[ex1]-[]-[ex1]-[]", 1, 2, null, null, null, null, 3, null, null ],
+    [ "[ex2]-[]-[]-[]", 2, null, 4, null, null, null, null, null, null ],
+    [ "[ex3]-[ex3]-[]-[ex3]", null, null, 3, 1, 2, null, null, 1, 2 ]
 ];
 
 
-testQuery('SELECT * FROM test3 OUTER JOIN test4 ON test3.rowName() = test4.rowName() OUTER JOIN test5 on test3.rowName() = test5.rowName() OUTER JOIN test6 on test3.rowName() = test6.rowName()',
-          expected);
+testQuery('SELECT * FROM test3 OUTER JOIN test4 ON test3.rowName() = test4.rowName() OUTER JOIN test5 on test3.rowName() = test5.rowName() OUTER JOIN test6 on test3.rowName() = test6.rowName() ORDER BY rowName()',
+          expected, true /* sortColumns */);
 
 //MLDB-1384
 //asking for unknow column in the WHERE should not throw.

--- a/testing/MLDB-878_experiment_proc.py
+++ b/testing/MLDB-878_experiment_proc.py
@@ -78,7 +78,7 @@ class Mldb878Test(MldbUnitTest):
         assert len(js_rez["status"]["folds"]) == 2
         for i in xrange(2):
             assert js_rez["status"]["folds"][i]["resultsTest"]["auc"] > 0.95, \
-                'expected AUC to be above 0.95'
+                'expected AUC %f to be above 0.95' % js_rez["status"]["folds"][i]["resultsTest"]["auc"]
 
         # score using the predictor (MLDB-1070)
         def apply_predictor():

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -898,3 +898,65 @@
    fun:_dl_init
    obj:/lib/x86_64-linux-gnu/ld-2.19.so
 }
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNSs4_Rep9_S_createEmmRKSaIcE
+   obj:/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21
+   fun:_ZNSsC1EPKcRKSaIcE
+   fun:__static_initialization_and_destruction_0
+   ...
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/lib/x86_64-linux-gnu/ld-2.19.so
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:_ZN2ML11Dense_LayerIfE10RegisterMeC1Ev
+   ...
+   fun:_dl_init
+   obj:/lib/x86_64-linux-gnu/ld-2.19.so
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:_ZN2ML11Dense_LayerIdE10RegisterMeC1Ev
+   ...
+   fun:_dl_init
+   obj:/lib/x86_64-linux-gnu/ld-2.19.so
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znwm
+   fun:_ZN10Datacratic20ValueDescriptionInitISt3mapISsNS_8JsonDiffESt4lessISsESaISt4pairIKSsS2_EEEE6createEv
+   fun:operator()
+   fun:_ZN10Datacratic24registerValueDescriptionERKSt9type_infoSt8functionIFPNS_16ValueDescriptionEvEES3_IFvRS4_EEb
+   fun:_ZN10Datacratic27getDefaultDescriptionSharedISt3mapISsNS_8JsonDiffESt4lessISsESaISt4pairIKSsS2_EEEEESt10shared_ptrIKNS_17ValueDescriptionTIT_EEEPSC_
+   fun:getDefaultDescriptionSharedT<std::map<std::basic_string<char>, Datacratic::JsonDiff> >
+   fun:addField<std::map<std::basic_string<char>, Datacratic::JsonDiff>, Datacratic::JsonDiff>
+   fun:_ZN10Datacratic19JsonDiffDescriptionC1Ev
+   fun:_ZN10Datacratic21getDefaultDescriptionEPNS_8JsonDiffE
+   fun:_ZN10Datacratic31JsonArrayElementDiffDescriptionC1Ev
+   fun:operator()
+   fun:_ZNSt17_Function_handlerIFPN10Datacratic16ValueDescriptionEvEZNS0_31JsonArrayElementDiffDescription5RegmeC1EvEUlvE_E9_M_invokeERKSt9_Any_data
+   fun:operator()
+   fun:_ZN10Datacratic24registerValueDescriptionERKSt9type_infoSt8functionIFPNS_16ValueDescriptionEvEES3_IFvRS4_EEb
+   fun:_ZN10Datacratic24registerValueDescriptionERKSt9type_infoSt8functionIFPNS_16ValueDescriptionEvEEb
+   fun:_ZN10Datacratic31JsonArrayElementDiffDescription5RegmeC1Ev
+   fun:__static_initialization_and_destruction_0
+   fun:_GLOBAL__sub_I_json_diff.cc
+}


### PR DESCRIPTION
This patch moves from a vector representation to an indexed string representation for paths.  It results in roughly a 2x speed improvement for query performance, due to less pointer chasing, and mostly closes the performance gap with the pre-singularity version of MLDB.

There are other improvements possible; this is the low-hanging fruit.
