### PR TITLE
MLDB-1813 matrix named row removal

### DIFF
--- a/plugins/embedding.cc
+++ b/plugins/embedding.cc
@@ -146,7 +146,8 @@ struct EmbeddingDatasetRepr {
 
     struct Row {
         Row(RowName rowName, ML::distribution<float> coords, Date timestamp)
-            : rowName(std::move(rowName)), coords(std::move(coords))
+            : rowName(std::move(rowName)), coords(std::move(coords)),
+              timestamp(timestamp)
         {
         }
 

--- a/plugins/pooling_function.cc
+++ b/plugins/pooling_function.cc
@@ -124,6 +124,7 @@ applyT(const ApplierT & applier_, PoolingInput input) const
 
     size_t num_embed_cols = columnNames.size() * functionConfig.aggregators.size();
 
+    Date outputTs = input.words.getEffectiveTimestamp();
     StructValue inputRow;
     inputRow.emplace_back("words", std::move(input.words));
 
@@ -132,8 +133,6 @@ applyT(const ApplierT & applier_, PoolingInput input) const
 
     std::vector<double> outputEmbedding;
     outputEmbedding.reserve(num_embed_cols);
-
-    Date outputTs = input.words.getEffectiveTimestamp();
 
     if (queryOutput.empty()) {
         outputEmbedding.resize(num_embed_cols, 0.0);  // TODO: should be NaN?

--- a/plugins/tabular_dataset.cc
+++ b/plugins/tabular_dataset.cc
@@ -1388,6 +1388,13 @@ getRowStream() const
         (itl.get()); 
 } 
 
+ExpressionValue
+TabularDataset::
+getRowExpr(const RowName & row) const
+{
+    return itl->getRowExpr(row);
+}
+
 GenerateRowsWhereFunction
 TabularDataset::
 generateRowsWhere(const SqlBindingScope & context,

--- a/plugins/tabular_dataset.h
+++ b/plugins/tabular_dataset.h
@@ -52,6 +52,8 @@ struct TabularDataset : public Dataset {
     virtual std::shared_ptr<ColumnIndex> getColumnIndex() const;
 
     virtual std::shared_ptr<RowStream> getRowStream() const;
+
+    virtual ExpressionValue getRowExpr(const RowName & row) const;
     
     virtual std::pair<Date, Date> getTimestampRange() const;
 

--- a/server/analytics.h
+++ b/server/analytics.h
@@ -48,6 +48,20 @@ struct RowProcessor {
     bool operator () (NamedRowValue & output) {return processorfct(output);}
 };
 
+struct RowProcessorExpr {
+    std::function<bool (Path & rowName,
+                        ExpressionValue & output,
+                        std::vector<ExpressionValue> & calc)> processorfct;
+    bool processInParallel;
+
+    bool operator () (Path & rowName,
+                      ExpressionValue & output,
+                      std::vector<ExpressionValue> & calc)
+    {
+        return processorfct(rowName, output, calc);
+    }
+};
+
 struct RowProcessorEx {
     std::function<bool (NamedRowValue & output, const std::vector<ExpressionValue> & calc)> processorfct;
     bool processInParallel;
@@ -68,6 +82,21 @@ bool iterateDataset(const SelectExpression & select,
                     ssize_t offset,
                     ssize_t limit,
                     std::function<bool (const Json::Value &)> onProgress);
+
+/** Equivalent to SELECT (select) FROM (dataset) WHEN (when) WHERE (where), and each matching
+    row is passed to the aggregator.
+*/
+bool iterateDatasetExpr(const SelectExpression & select,
+                        const Dataset & from,
+                        const Utf8String & alias,
+                        const WhenExpression & when,
+                        const SqlExpression & where,
+                        std::vector<std::shared_ptr<SqlExpression> > calc,
+                        RowProcessorExpr processor,
+                        const OrderByExpression & orderBy,
+                        ssize_t offset,
+                        ssize_t limit,
+                        std::function<bool (const Json::Value &)> onProgress);
 
 /** Equivalent to SELECT (select) FROM (dataset) WHEN (when) WHERE (where), and each matching
     row is passed to the aggregator.

--- a/server/bound_queries.h
+++ b/server/bound_queries.h
@@ -113,6 +113,20 @@ struct BoundSelectQuery {
                  ssize_t limit,
                  std::function<bool (const Json::Value &)> onProgress);
 
+    bool executeExpr(RowProcessorExpr processor,
+                     ssize_t offset,
+                     ssize_t limit,
+                     std::function<bool (const Json::Value &)> onProgress);
+
+    bool executeExpr(std::function<bool (RowName & rowName,
+                                         ExpressionValue & val,
+                                         std::vector<ExpressionValue> & calcd,
+                                         int rowNum)> processor,
+                     bool processInParallel,
+                     ssize_t offset,
+                     ssize_t limit,
+                     std::function<bool (const Json::Value &)> onProgress);
+
     std::shared_ptr<Executor> executor;
 
     std::shared_ptr<ExpressionValueInfo> getSelectOutputInfo() const;

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -3628,7 +3628,7 @@ getFiltered(const VariableFilter & filter,
         const ExpressionValue * output = atoms.extract(storage);
         if (output)
             return *output;
-        else return (storage = ExpressionValue());
+        else return (storage = ExpressionValue::null(Date::notADate()));
     }
     else {
         // Atoms get added to rows

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -1590,12 +1590,25 @@ makeInputDatasetDescription();
 
 struct BoundWhenExpression {
     
-    typedef std::function<void (MatrixNamedRow & row,
+    typedef std::function<void (ExpressionValue & row,
                                 const SqlRowScope & rowScope)> FilterFunction;
 
-    FilterFunction filterInPlace;
+    BoundWhenExpression(FilterFunction fn = nullptr,
+                        const WhenExpression * expr = nullptr)
+        : filterInPlaceFn(fn), expr(expr)
+    {
+    }
 
-    /// Expression that lef to this bound expression
+    FilterFunction filterInPlaceFn;
+
+    void filterInPlace(ExpressionValue & row,
+                       const SqlRowScope & rowScope) const
+    {
+        if (filterInPlaceFn)
+            filterInPlaceFn(row, rowScope);
+    }
+
+    /// Expression that led to this bound expression
     const WhenExpression * expr;
 };
 


### PR DESCRIPTION
This simplifies and streamlines the query logic by removing the use of MatrixNamedRow (an exploded format) in query processing and sticking to ExpressionValues.

It has an effect on efficiency: in cases where there is SQL processing, it will be faster (as no converting back and forth from ExpressionValues is needed).  However, for a select * it will be somewhat slower.

There is a forthcoming patch to fix that situation by making the ExpressionValue be used through the entire query processing path.

Note that it includes the MLDB-1818 diff, as it's built on top of that code.  Once that branch is merged, this can be rebased and will end up substantially smaller.