### PR TITLE
Don'e re-sort and copy already sorted Structured ExpressionValues (MLDB-1764)

### DIFF
--- a/sql/path.cc
+++ b/sql/path.cc
@@ -421,6 +421,24 @@ operator <  (const PathElement & other) const
 
 bool
 PathElement::
+operator <= (const PathElement & other) const
+{
+    //ExcAssertEqual(digits_, calcDigits(data(), dataLength()));
+    //ExcAssertEqual(other.digits_, calcDigits(other.data(), other.dataLength()));
+
+    if (digits_ == NO_DIGITS && other.digits_ == NO_DIGITS) {
+        size_t l1 = dataLength();
+        size_t l2 = other.dataLength();
+        int res = std::memcmp(data(), other.data(), std::min(l1, l2));
+        if (res) return res <= 0;
+        return l1 <= l2;
+    }
+
+    return compareString(other.data(), other.dataLength()) <= 0;
+}
+
+bool
+PathElement::
 startsWith(const std::string & other) const
 {
     return toUtf8String().startsWith(other);

--- a/sql/path.h
+++ b/sql/path.h
@@ -137,6 +137,7 @@ struct PathElement {
     bool operator == (const PathElement & other) const;
     bool operator != (const PathElement & other) const;
     bool operator <  (const PathElement & other) const;
+    bool operator <= (const PathElement & other) const;
 
     bool startsWith(const std::string & other) const;
     bool startsWith(const PathElement & other) const;


### PR DESCRIPTION
Pure performance improvement: don't copy and sort something that's already sorted.
