### PR TITLE
Refactored dataset scope (MLDB-1811)

### DIFF
--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -998,7 +998,10 @@ overrideFunction(const Utf8String & tableName,
                      const SqlRowScope & scope)
                 { 
                     auto & row = scope.as<SqlExpressionDatasetScope::RowScope>();
-                    return ExpressionValue(itl->getSubRowName(row.row.rowName, tableSide).toUtf8String(), Date::negativeInfinity());
+                    return ExpressionValue
+                        (itl->getSubRowName(row.getRowName(), tableSide)
+                             .toUtf8String(),
+                         Date::negativeInfinity());
                 },
                 std::make_shared<Utf8StringValueInfo>()
             };
@@ -1015,7 +1018,10 @@ overrideFunction(const Utf8String & tableName,
                      const SqlRowScope & scope)
                 {
                     auto & row = scope.as<SqlExpressionDatasetScope::RowScope>();
-                    return ExpressionValue(itl->getSubRowNameFromChildTable(tableName, row.row.rowName, tableSide).toUtf8String(), Date::negativeInfinity());
+                    return ExpressionValue
+                        (itl->getSubRowNameFromChildTable
+                         (tableName, row.getRowName(), tableSide).toUtf8String(),
+                         Date::negativeInfinity());
                 },
                 std::make_shared<Utf8StringValueInfo>()
             };
@@ -1033,7 +1039,7 @@ overrideFunction(const Utf8String & tableName,
                      const SqlRowScope & scope)
                 {
                     auto & row = scope.as<SqlExpressionDatasetScope::RowScope>();
-                    RowHash rowHash(row.row.rowName);
+                    RowHash rowHash(row.getRowHash());
                     return ExpressionValue(itl->rows[itl->rowIndex[rowHash]].leftName, Date::negativeInfinity());
                 },
                 std::make_shared<Utf8StringValueInfo>()
@@ -1044,7 +1050,7 @@ overrideFunction(const Utf8String & tableName,
                      const SqlRowScope & scope)
                 {
                     auto & row = scope.as<SqlExpressionDatasetScope::RowScope>();
-                    RowHash rowHash(row.row.rowName);
+                    RowHash rowHash(row.getRowHash());
                     return ExpressionValue(itl->rows[itl->rowIndex[rowHash]].rightName, Date::negativeInfinity());
                 },
                 std::make_shared<Utf8StringValueInfo>()

--- a/server/dataset_context.cc
+++ b/server/dataset_context.cc
@@ -133,6 +133,147 @@ doGetColumn(const Utf8String & tableName,
 /* ROW EXPRESSION DATASET CONTEXT                                            */
 /*****************************************************************************/
 
+RowName
+SqlExpressionDatasetScope::RowScope::
+getRowName() const
+{
+    if (rowName) return *rowName;
+    else {
+        ExcAssert(row);
+        return row->rowName;
+    }
+}
+
+const RowName &
+SqlExpressionDatasetScope::RowScope::
+getRowName(RowName & storage) const
+{
+    if (rowName) return *rowName;
+    else return row->rowName;
+}
+
+RowHash
+SqlExpressionDatasetScope::RowScope::
+getRowHash() const
+{
+    if (rowName) return *rowName;
+    else return row->rowHash;
+}
+
+const ExpressionValue &
+SqlExpressionDatasetScope::RowScope::
+getColumn(const ColumnName & columnName,
+          const VariableFilter & filter,
+          ExpressionValue & storage,
+          ssize_t knownOffset) const
+{
+    if (expr) {
+        const ExpressionValue * val
+            = expr->tryGetNestedColumn(columnName, storage, filter);
+        if (!val)
+            return storage = ExpressionValue::null(Date::negativeInfinity());
+        else return *val;
+    }
+    else {
+        const ExpressionValue * fromOutput
+            = searchRow(row->columns, columnName, filter, storage);
+        if (fromOutput)
+            return *fromOutput;
+        
+        return storage = std::move(ExpressionValue::null(Date::negativeInfinity()));
+    }
+}
+
+ExpressionValue
+SqlExpressionDatasetScope::RowScope::
+getColumnCount() const
+{
+    ML::Lightweight_Hash_Set<ColumnHash> columns;
+    Date ts = Date::negativeInfinity();
+
+    if (row) {
+        
+        for (auto & c: row->columns) {
+            columns.insert(std::get<0>(c));
+            ts.setMax(std::get<2>(c));
+        }
+    }
+    else {
+        auto onAtom = [&] (const Path & columnName,
+                           const Path & prefix,
+                           const CellValue & val,
+                           Date ts)
+            {
+                if (prefix.empty()) {
+                    columns.insert(columnName);
+                }
+                else {
+                    columns.insert(prefix + columnName);
+                }
+                return true;
+            };
+
+        expr->forEachAtom(onAtom);
+    }
+    
+    return ExpressionValue(columns.size(), ts);
+}
+        
+const ExpressionValue &
+SqlExpressionDatasetScope::RowScope::
+getFilteredValue(const VariableFilter & filter,
+                 ExpressionValue & storage) const
+{
+    if (row) {
+        // TODO: if one day we are able to prove that this is
+        // the only expression that touches the row, we could
+        // move it into place
+        ExpressionValue val(row->columns);
+        return storage = val.getFilteredDestructive(filter);
+    }
+    else {
+        return expr->getFiltered(filter, storage);
+    }
+}
+
+ExpressionValue
+SqlExpressionDatasetScope::RowScope::
+getReshaped(const std::unordered_map<ColumnHash, ColumnName> & index,
+            const VariableFilter & filter) const
+{
+    RowValue result;
+
+    if (row) {
+        for (auto & c: row->columns) {
+            auto it = index.find(std::get<0>(c));
+            if (it == index.end()) {
+                continue;
+            }
+            
+            result.emplace_back(it->second, std::get<1>(c), std::get<2>(c));
+        }
+    }
+    else {
+        auto onAtom = [&] (const Path & columnName,
+                           const Path & prefix,
+                           const CellValue & val,
+                           Date ts)
+            {
+                ColumnName newColumnName = prefix + columnName;
+                auto it = index.find(newColumnName);
+                if (it == index.end())
+                    return true;
+                result.emplace_back(it->second, val, ts);
+                return true;
+            };
+
+        expr->forEachAtom(onAtom);
+    }
+
+    ExpressionValue val(std::move(result));
+    return  val.getFilteredDestructive(filter);
+}
+
 SqlExpressionDatasetScope::
 SqlExpressionDatasetScope(std::shared_ptr<Dataset> dataset, const Utf8String& alias)
     : SqlExpressionMldbScope(dataset->server), dataset(*dataset), alias(alias)
@@ -182,13 +323,7 @@ doGetColumn(const Utf8String & tableName,
                  const VariableFilter & filter) -> const ExpressionValue &
             {
                 auto & row = context.as<RowScope>();
-
-                const ExpressionValue * fromOutput
-                    = searchRow(row.row.columns, simplified, filter, storage);
-                if (fromOutput)
-                    return *fromOutput;
-
-                return storage = std::move(ExpressionValue::null(Date::negativeInfinity()));
+                return row.getColumn(simplified, filter, storage);
             },
             std::make_shared<AtomValueInfo>()};
 }
