### PR TITLE
Reduced storage requirements where row names are integers (MLDB-1763)

### DIFF
--- a/sql/path.cc
+++ b/sql/path.cc
@@ -538,7 +538,9 @@ toIndex() const
     const char * p = data();
     const char * e = p + dataLength();
     if (e == p)
-        return false;
+        return -1;
+    if (*p == '0' && dataLength() != 1)
+        return -1;
     for (; p != e;  ++p) {
         if (!isdigit(*p))
             return -1;
@@ -982,6 +984,25 @@ toUtf8String() const
         result += at(i).toEscapedUtf8String(); 
         first = false;
     }
+    return result;
+}
+
+ssize_t
+Path::
+toIndex() const
+{
+    if (length_ != 1 || digits(0) != PathElement::DIGITS_ONLY)
+        return -1;
+    return at(0).toIndex();
+}
+
+size_t
+Path::
+requireIndex() const
+{
+    ssize_t result = toIndex();
+    if (result == -1)
+        throw HttpReturnException(400, "Path was not an index");
     return result;
 }
 

--- a/sql/path.h
+++ b/sql/path.h
@@ -741,6 +741,28 @@ struct Path {
 
     Utf8String toUtf8String() const;
 
+    /** Returns if this is an index, that is a non-negative integer
+        (possibly with leading zeros) that can be converted into an
+        array index.
+    */
+    bool isIndex() const
+    {
+        return length_ == 1
+            && digits(0) == PathElement::DIGITS_ONLY
+            && at(0).isIndex();
+    }
+
+    /** Convert to an integer, and return it.  If isIndex() is false,
+        then this will return -1.
+    */
+    ssize_t toIndex() const;
+
+    /** Convert to an integer, and return it.  If isIndex() is false,
+        then this will throw an exception.
+    */
+    size_t requireIndex() const;
+
+
     Path operator + (const Path & other) const;
     Path operator + (Path && other) const;
     Path operator + (const PathElement & other) const;

--- a/sql/testing/path_test.cc
+++ b/sql/testing/path_test.cc
@@ -231,10 +231,10 @@ BOOST_AUTO_TEST_CASE(test_indexes)
 {
     BOOST_CHECK_EQUAL(PathElement(0).toIndex(), 0);
     BOOST_CHECK_EQUAL(PathElement("0").toIndex(), 0);
-    BOOST_CHECK_EQUAL(PathElement("00").toIndex(), 0);
+    BOOST_CHECK_EQUAL(PathElement("00").toIndex(), -1);
     BOOST_CHECK_EQUAL(PathElement(123456789).toIndex(), 123456789);
     BOOST_CHECK_EQUAL(PathElement("123456789").toIndex(), 123456789);
-    BOOST_CHECK_EQUAL(PathElement("0123456789").toIndex(), 123456789);
+    BOOST_CHECK_EQUAL(PathElement("0123456789").toIndex(), -1);
     BOOST_CHECK_EQUAL(PathElement(-1).toIndex(), -1);
     BOOST_CHECK_EQUAL(PathElement(-1000).toIndex(), -1);
 }


### PR DESCRIPTION
Goes from roughly 80 byte overhead per row to a 16 byte overhead when row names are just integers.