### PR TITLE
Handle dynamic columns in new executor (MLDB-1843)

### DIFF
--- a/sql/execution_pipeline_impl.cc
+++ b/sql/execution_pipeline_impl.cc
@@ -123,8 +123,14 @@ doGetAllColumns(const Utf8String & tableName,
         {
             ColumnName newColumnName = prefix + columnName;
             auto it = index.find(newColumnName);
-            if (it == index.end())
+            if (it == index.end()) {
+                if (hasUnknownColumns) {
+                    ColumnName outputName = keep(columnName);
+                    if (!outputName.empty())
+                        result.emplace_back(std::move(outputName), val, ts);
+                }
                 return true;
+            }
             result.emplace_back(it->second, val, ts);
             return true;
         };
@@ -136,7 +142,8 @@ doGetAllColumns(const Utf8String & tableName,
     };
 
     GetAllColumnsOutput result;
-    result.info = std::make_shared<RowValueInfo>(columnsWithInfo, SCHEMA_CLOSED);
+    result.info = std::make_shared<RowValueInfo>
+        (columnsWithInfo, hasUnknownColumns ? SCHEMA_OPEN : SCHEMA_CLOSED);
     result.exec = exec;
     return result;
 }

--- a/testing/MLDB-1843-select-disappearing-values.js
+++ b/testing/MLDB-1843-select-disappearing-values.js
@@ -1,0 +1,48 @@
+// This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+
+function assertEqual(expr, val, msg)
+{
+    if (expr == val)
+        return;
+    if (JSON.stringify(expr) == JSON.stringify(val))
+        return;
+
+    throw "Assertion failure: " + msg + ": " + JSON.stringify(expr)
+        + " not equal to " + JSON.stringify(val);
+}
+
+var query = "SELECT tokenize('a,b,c') AS *"
+
+var resp = mldb.put("/v1/functions/f1", {
+    "type": "sql.query",
+    "params": {
+        "query": query,
+    }
+});
+
+assertEqual(resp.responseCode, 201);
+
+var resp = mldb.put("/v1/functions/f2", {
+    "type": "sql.query",
+    "params": {
+        "query": "SELECT * FROM (" + query + ")"
+    }
+});
+
+assertEqual(resp.responseCode, 201);
+
+mldb.log("--------------- first query");
+
+var resp1 = mldb.query("SELECT f1() AS *");
+
+mldb.log(resp1);
+
+mldb.log("--------------- second query");
+
+var resp2 = mldb.query("SELECT f2() AS *");
+
+mldb.log(resp2);
+
+assertEqual(resp1, resp2);
+
+"success"

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -408,6 +408,8 @@ $(eval $(call mldb_unit_test,MLDBFB-636-join-rowhash.py))
 $(eval $(call mldb_unit_test,MLDBFB-634-join-nested-column.py))
 $(eval $(call mldb_unit_test,MLDBFB-646-column-expression-select.js))
 $(eval $(call mldb_unit_test,MLDBFB-650-names-aggregators.py))
+$(eval $(call mldb_unit_test,MLDB-1843-select-disappearing-values.js))
+
 
 $(eval $(call test,MLDBFB-239-s3-test,aws vfs_handlers,boost $(MANUAL_IF_NO_S3)))
 $(eval $(call mldb_unit_test,MLDB-1755-column-execution-memory-use.js))


### PR DESCRIPTION
Fixes problems with dynamic schemas in the new executor's table expressions.