### PR TITLE
Fixed tabular dataset (MLDB-1837)

### DIFF
--- a/plugins/tabular_dataset.cc
+++ b/plugins/tabular_dataset.cc
@@ -69,7 +69,7 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
             size_t sum = 0;
             chunkiter = store->chunks.begin();
             while (chunkiter != store->chunks.end()
-                   && start > sum + chunkiter->rowCount())  {
+                   && start >= sum + chunkiter->rowCount())  {
                 sum += chunkiter->rowCount();
                 ++chunkiter;
             }


### PR DESCRIPTION
Fixes an issue with the initAt() function over Tabular datasets whereby it could end up at an invalid iterator position if it started off between chunks.

One character fix.