@@ -212,7 +347,7 @@ doGetFunction(const Utf8String & tableName,
                      const SqlRowScope & context)
                 {
                     auto & row = context.as<RowScope>();
-                    return ExpressionValue(row.row.rowName.toUtf8String(),
+                    return ExpressionValue(row.getRowName().toUtf8String(),
                                            Date::negativeInfinity());
                 },
                 std::make_shared<Utf8StringValueInfo>()
@@ -224,7 +359,7 @@ doGetFunction(const Utf8String & tableName,
                      const SqlRowScope & context)
                 {
                     auto & row = context.as<RowScope>();
-                    return ExpressionValue(CellValue(row.row.rowName),
+                    return ExpressionValue(CellValue(row.getRowName()),
                                            Date::negativeInfinity());
                 },
                 std::make_shared<PathValueInfo>()
@@ -236,7 +371,7 @@ doGetFunction(const Utf8String & tableName,
                      const SqlRowScope & context)
                 {
                     auto & row = context.as<RowScope>();
-                    return ExpressionValue(row.row.rowHash,
+                    return ExpressionValue(row.getRowHash().hash(),
                                            Date::negativeInfinity());
                 },
                 std::make_shared<Uint64ValueInfo>()
@@ -260,22 +395,13 @@ doGetFunction(const Utf8String & tableName,
                      const SqlRowScope & context)
                 {
                     auto & row = context.as<RowScope>();
-                    ML::Lightweight_Hash_Set<ColumnHash> columns;
-                    Date ts = Date::negativeInfinity();
-                    
-                    for (auto & c: row.row.columns) {
-                        columns.insert(std::get<0>(c));
-                        ts.setMax(std::get<2>(c));
-                    }
-                    
-                    return ExpressionValue(columns.size(), ts);
+                    return row.getColumnCount();
                 },
                 std::make_shared<Uint64ValueInfo>()};
     }
 
     return SqlExpressionMldbScope
-        ::doGetFunction(tableName, functionName,
-                        args, argScope);
+        ::doGetFunction(tableName, functionName, args, argScope);
 }
 
 ColumnGetter
@@ -367,20 +493,17 @@ doGetAllColumns(const Utf8String & tableName,
         columnsWithInfo[i].columnName = std::move(outputName);
     }
 
-    std::function<ExpressionValue (const SqlRowScope &,  const VariableFilter &)> exec;
+    std::function<ExpressionValue (const SqlRowScope &, const VariableFilter &)> exec;
 
     if (allWereKept && noneWereRenamed) {
         // We can pass right through; we have a select *
 
-        exec = [=] (const SqlRowScope & context, const VariableFilter & filter) -> ExpressionValue
+        exec = [=] (const SqlRowScope & context,
+                    const VariableFilter & filter) -> ExpressionValue
             {
+                ExpressionValue storage;
                 auto & row = context.as<RowScope>();
-
-                // TODO: if one day we are able to prove that this is
-                // the only expression that touches the row, we could
-                // move it into place
-                ExpressionValue val(row.row.columns);
-                return val.getFilteredDestructive(filter);
+                return row.getFilteredValue(filter, storage);
             };
     }
     else {
@@ -388,20 +511,7 @@ doGetAllColumns(const Utf8String & tableName,
         exec = [=] (const SqlRowScope & context, const VariableFilter & filter)
             {
                 auto & row = context.as<RowScope>();
-
-                RowValue result;
-
-                for (auto & c: row.row.columns) {
-                    auto it = index.find(std::get<0>(c));
-                    if (it == index.end()) {
-                        continue;
-                    }
-                
-                    result.emplace_back(it->second, std::get<1>(c), std::get<2>(c));
-                }
-
-                ExpressionValue val(std::move(result));
-                return  val.getFilteredDestructive(filter);
+                return row.getReshaped(index, filter);
             };
 
     }


### PR DESCRIPTION
Refactoring towards allowing ExpressionValue to be passed into a Dataset Scope to remove the dependency on MatrixNamedRow et al.