### PR TITLE
Added test for already fixed rowPath() with new executor (MLDB-1810)

### DIFF
--- a/testing/MLDB-1810-new-executor-rowpath.js
+++ b/testing/MLDB-1810-new-executor-rowpath.js
@@ -1,0 +1,22 @@
+// This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+
+var resp = mldb.query("select * named ['hello', 'world'] from row_dataset({x:1})");
+
+mldb.log(resp);
+
+// Make sure that the row name is properly structured, and not a single string
+assertEqual(resp[0].rowName, "hello.world");
+
+"success"

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -406,3 +406,4 @@ $(eval $(call mldb_unit_test,MLDB-1808_precision_loss_issue.py))
 
 $(eval $(call test,MLDBFB-239-s3-test,aws vfs_handlers,boost $(MANUAL_IF_NO_S3)))
 $(eval $(call mldb_unit_test,MLDB-1755-column-execution-memory-use.js))
+$(eval $(call mldb_unit_test,MLDB-1810-new-executor-rowpath.js))


### PR DESCRIPTION
Adds a testcase that was left behind in previous changes that fixed the underlying problem.