### PR TITLE
Refactored uses of ExpressionValue::getStructured() and removed (MLDB-1818)

### DIFF
--- a/container_files/public_html/doc/builtin/sql/ValueExpression.md
+++ b/container_files/public_html/doc/builtin/sql/ValueExpression.md
@@ -383,6 +383,14 @@ With `{arrays: 'encode'}` the output will be:
 |:---:|:---:|:---:|:-----:|:------:|:------:
 | 'b' | 'e' | 1 | 1   | '{"j":"k"}' | '{"l":"m"}'
 
+The full set of options to the `parse_json` function are as follows:
+
+![](%%type Datacratic::MLDB::Builtins::ParseJsonOptions)
+
+and the possible values for the `arrays` field are:
+
+![](%%type Datacratic::MLDB::JsonArrayHandling)
+
 
 ### Numeric functions
 
@@ -530,7 +538,12 @@ calculate
 
 The following functions are used to extract and process web data.
 
-- `extract_domain(str, {removeSubdomain: false})` extracts the domain name from a URL. Setting the option `removeSubdomain` to `True` will return only the domain without the subdomain. Note that the string passed in must be a complete and valid URL. If a scheme (`http://`, etc) is not present, an error will be thrown.
+- `extract_domain(str, {removeSubdomain: false})` extracts the domain name from a URL. Setting the option `removeSubdomain` to `true` will return only the domain without the subdomain. Note that the string passed in must be a complete and valid URL. If a scheme (`http://`, etc) is not present, an error will be thrown.
+
+The full set of options to the `extract_domain` function are as follows:
+
+![](%%type Datacratic::MLDB::Builtins::ExtractDomainOptions)
+
 
 See also the ![](%%doclink http.useragent function) that can be used to parse a user agent string.
 
@@ -540,13 +553,11 @@ See also the ![](%%doclink http.useragent function) that can be used to parse a 
 can be used to create bag-of-tokens representations of strings, by returning a row whose
 columns are formed by tokenizing `str` by splitting along `splitchars` and whose values by default are the
 number of occurrences of those tokens within `str`. For example `tokenize('a b b c c c', {splitchars:' '})` will return the row `{'a': 1, 'b': 2, 'c': 3}`.
-  - `offset` and `limit` are used to skip the first `offset` tokens and only generate `limit` tokens
-  - `value` (if not set to `null`) will be used instead of token-counts for the values of the columns in the output row
-  - `quotechar` is interpreted as a single character to delimit tokens which may contain the `splitchars`, so by default `tokenize('a,"b,c"', {quotechar:'"'})` will return the row `{'a':1,'b,c':1}`
-  - `min_token_length` is used to specify the minimum length of tokens that are returned
-  - `ngram_range` is used to specify the n-grams to return. `[1, 1]` will return only unigrams, while `[2, 3]` will return bigrams and trigrams, where tokens are joined by underscores. For example, `tokenize('Good day world', {splitchars:' ', ngram_range:[2,3]})` will return the row `{'Good_day': 1, 'Good_day_world': 1, 'day_world': 1}`
-- `token_extract(str, n, {splitchars: ',', quotechar: '', offset: 0, limit: null, min_token_length: 1})` will return the `n`th token from `str` using the same tokenizing rules as `tokenize()` above. Only the tokens respecting the `min_token_length` will be considered
+- `token_extract(str, n, {splitchars: ',', quotechar: '', offset: 0, limit: null, min_token_length: 1})` will return the `n`th token from `str` using the same tokenizing rules as `tokenize()` above. Only the tokens respecting the `min_token_length` will be considered, and ngram options are ignored.
 
+Parameters to `tokenize` and `token_extract` are as follows:
+
+![](%%type Datacratic::TokenizeOptions)
 
 
 ## <a name="aggregatefunctions"></a>Aggregate Functions

--- a/http/http_exception.cc
+++ b/http/http_exception.cc
@@ -23,7 +23,8 @@ void rethrowHttpException(int httpCode, const Utf8String & message, Any details)
         Json::Value details2 = jsonEncode(details);
         details2["context"]["details"] = jsonEncode(http.details);
         details2["context"]["error"] = http.message;
