### PR TITLE
Sharded row index for Tabular dataset (MLDB-1762)

### DIFF
--- a/plugins/tabular_dataset_chunk.h
+++ b/plugins/tabular_dataset_chunk.h
@@ -102,6 +102,16 @@ struct TabularDatasetChunk {
         }
     }
 
+    RowName getRowName(size_t index) const
+    {
+        return rowNames.at(index);
+    }
+
+    const RowName & getRowName(size_t index, RowName & storage) const
+    {
+        return rowNames.at(index);
+    }
+
     std::vector<std::shared_ptr<FrozenColumn> > columns;
     std::unordered_map<ColumnName, std::shared_ptr<FrozenColumn>, PathNewHasher> sparseColumns;
     std::vector<RowName> rowNames;


### PR DESCRIPTION
Also fixes issues with row name generation when offset and limit aren't at their default values.

This reduces by about 80% the time elapsed creating the row index of a large tabular dataset post-import.
