### PR TITLE
Removed spdlog from public API (MLDB-1757)

### DIFF
--- a/core/procedure.h
+++ b/core/procedure.h
@@ -12,7 +12,6 @@
 #include "mldb/rest/rest_entity.h"
 #include "mldb/sql/sql_expression.h"
 #include "mldb/sql/sql_expression_operations.h"
-#include "mldb/utils/log.h"
 #include <set>
 #include <iostream>
 #include <typeinfo>

--- a/plugins/bucketize_procedure.cc
+++ b/plugins/bucketize_procedure.cc
@@ -20,6 +20,7 @@
 #include "mldb/types/date.h"
 #include "mldb/sql/sql_expression.h"
 #include "mldb/plugins/sql_config_validator.h"
+#include "mldb/utils/log.h"
 #include "progress.h"
 #include <memory>
 

--- a/plugins/classifier.cc
+++ b/plugins/classifier.cc
@@ -42,6 +42,7 @@
 #include "mldb/types/any_impl.h"
 #include "mldb/rest/in_process_rest_connection.h"
 #include "mldb/server/static_content_macro.h"
+#include "mldb/utils/log.h"
 
 
 using namespace std;

--- a/plugins/tfidf.cc
+++ b/plugins/tfidf.cc
@@ -25,6 +25,7 @@
 #include "mldb/vfs/filter_streams.h"
 #include "mldb/vfs/fs_utils.h"
 #include "mldb/plugins/sql_config_validator.h"
+#include "mldb/utils/log.h"
 
 using namespace std;
 


### PR DESCRIPTION
Avoids including spdlog as part of the plugin API headers and thus exposing our users to it.