### PR TITLE
Disable access logging for uwsgi_validator_runner

### DIFF
--- a/container_files/init/uwsgi_validator_runner.sh
+++ b/container_files/init/uwsgi_validator_runner.sh
@@ -12,6 +12,7 @@ exec /sbin/setuser _mldb /usr/local/bin/uwsgi \
     --die-on-term \
     --processes 8 \
     --logto=/var/log/validator_api/validator_api.log \
+    --disable-logging \
     --chdir=/opt/bin \
     --wsgi-file=/opt/bin/validator_api.wsgi \
     --pythonpath=/opt/lib/python2.7 \


### PR DESCRIPTION
Option name is misleading, it disables access logging, not all logging.
Exceptions and operational messages such as child proc restarting are
still logged.