### PR TITLE
MLDB-1603 non printable chars json

### DIFF
--- a/plugins/importtext_procedure.cc
+++ b/plugins/importtext_procedure.cc
@@ -364,7 +364,7 @@ const char * findInvalidAscii(const char * start, size_t length, char*buf, char 
     char* p = buf;
     char* end = buf+length;
     while (p != end) {
-        if (!isJsonValid(*p))
+        if (!isJsonValidAscii(*p))
             *p = replaceInvalidCharactersWith;
         ++p;
     }

--- a/testing/MLDB-1603-nonprintable-chars-json.js
+++ b/testing/MLDB-1603-nonprintable-chars-json.js
@@ -1,0 +1,34 @@
+// This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+// Make sure a valid character code works
+var str = "string with embedded chars " + String.fromCharCode(17);
+
+var resp = mldb.query("select '" + str + "' as res");
+
+mldb.log(resp);
+
+assertEqual(resp[0].columns[0][1], str);
+
+// Make sure a null character doesn't work
+
+var str = "string with embedded chars " + String.fromCharCode(0);
+
+var resp = mldb.get('/v1/query', { q: "select '" + str + "' as res" });
+
+mldb.log(resp);
+
+assertEqual(resp.responseCode, 400);
+
+"success"
+

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -345,6 +345,7 @@ $(eval $(call mldb_unit_test,MLDBFB-506-stats-tbl-sql-expr.py))
 $(eval $(call mldb_unit_test,MLDB-1594-aggregator-empty-row.py))
 $(eval $(call mldb_unit_test,MLDB-1707-no-context-resolve-table.py))
 $(eval $(call mldb_unit_test,MLDB-1706-horizontal.py))
+$(eval $(call mldb_unit_test,MLDB-1603-nonprintable-chars-json.js))
 
 # The MLDB-1398 test case requires a library and a plugin
 # Tensorflow plugins

--- a/types/json_printing.h
+++ b/types/json_printing.h
@@ -26,7 +26,7 @@ void jsonEscape(const std::string & str, std::ostream & out);
 
 void jsonEscape(const std::string & str, std::string & out);
 
-bool isJsonValid(char c);
+bool isJsonValidAscii(char c);
 
 /*****************************************************************************/
 /* JSON PRINTING CONTEXT                                                     */


### PR DESCRIPTION
Allows all ASCII control characters to be represented in JSON, as per the JSON spec.