### PR TITLE
Escape \ and $ in command_key. Fixes cache miss.

### DIFF
--- a/jml-build/functions.mk
+++ b/jml-build/functions.mk
@@ -46,12 +46,13 @@ ifneq ($(__BASH_MAKE_COMPLETION__),1)
 NOTHING :=
 SPACE := $(NOTHING) $(NOTHING)
 TAB := $(NOTHING)	$(NOTHING)
+DOLLAR := $$
 
 hash_command2 = $(wordlist 1,1,$(shell echo $(strip $(1)) | md5sum))
 
 hash_command1 = $(eval HASH:=$(call hash_command2,$(1)))$(shell echo $(1)_hash:=$(HASH) >> .make_hash_cache)$(eval $(1)_hash:=$(HASH))
 
-command_key = $(subst =,_,$(subst $(SPACE),_,$(strip $(1))))
+command_key = $(subst =,_,$(subst $(SPACE),_,$(subst $(DOLLAR),_,$(subst \,,$(strip $(1))))))
 
 hash_command = $(eval KEY=$(call command_key,$(1)))$(if $($(KEY)_hash),,$(call hash_command1,$(KEY)))$(if $($(KEY)_hash),,$(error hash_command1 didnt set variable $(KEY)_hash))$($(KEY)_hash)
 


### PR DESCRIPTION
When not escaped, \ and $ would cause a mismatch between the key stored
in the .make_hash_cache file and the key returned to make, thereby
causing costly execution of `bash -c 'echo ... | md5sum'` and adding a
duplicate target to .make_hash_cache

This fixes the cache miss cases and speeds up the build startup time.