### PR TITLE
Don't perform extra SqlRowScope type checking (MLDB-1421)

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -267,3 +267,9 @@ sudo apt-get install clang-3.5
 
 You can then add `toolchain=clang` to compile with the clang compiler.
 
+## Environment variables
+
+* `MLDB_CHECK_ROW_SCOPE_TYPES` is a boolean (default 0) that tells MLDB
+  whether to do extra type checking of row scopes.  Setting to 1 will
+  do so, at the expense of slightly slower code.  It may be helpful in
+  debugging of segmentation faults.

--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -15,6 +15,7 @@
 #include "mldb/types/enum_description.h"
 #include "mldb/types/pair_description.h"
 #include "mldb/types/map_description.h"
+#include "mldb/jml/utils/environment.h"
 #include "sql_expression_operations.h"
 #include "table_expression_operations.h"
 #include "interval.h"
@@ -653,6 +654,25 @@ UnboundEntitiesDescription()
 /*****************************************************************************/
 /* SQL ROW SCOPE                                                             */
 /*****************************************************************************/
+
+// Environment variable that tells us whether we check the row scope types
+// or not, which may be more expensive.
+ML::Env_Option<bool> MLDB_CHECK_ROW_SCOPE_TYPES
+("MLDB_CHECK_ROW_SCOPE_TYPES", false);
+
+// Visible manifestation of that variable.  We statically initialize it here
+// so that it can still be accessed before shared library initialization.
+bool SqlRowScope::checkRowScopeTypes = false;
+
+namespace {
+// Initialize with the final value once the library loads
+struct InitializeCheckRowScopeTypes {
+    InitializeCheckRowScopeTypes()
+    {
+        SqlRowScope::checkRowScopeTypes = MLDB_CHECK_ROW_SCOPE_TYPES;
+    }
+};
+} // file scope
 
 void
 SqlRowScope::

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -812,13 +812,19 @@ struct SqlRowScope {
                                      const std::type_info & typeFound)
         __attribute__((noreturn));
 
+    /** Static variable controlled by the MLDB_CHECK_ROW_SCOPE_TYPES
+        environment variable that decides whether we do extra checks
+        (which may be expensive) or not.
+    */
+    static bool checkRowScopeTypes;
+
     /** Assert that the type of this object is the one given, and return it
         as that type.
     */
     template<typename T>
     T & as()
     {
-        if (typeid(*this) == typeid(T))
+        if (JML_LIKELY(!checkRowScopeTypes) || typeid(*this) == typeid(T))
             return static_cast<T &>(*this);
 
         auto * cast = dynamic_cast<T *>(this);
@@ -834,7 +840,7 @@ struct SqlRowScope {
     template<typename T>
     const T & as() const
     {
-        if (typeid(*this) == typeid(T))
+        if (JML_LIKELY(!checkRowScopeTypes) || typeid(*this) == typeid(T))
             return static_cast<const T &>(*this);
 
         auto * cast = dynamic_cast<const T *>(this);


### PR DESCRIPTION
Saves some slightly more expensive checks when converting row scopes.