### PR TITLE
Sped up sparse mutable chunked recording (MLDB-1838)

### DIFF
--- a/plugins/sparse_matrix_dataset.h
+++ b/plugins/sparse_matrix_dataset.h
@@ -31,30 +31,42 @@ struct SparseMatrixDataset: public Dataset {
         All other views are built on top of this.
     */
     virtual void recordRowItl(const RowName & rowName,
-                           const std::vector<std::tuple<ColumnName, CellValue, Date> > & vals);
+                              const std::vector<std::tuple<ColumnName, CellValue, Date> > & vals) override;
 
-    virtual void recordRows(const std::vector<std::pair<RowName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > & rows);
+    virtual void recordRows(const std::vector<std::pair<RowName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > & rows) override;
+
+    virtual void
+    recordRowExpr(const RowName & rowName,
+                  const ExpressionValue & vals) override;
+
+    virtual void
+    recordRowsExpr(const std::vector<std::pair<RowName, ExpressionValue> > & rows)
+        override;
 
     /** Return what is known about the given column.  Default returns
         an "any value" result, ie nothing is known about the column.
     */
-    virtual KnownColumn getKnownColumnInfo(const ColumnName & columnName) const;
+    virtual KnownColumn
+    getKnownColumnInfo(const ColumnName & columnName) const override;
 
-    /** Commit changes to the database.  Default is a no-op. */
-    virtual void commit();
+    /** Commit changes to the database. */
+    virtual void commit() override;
 
     // TODO: implement; the default version is very slow
     //virtual std::pair<Date, Date> getTimestampRange() const;
-    virtual Date quantizeTimestamp(Date timestamp) const;
 
-    virtual std::shared_ptr<MatrixView> getMatrixView() const;
-    virtual std::shared_ptr<ColumnIndex> getColumnIndex() const;
-    virtual std::shared_ptr<RowStream> getRowStream() const;
+    virtual Date quantizeTimestamp(Date timestamp) const override;
+
+    virtual std::shared_ptr<MatrixView> getMatrixView() const override;
+    virtual std::shared_ptr<ColumnIndex> getColumnIndex() const override;
+    virtual std::shared_ptr<RowStream> getRowStream() const override;
 
     virtual RestRequestMatchResult
     handleRequest(RestConnection & connection,
                   const RestRequest & request,
-                  RestRequestParsingContext & context) const;
+                  RestRequestParsingContext & context) const override;
+
+    virtual ExpressionValue getRowExpr(const RowName & rowName) const override;
 
 protected:
     struct Itl;
@@ -108,6 +120,8 @@ struct MutableSparseMatrixDataset: public SparseMatrixDataset {
     MutableSparseMatrixDataset(MldbServer * owner,
                                PolyConfig config,
                                const std::function<bool (const Json::Value &)> & onProgress);
+
+    virtual MultiChunkRecorder getChunkRecorder();
 
     struct Itl;
 };

--- a/testing/MLDB-1098-csv-export.py
+++ b/testing/MLDB-1098-csv-export.py
@@ -87,7 +87,7 @@ class CsvExportTest(unittest.TestCase):
                 "named" : "rowName"
             }
         }
-        mldb.put("/v1/procedures/csv_proc", csv_conf) 
+        mldb.log(mldb.put("/v1/procedures/csv_proc", csv_conf))
 
         # export it (end of roundtrip)
         tmp_file2 = tempfile.NamedTemporaryFile(dir='build/x86_64/tmp')
@@ -118,7 +118,7 @@ class CsvExportTest(unittest.TestCase):
             }
         })
 
-        mldb.post('/v1/procedures/export3/runs')
+        mldb.log(mldb.post('/v1/procedures/export3/runs'))
 
         lines_expect = [u'outf8 roowo;Ǆώύψ;ăØÆÅ',
                         'oascii roowo;1;2']

--- a/testing/MLDB-1428-text-sparse-output.py
+++ b/testing/MLDB-1428-text-sparse-output.py
@@ -23,7 +23,7 @@ class ImportTextToSparseTest(unittest.TestCase):
             } 
         })
 
-        res = mldb.query('SELECT * FROM iris limit 1')
+        res = mldb.query('SELECT * FROM iris ORDER BY rowName() limit 1')
 
         expected = [[
                         "_rowName",
@@ -33,14 +33,7 @@ class ImportTextToSparseTest(unittest.TestCase):
                         "d",
                         "label"
                     ],
-                    [
-                        "150",
-                        5.9,
-                        3,
-                        5.1,
-                        1.8,
-                        "Iris-virginica"
-                    ]]
+                    [u'1', 5.1, 3.5, 1.4, 0.2, u'Iris-setosa']]
 
         self.assertEqual(res, expected)
 
@@ -57,10 +50,10 @@ class ImportTextToSparseTest(unittest.TestCase):
             } 
         })
 
-        res = mldb.query('SELECT * FROM iris_ex limit 1')
+        res = mldb.query('SELECT * FROM iris_ex ORDER BY rowName() limit 1')
 
         expected = [["_rowName", "a", "b", "d", "label" ],
-                    ["150", 5.9, 3, 1.8, "Iris-virginica"]]
+                    [u'1', 5.1, 3.5, 0.2, u'Iris-setosa']]
 
         self.assertEqual(res, expected)
 

--- a/testing/MLDB-415-rawquery.js
+++ b/testing/MLDB-415-rawquery.js
@@ -30,7 +30,7 @@ function assertEqual(expr, val, msg)
 }
 
 
-var resp = mldb.get("/v1/query", {q:"SELECT y, label, x FROM test", format:'table'});
+var resp = mldb.get("/v1/query", {q:"SELECT y, label, x FROM test ORDER BY rowPath()", format:'table'});
 
 assertEqual(resp.responseCode, 200, "Error executing query");
 
@@ -38,9 +38,9 @@ plugin.log("returned", resp.json);
 
 var expected = [
    [ "_rowName", "label", "x", "y" ],
-   [ "ex3", "cat", 1, 2 ],
+   [ "ex1", "cat", 0, 0 ],
    [ "ex2", "dog", 1, 1 ],
-   [ "ex1", "cat", 0, 0 ]
+   [ "ex3", "cat", 1, 2 ]
 ];
 
 plugin.log("expected", expected);


### PR DESCRIPTION
Takes import of a 1.6 million line CSV file into sparse.mutable from 4 minutes to 36 seconds, and greatly reduces memory usage too.