### PR TITLE
Store timestamps as numbers to improve compression options in Tabular (MLDB-1815)

### DIFF
--- a/plugins/tabular_dataset_chunk.h
+++ b/plugins/tabular_dataset_chunk.h
@@ -151,7 +151,7 @@ public:
         ExcAssertLess(index, rowCount());
         std::vector<std::tuple<ColumnName, CellValue, Date> > result;
         result.reserve(columns.size());
-        Date ts = timestamps->get(index).toTimestamp();
+        Date ts = timestamps->get(index).mustCoerceToTimestamp();
         for (size_t i = 0;  i < columns.size();  ++i) {
             CellValue val = columns[i]->get(index);
             if (val.empty())
@@ -176,7 +176,7 @@ public:
         ExcAssertLess(index, rowCount());
         std::vector<std::tuple<ColumnName, CellValue, Date> > result;
         result.reserve(columns.size());
-        Date ts = timestamps->get(index).toTimestamp();
+        Date ts = timestamps->get(index).mustCoerceToTimestamp();
         for (size_t i = 0;  i < columns.size();  ++i) {
             CellValue val = columns[i]->get(index);
             if (val.empty())
@@ -210,7 +210,7 @@ public:
                     for (unsigned i = 0;  i < rowCount();  ++i) {
                         rows.emplace_back(getRowName(i),
                                           CellValue(),
-                                          timestamps->get(i).toTimestamp());
+                                          timestamps->get(i).mustCoerceToTimestamp());
                     }
                 }
                 return;
@@ -223,7 +223,7 @@ public:
             if (dense || !val.empty()) {
                 rows.emplace_back(getRowName(i),
                                   std::move(val),
-                                  timestamps->get(i).toTimestamp());
+                                  timestamps->get(i).mustCoerceToTimestamp());
             }
         }
     }
@@ -370,7 +370,7 @@ struct MutableTabularDatasetChunk {
             // Still integer row names
             integerRowNames.emplace_back(intRowName);
         }
-        timestamps.add(numRows, ts);
+        timestamps.add(numRows, ts.secondsSinceEpoch());
 
         for (unsigned i = 0;  i < columns.size();  ++i) {
             columns[i].add(numRows, std::move(vals[i]));

--- a/sql/cell_value.cc
+++ b/sql/cell_value.cc
@@ -599,6 +599,25 @@ coerceToTimestamp() const
     return CellValue();
 }
 
+Date
+CellValue::
+mustCoerceToTimestamp() const
+{
+    if (type == ST_EMPTY)
+        return Date::notADate();
+    if (isAsciiString()) {
+        return Date::parseIso8601DateTime(toString());
+    }
+    if (type == ST_TIMESTAMP)
+        return toTimestamp();
+    if (isNumber()) {
+        return Date::fromSecondsSinceEpoch(toDouble());
+    }
+    throw HttpReturnException(400, "Couldn't convert value '" + toUtf8String()
+                              + "' to timestamp",
+                              "value", *this);
+}
+
 CellValue
 CellValue::
 coerceToBlob() const

--- a/sql/cell_value.h
+++ b/sql/cell_value.h
@@ -328,6 +328,7 @@ struct CellValue {
     CellValue coerceToString() const;
     CellValue coerceToBoolean() const;
     CellValue coerceToTimestamp() const;
+    Date mustCoerceToTimestamp() const;
     CellValue coerceToBlob() const;
     PathElement coerceToPathElement() const;
     Path coerceToPath() const;


### PR DESCRIPTION
Since we have code to compress doubles but not timestamps, this allows us to take advantage of that code to do a better job at storing the timestamp column too.