### PR TITLE
Fixed SELECT in column expression (MLDBFB-646)

### DIFF
--- a/sql/binding_contexts.cc
+++ b/sql/binding_contexts.cc
@@ -186,6 +186,21 @@ doGetFunction(const Utf8String & tableName,
                 std::make_shared<PathValueInfo>()};
     }
 
+    if (functionName == "value") {
+        return {[=] (const std::vector<ExpressionValue> & args,
+                     const SqlRowScope & scope)
+                {
+                    auto & col = scope.as<ColumnScope>();
+                    if (!col.columnValue)
+                        throw HttpReturnException
+                            (400,
+                             "Evaluation value() in column "
+                             "expression without columns");
+                    return *col.columnValue;
+                },
+                std::make_shared<AnyValueInfo>()};
+    }
+
     auto fn = outer.doGetColumnFunction(functionName);
 
     if (fn)

--- a/sql/binding_contexts.h
+++ b/sql/binding_contexts.h
@@ -101,11 +101,18 @@ struct ColumnExpressionBindingScope: public SqlBindingScope {
     /// RowContex structure. Derived class's row scope must derive from this
     struct ColumnScope: public SqlRowScope {
         ColumnScope(const ColumnName & columnName)
-            : columnName(columnName)
+            : columnName(columnName), columnValue(nullptr)
+        {
+        }
+
+        ColumnScope(const ColumnName & columnName,
+                    const ExpressionValue & columnValue)
+            : columnName(columnName), columnValue(&columnValue)
         {
         }
 
         const ColumnName & columnName;
+        const ExpressionValue * columnValue;
     };
 
     virtual BoundFunction
@@ -114,11 +121,17 @@ struct ColumnExpressionBindingScope: public SqlBindingScope {
                   const std::vector<BoundSqlExpression> & args,
                   SqlBindingScope & argScope);
 
-    ColumnScope getColumnScope(const ColumnName & columnName)
+    static ColumnScope getColumnScope(const ColumnName & columnName)
     {
         return ColumnScope(columnName);
     }
-
+    
+    static ColumnScope getColumnScope(const ColumnName & columnName,
+                                      const ExpressionValue & val)
+    {
+        return ColumnScope(columnName, val);
+    }
+    
     virtual MldbServer * getMldbServer() const
     {
         return outer.getMldbServer();

--- a/testing/MLDBFB-646-column-expression-select.js
+++ b/testing/MLDBFB-646-column-expression-select.js
@@ -1,0 +1,51 @@
+// This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+
+var resp = mldb.query("select column expr(select value() * 10) named 'res' from (select x:1, y:2)");
+
+var expected = [
+   {
+      "columns" : [
+         [ "x", 10, "-Inf" ],
+         [ "y", 20, "-Inf" ]
+      ],
+      "rowHash" : "4ba25cf9b5244b88",
+      "rowName" : "res"
+   }
+];
+
+mldb.log(resp);
+
+assertEqual(resp, expected);
+
+resp = mldb.query("select column expr(select {a: value() * 10, b: value() * 20} ) named 'res' from (select x:1, y:2)");
+
+mldb.log(resp);
+
+expected = [
+   {
+      "columns" : [
+         [ "x.a", 10, "-Inf" ],
+         [ "x.b", 20, "-Inf" ],
+         [ "y.a", 20, "-Inf" ],
+         [ "y.b", 40, "-Inf" ]
+      ],
+      "rowHash" : "4ba25cf9b5244b88",
+      "rowName" : "res"
+   }
+];
+
+assertEqual(resp, expected);
+
+"success"

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -406,6 +406,7 @@ $(eval $(call mldb_unit_test,MLDB-1792_aggregator_error_message.py))
 $(eval $(call mldb_unit_test,try_except_builtin_fct.py))
 $(eval $(call mldb_unit_test,MLDB-1808_precision_loss_issue.py))
 $(eval $(call mldb_unit_test,MLDBFB-636-join-rowhash.py))
+$(eval $(call mldb_unit_test,MLDBFB-646-column-expression-select.js))
 
 $(eval $(call test,MLDBFB-239-s3-test,aws vfs_handlers,boost $(MANUAL_IF_NO_S3)))
 $(eval $(call mldb_unit_test,MLDB-1755-column-execution-memory-use.js))


### PR DESCRIPTION
Allows the `SELECT` part of `COLUMN EXPR (...)` to be used.

@simlmx FYI
@jpilaul would be worth adding to the tutorial on COLUMN EXPR

```
select column expr(select {a: value() * 10, b: value() * 20} ) named 'res' from (select x:1, y:2)
```

```
[
         [ "x.a", 10, "-Inf" ],
         [ "x.b", 20, "-Inf" ],
         [ "y.a", 20, "-Inf" ],
         [ "y.b", 40, "-Inf" ]
      ]
```