### PR TITLE
Path speedups (MLDB-1632)

### DIFF
--- a/sql/path.cc
+++ b/sql/path.cc
@@ -1326,8 +1326,8 @@ operator == (const Path & other) const
     //if (digits_ != other.digits_)
     //    return false;
 
-    // Short circuit
-    if (offset(0) == 0 && other.offset(0) == 0) {
+    // Short circuit (currently offset(0) is always 0, so always taken).
+    if (/*offset(0) == 0 && other.offset(0) == 0*/ true) {
         for (size_t i = 1;  i <= length_;  ++i) {
             if (offset(i) != other.offset(i)) {
                 return false;

--- a/sql/path.h
+++ b/sql/path.h
@@ -848,7 +848,7 @@ private:
     }
 
     /// Return the byte offsets of the begin and end of this element
-    inline size_t offset(size_t el) const
+    JML_ALWAYS_INLINE size_t offset(size_t el) const
     {
         //ExcAssertLessEqual(el, length_);
         if (JML_LIKELY(!externalOfs())) {


### PR DESCRIPTION
Trivial speedups to allow inlining and reduce the cost of paths.