-        throw HttpReturnException(httpCode == -1 ? http.httpCode : httpCode, message, details2);
+        throw HttpReturnException(httpCode == KEEP_HTTP_CODE
+                                  ? http.httpCode : httpCode, message, details2);
     } catch (const std::bad_alloc & exc) {
         Json::Value details2 = jsonEncode(details);
         details2["context"]["error"]
@@ -31,14 +32,17 @@ void rethrowHttpException(int httpCode, const Utf8String & message, Any details)
             "the operation.  Consider retrying with a smaller amount of data "
             "or running on a machine with more memory.  "
             "(std::bad_alloc)";
-        throw HttpReturnException(httpCode == -1 ? 400 : httpCode, message, details2);
+        throw HttpReturnException(httpCode == KEEP_HTTP_CODE
+                                  ? 400 : httpCode, message, details2);
     } catch (const std::exception & exc) {
         Json::Value details2 = jsonEncode(details);
         details2["context"]["error"] = exc.what();
-        throw HttpReturnException(httpCode == -1 ? 400 : httpCode, message, details2);
+        throw HttpReturnException(httpCode == KEEP_HTTP_CODE
+                                  ? 400 : httpCode, message, details2);
     }
 
-    throw HttpReturnException(httpCode == -1 ? 400 : httpCode, message, details);
+    throw HttpReturnException(httpCode == KEEP_HTTP_CODE
+                              ? 400 : httpCode, message, details);
 }
 
 void rethrowHttpException(int httpCode, const std::string & message, Any details)

