### PR TITLE
Allow for incremental queries (MLDB-1816)

### DIFF
--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -829,6 +829,70 @@ queryStructured(const SelectExpression & select,
     return output;
 }
 
+bool
+Dataset::
+queryStructuredIncremental(std::function<bool (Path &, ExpressionValue &)> & onRow,
+                           const SelectExpression & select,
+                           const WhenExpression & when,
+                           const SqlExpression & where,
+                           const OrderByExpression & orderBy,
+                           const TupleExpression & groupBy,
+                           const SqlExpression & having,
+                           const SqlExpression & rowName,
+                           ssize_t offset,
+                           ssize_t limit,
+                           Utf8String alias) const
+{
+    if (!having.isConstantTrue() && groupBy.clauses.empty())
+        throw HttpReturnException
+            (400, "HAVING expression requires a GROUP BY expression");
+
+    std::vector< std::shared_ptr<SqlExpression> > aggregators
+        = select.findAggregators(!groupBy.clauses.empty());
+    std::vector< std::shared_ptr<SqlExpression> > havingaggregators
+        = having.findAggregators(!groupBy.clauses.empty());
+    std::vector< std::shared_ptr<SqlExpression> > orderbyaggregators
+        = orderBy.findAggregators(!groupBy.clauses.empty());
+
+    // Do it ungrouped if possible
+    if (groupBy.clauses.empty() && aggregators.empty()) {
+        auto processor = [&] (NamedRowValue & row_,
+                              const std::vector<ExpressionValue> & calc)
+            {
+                Path path = getValidatedRowName(calc.at(0));
+                ExpressionValue val(std::move(row_.columns));
+                return onRow(path, val);
+            };
+
+        return iterateDataset(select, *this, alias, when, where,
+                              { rowName.shallowCopy() },
+                              {processor, true/*processInParallel*/},
+                              orderBy, offset, limit,
+                              nullptr);
+    }
+    else {
+
+        aggregators.insert(aggregators.end(), havingaggregators.begin(),
+                           havingaggregators.end());
+        aggregators.insert(aggregators.end(), orderbyaggregators.begin(),
+                           orderbyaggregators.end());
+
+        // Otherwise do it grouped...
+        auto processor = [&] (NamedRowValue & row)
+            {
+                ExpressionValue val(std::move(row.columns));
+                return onRow(row.rowName, val);
+            };
+
+         //QueryStructured always want a stable ordering, but it doesnt have to be by rowhash
+        return iterateDatasetGrouped(select, *this, alias, when, where,
+                                     groupBy, aggregators, having, rowName,
+                                     {processor, true/*processInParallel*/},
+                                     orderBy, offset, limit,
+                                     nullptr);
+    }
+}
+
 template<typename Filter>
 static std::pair<std::vector<RowName>, Any>
 executeFilteredColumnExpression(const Dataset & dataset,

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -534,6 +534,20 @@ struct Dataset: public MldbEntity {
                     Utf8String alias = "") const;
 
     /** Select from the database. */
+    virtual bool
+    queryStructuredIncremental(std::function<bool (Path &, ExpressionValue &)> & onRow,
+                               const SelectExpression & select,
+                               const WhenExpression & when,
+                               const SqlExpression & where,
+                               const OrderByExpression & orderBy,
+                               const TupleExpression & groupBy,
+                               const SqlExpression & having,
+                               const SqlExpression & rowName,
+                               ssize_t offset,
+                               ssize_t limit,
+                               Utf8String alias = "") const;
+
+    /** Select from the database. */
     virtual std::vector<MatrixNamedRow>
     queryString(const Utf8String & query) const;
     

--- a/server/analytics.cc
+++ b/server/analytics.cc
@@ -36,7 +36,7 @@ namespace MLDB {
 /** Equivalent to SELECT (select) FROM (dataset) WHEN (when) WHERE (where), and each matching
     row is passed to the aggregator.
 */
-void iterateDataset(const SelectExpression & select,
+bool iterateDataset(const SelectExpression & select,
                     const Dataset & from,
                     const Utf8String & alias,
                     const WhenExpression & when,
@@ -48,13 +48,13 @@ void iterateDataset(const SelectExpression & select,
                     ssize_t limit,
                     std::function<bool (const Json::Value &)> onProgress)
 {
-    BoundSelectQuery(select, from, alias, when, where, orderBy, calc)
+    return BoundSelectQuery(select, from, alias, when, where, orderBy, calc)
         .execute(processor, offset, limit, onProgress);
 }
 
 
 /** Full select function, with grouping. */
-void iterateDatasetGrouped(const SelectExpression & select,
+bool iterateDatasetGrouped(const SelectExpression & select,
                            const Dataset & from,
                            const Utf8String & alias,
                            const WhenExpression & when,
@@ -69,11 +69,12 @@ void iterateDatasetGrouped(const SelectExpression & select,
                            ssize_t limit,
                            std::function<bool (const Json::Value &)> onProgress)
 {
-    BoundGroupByQuery(select, from, alias, when, where, groupBy, aggregators, having, rowName, orderBy)
+    return BoundGroupByQuery(select, from, alias, when, where, groupBy,
+                             aggregators, having, rowName, orderBy)
       .execute(processor, offset, limit, onProgress);
 }
 
-void iterateDataset(const SelectExpression & select,
+bool iterateDataset(const SelectExpression & select,
                     const Dataset & from,
                     const Utf8String & alias,
                     const WhenExpression & when,
@@ -92,7 +93,7 @@ void iterateDataset(const SelectExpression & select,
             return processor(output);
         };
 
-    iterateDataset(select, from, std::move(alias), when, where, {}, {processor2, processor.processInParallel}, orderBy, offset, limit, onProgress);
+    return iterateDataset(select, from, std::move(alias), when, where, {}, {processor2, processor.processInParallel}, orderBy, offset, limit, onProgress);
 }
 
 /** Iterates over the dataset, extracting a dense feature vector from each row. */
@@ -299,7 +300,7 @@ getEmbedding(const SelectStatement & stm,
 }
 
 std::vector<MatrixNamedRow>
-queryWithoutDataset(SelectStatement& stm, SqlBindingScope& scope)
+queryWithoutDataset(const SelectStatement& stm, SqlBindingScope& scope)
 {
     for (const auto & c: stm.select.clauses) {
         if (c->isWildcard()) {
@@ -321,7 +322,7 @@ queryWithoutDataset(SelectStatement& stm, SqlBindingScope& scope)
 }
 
 std::vector<MatrixNamedRow>
-queryFromStatement(SelectStatement & stm,
+queryFromStatement(const SelectStatement & stm,
                    SqlBindingScope & scope,
                    BoundParameters params)
 {
@@ -387,6 +388,96 @@ queryFromStatement(SelectStatement & stm,
     else {
         // No from at all
         return queryWithoutDataset(stm, scope);
+    }
+}
+
+/** Select from the given statement.  This will choose the most
+    appropriate execution method based upon what is in the query.
+
+    The scope should be a clean scope, not requiring any row scope.
+    See the comment above if you have errors inside this function.
+
+    Will return the results one by one, and will stop when the
+    onRow function returns false.  Returns false if one of the
+    onRow calls returned false, or true otherwise.
+*/
+bool
+queryFromStatement(std::function<bool (Path &, ExpressionValue &)> & onRow,
+                   const SelectStatement & stm,
+                   SqlBindingScope & scope,
+                   BoundParameters params)
+{
+    BoundTableExpression table = stm.from->bind(scope);
+    
+    if (table.dataset) {
+        return table.dataset->queryStructuredIncremental
+            (onRow, stm.select, stm.when,
+             *stm.where,
+             stm.orderBy, stm.groupBy,
+             *stm.having,
+             *stm.rowName,
+             stm.offset, stm.limit, 
+             table.asName);
+    }
+    else if (table.table.runQuery && stm.from) {
+
+        auto getParamInfo = [&] (const Utf8String & paramName)
+            -> std::shared_ptr<ExpressionValueInfo>
+            {
+                throw HttpReturnException(500, "No query parameter " + paramName);
+            };
+        
+        if (!params)
+            params = [] (const Utf8String & param) -> ExpressionValue
+                {
+                    throw HttpReturnException(500, "No query parameter " + param);
+                };
+        
+        std::shared_ptr<PipelineElement> pipeline
+            = PipelineElement::root(scope)->statement(stm, getParamInfo);
+
+        auto boundPipeline = pipeline->bind();
+
+        auto executor = boundPipeline->start(params);
+        
+        std::vector<MatrixNamedRow> rows;
+
+        ssize_t limit = stm.limit;
+        ssize_t offset = stm.offset;
+
+        auto output = executor->take();
+
+        for (size_t n = 0;
+             output && (limit == -1 || n < limit + offset);
+             output = executor->take(), ++n) {
+
+            // MLDB-1329 band-aid fix.  This appears to break a circlar
+            // reference chain that stops the elements from being
+            // released.
+            output->group.clear();
+
+            if (n < offset) {
+                continue;
+            }
+
+            Path path = output->values.at(output->values.size() - 2)
+                .coerceToPath(); 
+            ExpressionValue val(std::move(output->values.back()));
+            if (!onRow(path, val))
+                return false;
+        }
+            
+        return true;
+    }
+    else {
+        // No from at all
+        auto rows = queryWithoutDataset(stm, scope);
+        for (auto & r: rows) {
+            ExpressionValue val(std::move(r.columns));
+            if (!onRow(r.rowName, val))
+                return false;
+        }
+        return true;
     }
 }
 

--- a/server/analytics.h
+++ b/server/analytics.h
@@ -58,7 +58,7 @@ struct RowProcessorEx {
 /** Equivalent to SELECT (select) FROM (dataset) WHEN (when) WHERE (where), and each matching
     row is passed to the aggregator.
 */
-void iterateDataset(const SelectExpression & select,
+bool iterateDataset(const SelectExpression & select,
                     const Dataset & from,
                     const Utf8String & alias,
                     const WhenExpression & when,
@@ -72,7 +72,7 @@ void iterateDataset(const SelectExpression & select,
 /** Equivalent to SELECT (select) FROM (dataset) WHEN (when) WHERE (where), and each matching
     row is passed to the aggregator.
 */
-void iterateDataset(const SelectExpression & select,
+bool iterateDataset(const SelectExpression & select,
                     const Dataset & from,
                     const Utf8String& alias,
                     const WhenExpression & when,
@@ -85,7 +85,7 @@ void iterateDataset(const SelectExpression & select,
                     std::function<bool (const Json::Value &)> onProgress = nullptr);
 
 /** Full select function, with grouping. */
-void iterateDatasetGrouped(const SelectExpression & select,
+bool iterateDatasetGrouped(const SelectExpression & select,
                            const Dataset & from,
                            const Utf8String& alias,
                            const WhenExpression & when,
@@ -135,7 +135,7 @@ getEmbedding(const SelectStatement & stm,
    you should be running this function under an SqlExpressionMldbScope.
  */
 std::vector<MatrixNamedRow>
-queryWithoutDataset(SelectStatement& stm, SqlBindingScope& scope);
+queryWithoutDataset(const SelectStatement& stm, SqlBindingScope& scope);
 
 /** Select from the given statement.  This will choose the most
     appropriate execution method based upon what is in the query.
@@ -144,7 +144,23 @@ queryWithoutDataset(SelectStatement& stm, SqlBindingScope& scope);
     See the comment above if you have errors inside this function.
 */
 std::vector<MatrixNamedRow>
-queryFromStatement(SelectStatement & stm,
+queryFromStatement(const SelectStatement & stm,
+                   SqlBindingScope & scope,
+                   BoundParameters params = nullptr);
+
+/** Select from the given statement.  This will choose the most
+    appropriate execution method based upon what is in the query.
+
+    The scope should be a clean scope, not requiring any row scope.
+    See the comment above if you have errors inside this function.
+
+    Will return the results one by one, and will stop when the
+    onRow function returns false.  Returns false if one of the
+    onRow calls returned false, or true otherwise.
+*/
+bool
+queryFromStatement(std::function<bool (Path &, ExpressionValue &)> & onRow,
+                   const SelectStatement & stm,
                    SqlBindingScope & scope,
                    BoundParameters params = nullptr);
 

--- a/server/bound_queries.h
+++ b/server/bound_queries.h
@@ -101,12 +101,12 @@ struct BoundSelectQuery {
                      std::vector<std::shared_ptr<SqlExpression> > calc,
                      int numBuckets = -1);
 
-    void execute(RowProcessorEx processor,
+    bool execute(RowProcessorEx processor,
                  ssize_t offset,
                  ssize_t limit,
                  std::function<bool (const Json::Value &)> onProgress);
 
-    void execute(std::function<bool (NamedRowValue & output,
+    bool execute(std::function<bool (NamedRowValue & output,
                                      std::vector<ExpressionValue> & calcd, int rowNum)> processor,
                  bool processInParallel,
                  ssize_t offset,
@@ -135,9 +135,9 @@ struct BoundGroupByQuery {
                      const SqlExpression & rowName,
                      const OrderByExpression & orderBy);
 
-    void execute(RowProcessor processor,
-            ssize_t offset, ssize_t limit,
-            std::function<bool (const Json::Value &)> onProgress);
+    bool execute(RowProcessor processor,  
+                 ssize_t offset, ssize_t limit,
+                 std::function<bool (const Json::Value &)> onProgress);
 
     const Dataset & from;
     WhenExpression when;

--- a/sql/execution_pipeline.cc
+++ b/sql/execution_pipeline.cc
@@ -538,16 +538,19 @@ partition(int numElements)
 
 std::shared_ptr<PipelineElement>
 PipelineElement::
-statement(SelectStatement& stm, GetParamInfo getParamInfo)
+statement(const SelectStatement& stm, GetParamInfo getParamInfo)
 {
     auto root = shared_from_this();
 
     bool hasGroupBy = !stm.groupBy.empty();
-    std::vector< std::shared_ptr<SqlExpression> > aggregators = stm.select.findAggregators(hasGroupBy);
+    std::vector< std::shared_ptr<SqlExpression> > aggregators
+        = stm.select.findAggregators(hasGroupBy);
+
+    auto groupBy = stm.groupBy;
 
     if (!hasGroupBy && !aggregators.empty()) {
         //if we have no group by but aggregators, make a universal group
-        stm.groupBy.clauses.emplace_back(SqlExpression::parse("1"));
+        groupBy.clauses.emplace_back(SqlExpression::parse("1"));
         hasGroupBy = true;
     }
 
@@ -558,9 +561,9 @@ statement(SelectStatement& stm, GetParamInfo getParamInfo)
                    SelectExpression::STAR, stm.where,
                    OrderByExpression(), getParamInfo)
             ->where(stm.where)
-            ->select(stm.groupBy)
-            ->sort(stm.groupBy)
-            ->partition(stm.groupBy.clauses.size())
+            ->select(groupBy)
+            ->sort(groupBy)
+            ->partition(groupBy.clauses.size())
             ->where(stm.having)
             ->select(stm.orderBy)
             ->sort(stm.orderBy)

--- a/sql/execution_pipeline.h
+++ b/sql/execution_pipeline.h
@@ -387,7 +387,7 @@ struct PipelineElement: public std::enable_shared_from_this<PipelineElement> {
 
     // return a pipeline that will execute the specified statement
     std::shared_ptr<PipelineElement>
-    statement(SelectStatement& statement, GetParamInfo getParamInfo);
+    statement(const SelectStatement& statement, GetParamInfo getParamInfo);
 };
 
 } // namespace MLDB


### PR DESCRIPTION
Provides an interface that can be used to receive results from an analytics query one at a time.  Also fixes constness issues in the interface, and returns the customary bool for a short-circuited exit.

NOTE: the queryStructuredIncremental function is not tested yet.  There is a coming commit that uses it to implement tested code.