### PR TITLE
Mldbfb 239 http client s3 handlers

### DIFF
--- a/vfs_handlers/exception_ptr.cc
+++ b/vfs_handlers/exception_ptr.cc
@@ -1,0 +1,51 @@
+/* exception_ptr.cc
+   Wolfgang Sourdeau, July 2015
+   Copyright (c) 2015 Datacratic.  All rights reserved.
+
+*/
+
+#include "exception_ptr.h"
+
+
+using namespace std;
+using namespace ML;
+
+
+/****************************************************************************/
+/* EXCEPTIONPTR HANDLER                                                     */
+/****************************************************************************/
+
+bool
+ExceptionPtrHandler::
+hasException()
+{
+    std::unique_lock<mutex> guard(excLock_);
+    return bool(excPtr_);
+}
+
+void
+ExceptionPtrHandler::
+takeException(std::exception_ptr newPtr)
+{
+    std::unique_lock<mutex> guard(excLock_);
+    excPtr_ = newPtr;
+}
+
+void
+ExceptionPtrHandler::
+takeCurrentException()
+{
+    takeException(std::current_exception());
+}
+
+void
+ExceptionPtrHandler::
+rethrowIfSet()
+{
+    std::unique_lock<mutex> guard(excLock_);
+    if (excPtr_) {
+        std::exception_ptr ptr = excPtr_;
+        excPtr_ = nullptr;
+        std::rethrow_exception(ptr);
+    }
+}

--- a/vfs_handlers/exception_ptr.cc
+++ b/vfs_handlers/exception_ptr.cc
@@ -1,18 +1,17 @@
-/* exception_ptr.cc
+/** exception_ptr.cc
    Wolfgang Sourdeau, July 2015
-   Copyright (c) 2015 Datacratic.  All rights reserved.
+   This file is part of MLDB. Copyright (c) 2015 Datacratic. All rights reserved.
 
 */
 
 #include "exception_ptr.h"
 
-
 using namespace std;
-using namespace ML;
+using namespace Datacratic;
 
 
 /****************************************************************************/
-/* EXCEPTIONPTR HANDLER                                                     */
+/* EXCEPTION PTR HANDLER                                                    */
 /****************************************************************************/
 
 bool

--- a/vfs_handlers/exception_ptr.h
+++ b/vfs_handlers/exception_ptr.h
@@ -1,0 +1,33 @@
+/* exception_ptr.h                                                 -*- C++ -*-
+   Wolfgang Sourdeau, July 2015
+   Copyright (c) 2015 Datacratic.  All rights reserved.
+
+*/
+
+#pragma once
+
+#include <exception>
+#include <mutex>
+
+
+namespace ML {
+
+/****************************************************************************/
+/* EXCEPTIONPTR HANDLER                                                     */
+/****************************************************************************/
+
+/* This class provides thread-safe handling of exception-ptr. */
+struct ExceptionPtrHandler {
+    bool hasException();
+    void takeException(std::exception_ptr newPtr);
+    void takeCurrentException();
+    void rethrowIfSet();
+    void clear()
+    { takeException(nullptr); }
+
+private:
+    std::mutex excLock_;
+    std::exception_ptr excPtr_;
+};
+
+} // namespace Datacratic

--- a/vfs_handlers/exception_ptr.h
+++ b/vfs_handlers/exception_ptr.h
@@ -1,7 +1,8 @@
-/* exception_ptr.h                                                 -*- C++ -*-
+/** exception_ptr.h                                                 -*- C++ -*-
    Wolfgang Sourdeau, July 2015
-   Copyright (c) 2015 Datacratic.  All rights reserved.
+   This file is part of MLDB. Copyright (c) 2015 Datacratic. All rights reserved.
 
+   A class that provides thread-safe handling of exception_ptr.
 */
 
 #pragma once
@@ -10,13 +11,12 @@
 #include <mutex>
 
 
-namespace ML {
+namespace Datacratic {
 
 /****************************************************************************/
-/* EXCEPTIONPTR HANDLER                                                     */
+/* EXCEPTION PTR HANDLER                                                    */
 /****************************************************************************/
 
-/* This class provides thread-safe handling of exception-ptr. */
 struct ExceptionPtrHandler {
     bool hasException();
     void takeException(std::exception_ptr newPtr);

--- a/vfs_handlers/vfs_handlers.mk
+++ b/vfs_handlers/vfs_handlers.mk
@@ -1,6 +1,7 @@
 # VFS Handlers
 
 LIBVFS_HANDLERS_SOURCES := \
+	exception_ptr.cc \
 	sftp.cc \
 	s3_handlers.cc \
 	archive.cc \


### PR DESCRIPTION
This PR modifies the S3 downloader and uploader classes by making use of the asynchronous methods offered by S3Api, rather than using multiple threads along with the blocking methods.
This finalizes MLDBFB-239 and brings the actual benefits expected from it, which is to reduce the number of context switches and thereby enhancing the scalability of the s3 subsystem.