### PR TITLE
Use reasonable form of implementation of rowPath() function that doesn't parse rowName() (MLDB-1765)

### DIFF
--- a/server/dataset_context.cc
+++ b/server/dataset_context.cc
@@ -207,14 +207,6 @@ doGetFunction(const Utf8String & tableName,
     if (fnoverride)
         return fnoverride;
 
-    // Look for a derived function
-    auto fnderived
-        = getDatasetDerivedFunction(tableName, functionName, args, argScope,
-                                    *this, "row");
-
-    if (fnderived)
-        return fnderived;
-
     if (functionName == "rowName") {
         return {[=] (const std::vector<ExpressionValue> & args,
                      const SqlRowScope & context)
@@ -250,6 +242,15 @@ doGetFunction(const Utf8String & tableName,
                 std::make_shared<Uint64ValueInfo>()
                 };
     }
+
+    // Look for a derived function.  We do it here so that it's only done
+    // if the function can't be found higher up.
+    auto fnderived
+        = getDatasetDerivedFunction(tableName, functionName, args, argScope,
+                                    *this, "row");
+
+    if (fnderived)
+        return fnderived;
 
     /* columnCount function: return number of columns with explicit values set
        in the current row.


### PR DESCRIPTION
Pure performance improvement.  We use a generic emulated version of rowPath() rather than the one provided by the dataset by overriding in the wrong place.
