### PR TITLE
Reduced Path allocations constructing from PathElement (MLDB-1845)

### DIFF
--- a/sql/path.cc
+++ b/sql/path.cc
@@ -848,7 +848,7 @@ PathBuilder &
 PathBuilder::
 add(PathElement && element)
 {
-    if (bytes.empty()) {
+    if (bytes.empty() && element.hasExternalStorage()) {
         bytes = element.stealBytes();
     }
     else {
@@ -943,7 +943,13 @@ Path::Path(PathElement && path)
         length_ = 0;
         return;
     }
-    bytes_ = path.stealBytes();
+    if (path.hasExternalStorage()) {
+        bytes_ = path.stealBytes();
+    }
+    else {
+        auto v = path.getStringView();
+        bytes_.append(v.first, v.first + v.second);
+    }
     if (externalOfs()) {
         ofsPtr_ = new uint32_t[2];
         ofsPtr_[0] = 0;
@@ -963,7 +969,13 @@ Path::Path(const PathElement & path)
         length_ = 0;
         return;
     }
-    bytes_ = path.getBytes();
+    if (path.hasExternalStorage()) {
+        bytes_ = path.getBytes();
+    }
+    else {
+        auto v = path.getStringView();
+        bytes_.append(v.first, v.first + v.second);
+    }
     if (externalOfs()) {
         ofsPtr_ = new uint32_t[2];
         ofsPtr_[0] = 0;

--- a/sql/path.h
+++ b/sql/path.h
@@ -149,6 +149,7 @@ struct PathElement {
 
     Utf8String toEscapedUtf8String() const;
 
+    bool hasExternalStorage() const { return complex_; }
     std::string stealBytes();
     std::string getBytes() const;
     


### PR DESCRIPTION
Simple fix to avoid using a std::string as a temporary.