### PR TITLE
Fixed pathnames for COLUMN EXPR (MLDB-1779)

### DIFF
--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -2056,7 +2056,7 @@ parse(ML::Parse_Context & context, bool allowUtf8)
             as = SqlExpression::parse(context, 10, allowUtf8);
             // As eats whitespace
         }
-        else as = SqlExpression::parse("columnName()");
+        else as = SqlExpression::parse("columnPath()");
         
         if (matchKeyword(context, "WHEN ")) {
             throw HttpReturnException(400, "WHEN clause not supported in row expression");

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -3766,7 +3766,7 @@ bind(SqlBindingScope & scope) const
         if (!keep)
             continue;
 
-        Utf8String newColName = boundAs(thisScope, GET_LATEST).toUtf8String();
+        ColumnName newColName = boundAs(thisScope, GET_LATEST).coerceToPath();
 
         vector<ExpressionValue> orderBy;
         for (auto & c: boundOrderBy) {

--- a/testing/MLDB-1779-select-column-expr-pathnames.js
+++ b/testing/MLDB-1779-select-column-expr-pathnames.js
@@ -1,0 +1,23 @@
+// This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+var resp1 = mldb.query('SELECT column expr () from (select x.a:1, y.b:2)');
+var resp2 = mldb.query('SELECT * from (select x.a:1, y.b:2)');
+
+mldb.log(resp1);
+mldb.log(resp2);
+
+assertEqual(resp1, resp2);
+
+"success"
+

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -396,3 +396,5 @@ $(eval $(call mldb_unit_test,MLDB-1766_dt_categorical.py))
 $(eval $(call mldb_unit_test,MLDB-1750-dist-tables.py))
 $(eval $(call mldb_unit_test,MLDB-1766_dt_categorical_iris.py))
 $(eval $(call mldb_unit_test,MLDB-1502-import-text-column-name-confusion.js))
+$(eval $(call mldb_unit_test,MLDB-1779-select-column-expr-pathnames.js))
+


### PR DESCRIPTION
It was assuming strings and using columnName() not columnPath() as the default AS