### PR TITLE
Copying optimizations for query execution (MLDB-1770)

### DIFF
--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -3039,9 +3039,13 @@ bind(SqlBindingScope & context) const
                      const VariableFilter & filter) -> const ExpressionValue &
         {
             StructValue result;
+            result.reserve(boundClauses.size());
             for (auto & c: boundClauses) {
-                ExpressionValue v = c(context, filter);
-                v.mergeToRowDestructive(result);
+                ExpressionValue storage;
+                const ExpressionValue & v = c(context, storage, filter);
+                if (&v == &storage)
+                    storage.mergeToRowDestructive(result);
+                else v.appendToRow(Path(), result);
             }
             
             return storage = std::move(ExpressionValue(std::move(result)));

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -1776,18 +1776,18 @@ bind(SqlBindingScope & scope) const
                      const VariableFilter & filter) -> const ExpressionValue &
         {  
             Date ts = Date::negativeInfinity();
-            std::vector<CellValue> cells;
 
             if (lastLevel) {
-                cells.reserve(boundClauses.size());
+                std::vector<CellValue> cells(boundClauses.size());
 
-                for (auto & c: boundClauses) {
+                for (size_t i = 0;  i < boundClauses.size();  ++i) {
+                    auto & c = boundClauses[i];
                     ExpressionValue storage2;
                     const ExpressionValue & v = c(scope, storage2, filter);
                     ts.setMax(v.getEffectiveTimestamp());
                     if (&v == &storage2)
-                        cells.emplace_back(storage2.stealAtom());
-                    else cells.emplace_back(v.getAtom());
+                        cells[i] = storage2.stealAtom();
+                    else cells[i] = v.getAtom();
                 }
 
                 ExpressionValue result(std::move(cells), ts);


### PR DESCRIPTION
Optimization to reduce copying that becomes a bottleneck when creating small embeddings like 3-space coordinates.