--- a/http/http_exception.h
+++ b/http/http_exception.h
@@ -16,6 +16,10 @@
 
 namespace Datacratic {
 
+/// Indicates on a rethrow that we should keep the HTTP code that was in
+/// the outer exception.
+constexpr int KEEP_HTTP_CODE = -1;
+
 struct HttpReturnException: public ML::Exception {
     HttpReturnException(int httpCode, const Utf8String & message, Any details = Any())
         : ML::Exception(message.rawData()), message(message), httpCode(httpCode), details(details)

--- a/plugins/json_importer.cc
+++ b/plugins/json_importer.cc
@@ -143,7 +143,7 @@ struct JsonScope : SqlExpressionMldbScope {
         {
             const auto & row = scope.as<JsonRowScope>();
             StructValue result;
-            result.reserve(row.expr.getStructured().size());
+            result.reserve(row.expr.rowLength());
 
             const auto onCol = [&] (const PathElement & columnName,
                                     const ExpressionValue & val)

--- a/server/bound_queries.cc
+++ b/server/bound_queries.cc
@@ -685,7 +685,8 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
 
                     return true;
                 } catch (...) {
-                    rethrowHttpException(-1, "Executing non-grouped query bound to row: " + ML::getExceptionString(),
+                    rethrowHttpException(KEEP_HTTP_CODE,
+                                         "Executing non-grouped query bound to row: " + ML::getExceptionString(),
                                          "row", row,
                                          "rowHash", rows[rowNum],
                                          "rowNum", rowNum);

--- a/sql/builtin_http_functions.cc
+++ b/sql/builtin_http_functions.cc
@@ -8,6 +8,7 @@
 #include "mldb/sql/builtin_functions.h"
 #include "mldb/types/url.h"
 #include "mldb/types/basic_value_descriptions.h"
+#include "mldb/types/structure_description.h"
 
 using namespace std;
 
@@ -20,6 +21,20 @@ namespace Builtins {
 /* HTTP FUNCTIONS                                                            */
 /*****************************************************************************/
 
+struct ExtractDomainOptions {
+    bool removeSubdomain = false;
+};
+
+DECLARE_STRUCTURE_DESCRIPTION(ExtractDomainOptions);
+DEFINE_STRUCTURE_DESCRIPTION(ExtractDomainOptions);
+
+ExtractDomainOptionsDescription::
+ExtractDomainOptionsDescription()
+{
+    addAuto("removeSubdomain", &ExtractDomainOptions::removeSubdomain,
+            "Flag to specify whether or not the subdomain is kept.");
+}
+
 BoundFunction extract_domain(const std::vector<BoundSqlExpression> & args)
 {
     // Return an expression but with the timestamp modified to something else
@@ -31,30 +46,10 @@ BoundFunction extract_domain(const std::vector<BoundSqlExpression> & args)
     return {[=] (const std::vector<ExpressionValue> & args,
                  const SqlRowScope & scope) -> ExpressionValue
             {
-                bool check[] = {false};
-                auto assertArg = [&] (size_t field, const string & name)
-                    {
-                        if (check[field])
-                            throw HttpReturnException(400, "Argument " + name + " is specified more than once");
-                        check[field] = true;
-                    };
-
-                bool removeSubdomain = false;
-                if(args.size() == 2) {
-                    const ExpressionValue::Structured & argRow =
-                        args.at(1).getStructured();
-
-                    for (auto& arg : argRow) {
-                        const ColumnName& columnName = std::get<0>(arg);
-                        if (columnName == ColumnName("removeSubdomain")) {
-                            assertArg(0, "removeSubdomain");
-                            removeSubdomain = std::get<1>(arg).asBool();
-                        }
-                        else {
-                            throw HttpReturnException(400, "Unknown argument "
-                                    "in extract_domain", "argument", columnName);
-                        }
-                    }
+                ExtractDomainOptions options;
+                if (args.size() == 2) {
+                    options
+                        = jsonDecode<ExtractDomainOptions>(args[1].extractJson());
                 }
 
                 auto & val = args[0];
@@ -64,7 +59,7 @@ BoundFunction extract_domain(const std::vector<BoundSqlExpression> & args)
                 Url url(val.getAtom().toUtf8String());
 
                 string return_host = url.host();
-                if(removeSubdomain && !url.hostIsIpAddress()) {
+                if(options.removeSubdomain && !url.hostIsIpAddress()) {
                     size_t last_dot = return_host.rfind('.');
                     size_t second_last_dot = return_host.rfind('.', last_dot-1);
                     if(second_last_dot != std::string::npos)

--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -24,6 +24,7 @@
 #include "mldb/http/http_exception.h"
 #include "mldb/server/dataset_context.h"
 #include "mldb/types/value_description.h"
+#include "mldb/jml/utils/string_functions.h"
 
 #include <mutex>
 

--- a/sql/tokenize.h
+++ b/sql/tokenize.h
@@ -12,37 +12,48 @@
 #include <string>
 #include <unordered_map>
 #include <functional>
+#include <vector>
 #include "types/string.h"
-#include "jml/stats/distribution.h"
+#include "mldb/types/value_description_fwd.h"
+#include "cell_value.h"
 
 namespace ML {
-    struct Parse_Context;
+struct Parse_Context;
 }
 
 namespace Datacratic {
 
-    void
-    tokenize_exec(std::function<bool (Utf8String&)> exec,
+/** Common options for the tokenize function. */
+struct TokenizeOptions {
+    Utf8String splitchar = ",";
+    Utf8String quotechar = "";
+    int offset = 0, limit = -1;
+    MLDB::CellValue value;
+    int min_token_length = 1;
+    std::pair<int, int> ngram_range = { 1, 1};
+};
+
+/** Allow these options to be accessed and documented via the ValueDescription
+    system.
+*/
+DECLARE_STRUCTURE_DESCRIPTION(TokenizeOptions);
+
+void
+tokenize_exec(std::function<bool (Utf8String&)> exec,
               ML::Parse_Context& context,
               const Utf8String& splitchars,
               const Utf8String& quotechar,
               int min_token_length);
 
-    char32_t expectUtf8Char(ML::Parse_Context & context);
+char32_t expectUtf8Char(ML::Parse_Context & context);
 
-    bool tokenize(std::unordered_map<Utf8String, int>& bagOfWords,
-                  ML::Parse_Context& pcontext,
-                  const Utf8String& splitchars,
-                  const Utf8String& quotechar,
-                  int offset, int limit,
-                  int min_token_length,
-                  ML::distribution<float, std::vector<float> > & ngram_range);
+bool tokenize(std::unordered_map<Utf8String, int>& bagOfWords,
+              ML::Parse_Context& pcontext,
+              const TokenizeOptions & options);
 
-    Utf8String token_extract(ML::Parse_Context& context,
-                             const Utf8String& splitchars,
-                             const Utf8String& quotechar,
-                             int offset, int limit, int nth,
-                             int min_token_length);
+Utf8String token_extract(ML::Parse_Context& context,
+                         int nth,
+                         const TokenizeOptions & options);
 
-}
+} // namespace Datacratic
 

--- a/testing/MLDB-907-tokenize.py
+++ b/testing/MLDB-907-tokenize.py
@@ -138,7 +138,7 @@ class TokenizeTest(MldbUnitTest):  # noqa
         result = mldb.get(
             '/v1/query',
             q="""SELECT tokenize('I would want a burger',
-                                 {splitchars: ' ', ngram_range: {1, 3}, min_token_length:2})
+                                 {splitchars: ' ', ngram_range: [1, 3], min_token_length:2})
                         AS tokens""")
         self.find_column(result, "tokens.would_want_burger", 1)
         self.find_column(result, "tokens.burger", 1)
@@ -150,7 +150,7 @@ class TokenizeTest(MldbUnitTest):  # noqa
         result = mldb.get(
             '/v1/query',
             q="""SELECT tokenize('I would want a burger I would want a burger',
-                                 {splitchars: ' ', ngram_range: {3, 3}, min_token_length:2})
+                                 {splitchars: ' ', ngram_range: [3, 3], min_token_length:2})
                         AS tokens""")
         self.find_column(result, "tokens.would_want_burger", 2)
         self.not_find_column(result, "tokens.would_want")
@@ -167,7 +167,7 @@ class TokenizeTest(MldbUnitTest):  # noqa
             mldb.get(
                 '/v1/query',
                 q="""SELECT tokenize('I would want a burger',
-                                     {splitchars: ' ', ngram_range: {-2, 8}})
+                                     {splitchars: ' ', ngram_range: [-2, 8]})
                             AS tokens""")
 
     def test_tokenize_to_print_json(self):

--- a/testing/MLDBFB-573_parse_json.py
+++ b/testing/MLDBFB-573_parse_json.py
@@ -42,7 +42,7 @@ class MldbFb573(MldbUnitTest):
 
     def test_null_arrays(self):
         with self.assertRaisesRegexp(mldb_wrapper.ResponseException,
-            'got: NULL'):
+            'NULL value found'):
             mldb.query("SELECT parse_json(x, {arrays: parse}) from sample")
 
     def test_parse_empty_list(self):

--- a/types/enum_description.h
+++ b/types/enum_description.h
@@ -1,10 +1,9 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** enum_description.h                                             -*- C++ -*-
     Jeremy Barnes, 21 August 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
-    Value description for a pointer.
+    Value description for an enum.
 */
 
 #pragma once
@@ -48,6 +47,12 @@ struct EnumDescription: public ValueDescriptionT<Enum> {
 
     virtual void parseJsonTyped(Enum * val, JsonParsingContext & context) const
     {
+        if (context.isNull()) {
+            context.exception("NULL value found parsing enumeration "
+                              + this->typeName + "; expected either a "
+                              "string or an integer");
+        }
+
         if (context.isString()) {
             std::string s = context.expectStringAscii();
             auto it = parse.find(s);

--- a/types/json_parsing.cc
+++ b/types/json_parsing.cc
@@ -1506,6 +1506,8 @@ int
 StructuredJsonParsingContext::
 expectInt()
 {
+    if (current->isNull() || !current->isConvertibleTo(Json::intValue))
+        exception("Integer was expected; instead got '" + current->toStringNoNewLine() + "'");
     return current->asInt();
 }
 
@@ -1513,6 +1515,8 @@ unsigned int
 StructuredJsonParsingContext::
 expectUnsignedInt()
 {
+    if (current->isNull() || !current->isConvertibleTo(Json::uintValue))
+        exception("Unsigned integer was expected; instead got '" + current->toStringNoNewLine() + "'");
     return current->asUInt();
 }
 
@@ -1520,6 +1524,8 @@ long
 StructuredJsonParsingContext::
 expectLong()
 {
+    if (current->isNull() || !current->isConvertibleTo(Json::intValue))
+        exception("Integer was expected; instead got '" + current->toStringNoNewLine() + "'");
     return current->asInt();
 }
 
@@ -1527,6 +1533,8 @@ unsigned long
 StructuredJsonParsingContext::
 expectUnsignedLong()
 {
+    if (current->isNull() || !current->isConvertibleTo(Json::uintValue))
+        exception("Unsigned integer was expected; instead got '" + current->toStringNoNewLine() + "'");
     return current->asUInt();
 }
 
@@ -1534,6 +1542,8 @@ long long
 StructuredJsonParsingContext::
 expectLongLong()
 {
+    if (current->isNull() || !current->isConvertibleTo(Json::intValue))
+        exception("Integer was expected; instead got '" + current->toStringNoNewLine() + "'");
     return current->asInt();
 }
 
@@ -1541,6 +1551,8 @@ unsigned long long
 StructuredJsonParsingContext::
 expectUnsignedLongLong()
 {
+    if (current->isNull() || !current->isConvertibleTo(Json::uintValue))
+        exception("Unsigned integer was expected; instead got '" + current->toStringNoNewLine() + "'");
     return current->asUInt();
 }
 
@@ -1548,6 +1560,8 @@ float
 StructuredJsonParsingContext::
 expectFloat()
 {
+    if (current->isNull())
+        exception("NULL found where floating point value expected");
     return current->asDouble();
 }
 
@@ -1555,6 +1569,8 @@ double
 StructuredJsonParsingContext::
 expectDouble()
 {
+    if (current->isNull())
+        exception("NULL found where floating point value expected");
     return current->asDouble();
 }
 

--- a/types/pair_description.h
+++ b/types/pair_description.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** pair_description.h                                          -*- C++ -*-
     Jeremy Barnes, 21 August 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Value description for a pointer.
 */
@@ -15,10 +14,11 @@ namespace Datacratic {
 
 template<typename T, typename U>
 struct PairDescription
-    : public ValueDescriptionI<std::pair<T, U>, ValueKind::TUPLE, PairDescription<T, U> > {
+    : public ValueDescriptionI<std::pair<T, U>, ValueKind::TUPLE,
+                               PairDescription<T, U> > {
 
     PairDescription(ValueDescriptionT<T> * inner1,
-                       ValueDescriptionT<U> * inner2)
+                    ValueDescriptionT<U> * inner2)
         : inner1(inner1), inner2(inner2)
     {
     }
@@ -38,19 +38,19 @@ struct PairDescription
     std::shared_ptr<const ValueDescriptionT<T> > inner1;
     std::shared_ptr<const ValueDescriptionT<U> > inner2;
 
-    virtual size_t getTupleLength() const
+    virtual size_t getTupleLength() const override
     {
         return 2;
     }
 
     virtual std::vector<std::shared_ptr<const ValueDescription> >
-    getTupleElementDescriptions() const
+    getTupleElementDescriptions() const override
     {
         return { inner1, inner2 };
     }
 
     virtual const ValueDescription &
-    getArrayElementDescription(const void * val, uint32_t element) const
+    getArrayElementDescription(const void * val, uint32_t element) const override
     {
         if (element == 0)
             return *inner1;

--- a/types/structure_description.h
+++ b/types/structure_description.h
@@ -231,6 +231,21 @@ struct StructureDescription
         orderedFields.push_back(it);
     }
 
+    /** Add a description with an automatic default value derived
+        from the default constructor.
+    */
+    template<typename V, typename Base,
+             typename Desc = ValueDescriptionWithDefault<V> >
+    void addAuto(std::string name,
+                 V Base::* field,
+                 std::string comment,
+                 std::shared_ptr<const ValueDescriptionT<V> > baseDesc
+                     = getDefaultDescriptionSharedT<V>())
+    {
+        V defValue = Base() .* field;
+        addField(std::move(name), field, comment, defValue, baseDesc);
+    }
+
     using ValueDescriptionT<Struct>::parents;
 
     template<typename V>

--- a/types/testing/value_description_test.cc
+++ b/types/testing/value_description_test.cc
@@ -609,3 +609,41 @@ BOOST_AUTO_TEST_CASE(test_tuple_description_wrong_length)
         BOOST_CHECK_EQUAL(std::get<2>(testTuple), 3);
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_null_parsing)
+{
+    { 
+        // Make sure that nulls result in parsing errors not zeros
+        JML_TRACE_EXCEPTIONS(false);
+        BOOST_CHECK_THROW(jsonDecode<int>(Json::Value()), std::exception);
+        BOOST_CHECK_THROW(jsonDecode<unsigned int>(Json::Value()), std::exception);
+        BOOST_CHECK_THROW(jsonDecode<long int>(Json::Value()), std::exception);
+        BOOST_CHECK_THROW(jsonDecode<unsigned long int>(Json::Value()), std::exception);
+        BOOST_CHECK_THROW(jsonDecode<long long int>(Json::Value()), std::exception);
+        BOOST_CHECK_THROW(jsonDecode<unsigned long long int>(Json::Value()), std::exception);
+        BOOST_CHECK_THROW(jsonDecode<double>(Json::Value()), std::exception);
+        BOOST_CHECK_THROW(jsonDecode<float>(Json::Value()), std::exception);
+        BOOST_CHECK_THROW(jsonDecode<SomeSize>(Json::Value()), std::exception);
+
+        //BOOST_CHECK_THROW(jsonDecode<unsigned int>(Json::parse("-1")),
+        //                  std::exception);
+
+        BOOST_CHECK_THROW(jsonDecodeStr<int>(string("null")), std::exception);
+        BOOST_CHECK_THROW(jsonDecodeStr<unsigned int>(string("null")), std::exception);
+        BOOST_CHECK_THROW(jsonDecodeStr<long int>(string("null")), std::exception);
+        BOOST_CHECK_THROW(jsonDecodeStr<unsigned long int>(string("null")), std::exception);
+        BOOST_CHECK_THROW(jsonDecodeStr<long long int>(string("null")), std::exception);
+        BOOST_CHECK_THROW(jsonDecodeStr<unsigned long long int>(string("null")), std::exception);
+        BOOST_CHECK_THROW(jsonDecodeStr<double>(string("null")), std::exception);
+        BOOST_CHECK_THROW(jsonDecodeStr<float>(string("null")), std::exception);
+        BOOST_CHECK_THROW(jsonDecodeStr<SomeSize>(string("null")), std::exception);
+
+        //BOOST_CHECK_THROW(jsonDecodeStr<unsigned int>(string("-1")),
+        //                  std::exception);
+    }
+
+    BOOST_CHECK_EQUAL(jsonDecode<int>(Json::parse("1")), 1);
+    BOOST_CHECK_EQUAL(jsonDecode<int>(Json::parse("-1")), -1);
+
+    BOOST_CHECK_EQUAL(jsonDecode<unsigned int>(Json::parse("1")), 1);
+}

--- a/types/utility_descriptions.h
+++ b/types/utility_descriptions.h
@@ -1,10 +1,9 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** utility_descriptions.h                                         -*- C++ -*-
     Jeremy Barnes, 21 August 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
-    Value description for a pointer.
+    Utility functions for value descriptions.
 */
 
 #pragma once
@@ -42,6 +41,9 @@ struct BridgedValueDescription: public ValueDescription {
     virtual const ValueDescription &
     getArrayElementDescription(const void * val, uint32_t element) const;
     virtual void setArrayLength(void * val, size_t newLength) const JML_OVERRIDE;
+    virtual size_t getTupleLength() const override;
+    virtual std::vector<std::shared_ptr<const ValueDescription> >
+    getTupleElementDescriptions() const override;
     virtual const ValueDescription & getKeyValueDescription() const JML_OVERRIDE;
     virtual const ValueDescription & contained() const JML_OVERRIDE;
     virtual OwnershipModel getOwnershipModel() const JML_OVERRIDE;

--- a/types/value_description.cc
+++ b/types/value_description.cc
@@ -106,14 +106,14 @@ std::vector<std::shared_ptr<const ValueDescription> >
 ValueDescription::
 getTupleElementDescriptions() const
 {
-    throw ML::Exception("type '" + typeName + "' is not a tuple");
+    throw ML::Exception("type '" + typeName + "' is not a tuple " + ML::type_name(*this));
 }
 
 size_t
 ValueDescription::
 getTupleLength() const
 {
-    throw ML::Exception("type '" + typeName + "' is not a tuple");
+    throw ML::Exception("type '" + typeName + "' is not a tuple " + ML::type_name(*this));
 }
 
 const void *
@@ -639,6 +639,22 @@ getArrayElementDescription(const void * val, uint32_t element) const
 {
     ExcAssert(impl);
     return impl->getArrayElementDescription(val, element);
+}
+
+size_t
+BridgedValueDescription::
+getTupleLength() const
+{
+    ExcAssert(impl);
+    return impl->getTupleLength();
+}
+
+std::vector<std::shared_ptr<const ValueDescription> >
+BridgedValueDescription::
+getTupleElementDescriptions() const
+{
+    ExcAssert(impl);
+    return impl->getTupleElementDescriptions();
 }
 
 void


### PR DESCRIPTION
Removes the getStructured() method from ExpressionValue, which should basically never be used and couples the semantics of the ExpressionValue class to its internal implementation.

The main uses of the method were in parsing options to functions, which were refactored to use the ValueDescription system (which also allows for generated documentation).  As part of those changes, a new `addAuto()` function was added to `StructureValueDescription` to allow default values to be automatically inferred, and some validation errors were fixed in the JSON parsing code.

The optimized path for aggregators on a static set of columns was also fixed to no longer use getStructured; this should avoid several situations where using embeddings with aggregators would have caused issues.

Finally, a couple of tests which were confused between arrays and structures were fixed.
