### PR TITLE
Fix s3 tryPop infinite loop

### DIFF
--- a/soa/service/s3.cc
+++ b/soa/service/s3.cc
@@ -2224,6 +2224,9 @@ struct StreamingUploadSource {
                         onException();
                     }
                 }
+                else {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                }
             }
         }
     };


### PR DESCRIPTION
https://github.com/mldbai/mldb/pull/437/files#diff-1df7fd725c20425abb80dbf865d2a6f2R2190

Si tryPop retourne instantanément, ça infinite looooooop.