### PR TITLE
More fixes for types and new executor (MLDB-1843)

### DIFF
--- a/plugins/importtext_procedure.cc
+++ b/plugins/importtext_procedure.cc
@@ -861,7 +861,7 @@ struct ImportTextProcedureWorkInstance
         // Figure out our output column names from the bound
         // select clause
 
-        if (selectBound.info->getSchemaCompleteness() != SCHEMA_CLOSED) {
+        if (selectBound.info->getSchemaCompletenessRecursive() != SCHEMA_CLOSED) {
             areOutputColumnNamesKnown = false;
         }
 

--- a/plugins/matrix.cc
+++ b/plugins/matrix.cc
@@ -65,7 +65,7 @@ classifyColumns(const Dataset & dataset, SelectExpression select)
     std::vector<ColumnName> selectedColumnsVec = boundSelect.info->allColumnNames();
     std::set<ColumnName> selectedColumns(selectedColumnsVec.begin(),
                                          selectedColumnsVec.end());
-    if (boundSelect.info->getSchemaCompleteness() == SCHEMA_OPEN)
+    if (boundSelect.info->getSchemaCompletenessRecursive() == SCHEMA_OPEN)
         cerr << "WARNING: non-enumerated columns will not be used "
             "in correlation training" << endl;
     

--- a/sql/binding_contexts.cc
+++ b/sql/binding_contexts.cc
@@ -378,7 +378,7 @@ doGetColumn(const Utf8String & tableName,
     if (!info) {
         // Don't know the column.  Is it because it never exists, or because
         // the schema is dynamic, or because its deeper?
-        if (inputInfo->getSchemaCompleteness() != SCHEMA_CLOSED
+        if (inputInfo->getSchemaCompletenessRecursive() != SCHEMA_CLOSED
             || columnName.size() > 1) {
             // Dynamic columns; be prepared to do either depending upon
             // what we find
@@ -426,7 +426,7 @@ doGetAllColumns(const Utf8String & tableName,
 {
     GetAllColumnsOutput result;
 
-    if (!inputInfo || inputInfo->getSchemaCompleteness() != SCHEMA_CLOSED) {
+    if (!inputInfo || inputInfo->getSchemaCompletenessRecursive() != SCHEMA_CLOSED) {
         // In recording mode, or with dynamic columns; we filter once we have the
         // value
 

--- a/sql/execution_pipeline_impl.cc
+++ b/sql/execution_pipeline_impl.cc
@@ -40,7 +40,7 @@ TableLexicalScope(std::shared_ptr<RowValueInfo> rowInfo,
                   return first.columnName < second.columnName;
               });
     
-    hasUnknownColumns = rowInfo->getSchemaCompleteness() == SCHEMA_OPEN;
+    hasUnknownColumns = rowInfo->getSchemaCompletenessRecursive() == SCHEMA_OPEN;
 }
 
 ColumnGetter
@@ -107,7 +107,8 @@ doGetAllColumns(const Utf8String & tableName,
         index[column.columnName] = ColumnName(outputName);
     }
 
-    auto exec = [=] (const SqlRowScope & rowScope, const VariableFilter & filter) -> ExpressionValue
+    auto exec = [=] (const SqlRowScope & rowScope, const VariableFilter & filter)
+        -> ExpressionValue
     {
         auto & row = rowScope.as<PipelineResults>();
 
@@ -125,7 +126,7 @@ doGetAllColumns(const Utf8String & tableName,
             auto it = index.find(newColumnName);
             if (it == index.end()) {
                 if (hasUnknownColumns) {
-                    ColumnName outputName = keep(columnName);
+                    ColumnName outputName = keep(newColumnName);
                     if (!outputName.empty())
                         result.emplace_back(std::move(outputName), val, ts);
                 }

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -503,6 +503,13 @@ getSchemaCompleteness() const
                               "type", ML::type_name(*this));
 }
 
+SchemaCompleteness
+ExpressionValueInfo::
+getSchemaCompletenessRecursive() const
+{
+    return SCHEMA_CLOSED;
+}
+
 std::vector<KnownColumn>
 ExpressionValueInfo::
 getKnownColumns() const
@@ -663,6 +670,7 @@ struct ExpressionValueInfoPtrDescription
             out["kind"] = "row";
             out["knownColumns"] = jsonEncode((*val)->getKnownColumns());
             out["hasUnknownColumns"] = (*val)->getSchemaCompleteness() == SCHEMA_OPEN;
+            out["hasUnknownColumnsRecursive"] = (*val)->getSchemaCompletenessRecursive() == SCHEMA_OPEN;
         }
         context.writeJson(out);
     }
@@ -699,6 +707,7 @@ struct RowValueInfoPtrDescription
         out["kind"] = "row";
         out["knownColumns"] = jsonEncode((*val)->getKnownColumns());
         out["hasUnknownColumns"] = (*val)->getSchemaCompleteness() == SCHEMA_OPEN;
+        out["hasUnknownColumnsRecursive"] = (*val)->getSchemaCompletenessRecursive() == SCHEMA_OPEN;
         context.writeJson(out);
     }
     
@@ -972,6 +981,13 @@ getSchemaCompleteness() const
     return SCHEMA_CLOSED;
 }
 
+SchemaCompleteness
+EmbeddingValueInfo::
+getSchemaCompletenessRecursive() const
+{
+    return getSchemaCompleteness();
+}
+
 
 // TODO: generalize
 std::shared_ptr<ExpressionValueInfo>
@@ -1138,6 +1154,13 @@ getSchemaCompleteness() const
     return SCHEMA_OPEN;
 }
 
+SchemaCompleteness
+AnyValueInfo::
+getSchemaCompletenessRecursive() const
+{
+    return SCHEMA_OPEN;
+}
+
 std::vector<KnownColumn>
 AnyValueInfo::
 getKnownColumns() const
@@ -1154,8 +1177,15 @@ RowValueInfo::
 RowValueInfo(const std::vector<KnownColumn> & columns,
              SchemaCompleteness completeness)
     : columns(columns),
-      completeness(completeness)
+      completeness(completeness),
+      completenessRecursive(completeness)
 {
+    for (auto & c: this->columns) {
+        if (c.valueInfo->getSchemaCompletenessRecursive() == SCHEMA_OPEN) {
+            completenessRecursive = SCHEMA_OPEN;
+            break;
+        }
+    }
 }
 
 bool
@@ -1194,6 +1224,13 @@ RowValueInfo::
 getSchemaCompleteness() const
 {
     return completeness;
+}
+
+SchemaCompleteness
+RowValueInfo::
+getSchemaCompletenessRecursive() const
+{
+    return completenessRecursive;
 }
 
 std::shared_ptr<ExpressionValueInfo>

--- a/sql/expression_value.h
+++ b/sql/expression_value.h
@@ -215,6 +215,12 @@ struct ExpressionValueInfo {
     /// it's not a row.
     virtual SchemaCompleteness getSchemaCompleteness() const;
 
+    /// Return whether the schema for a row is closed (only those columns are
+    /// there) or open (other columns may be present).  Will return closed
+    /// for atoms, and open for rows with any open schema inside them at any
+    /// recursive depth.
+    virtual SchemaCompleteness getSchemaCompletenessRecursive() const;
+
     /// Return the set of known columns for a row.  Default throws that it's not
     /// a row.
     virtual std::vector<KnownColumn> getKnownColumns() const;
@@ -1339,6 +1345,8 @@ struct AnyValueInfo: public ExpressionValueInfoT<ExpressionValue> {
 
     virtual SchemaCompleteness getSchemaCompleteness() const;
 
+    virtual SchemaCompleteness getSchemaCompletenessRecursive() const;
+
     virtual std::vector<KnownColumn> getKnownColumns() const;
 
     virtual bool couldBeRow() const
@@ -1398,6 +1406,8 @@ struct EmbeddingValueInfo: public ExpressionValueInfoT<ML::distribution<CellValu
 
     virtual SchemaCompleteness getSchemaCompleteness() const;
 
+    virtual SchemaCompleteness getSchemaCompletenessRecursive() const;
+
     virtual std::vector<KnownColumn> getKnownColumns() const;
 
     virtual std::vector<ColumnName> allColumnNames() const;
@@ -1437,9 +1447,7 @@ struct RowValueInfo: public ExpressionValueInfoT<RowValue> {
 
     virtual std::vector<KnownColumn> getKnownColumns() const override;
     virtual SchemaCompleteness getSchemaCompleteness() const override;
-
-    std::vector<KnownColumn> columns;
-    SchemaCompleteness completeness;
+    virtual SchemaCompleteness getSchemaCompletenessRecursive() const;
 
     virtual bool isCompatible(const ExpressionValue & value) const override
     {
@@ -1460,6 +1468,11 @@ struct RowValueInfo: public ExpressionValueInfoT<RowValue> {
     {
         return false;
     }
+
+protected:
+    std::vector<KnownColumn> columns;
+    SchemaCompleteness completeness;
+    SchemaCompleteness completenessRecursive;
 };
 
 /// For a row.  This may have information about columns within that row.

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -3478,8 +3478,9 @@ bind(SqlBindingScope & scope) const
             // i.e select x.a.* from x returns a.b
             // But we have to check the initial prefix for joins
             // i.e select x.a.* from x join y returns x.a.b
-            if (!inputColumnName.matchWildcard(simplifiedPrefix) && !inputColumnName.matchWildcard(prefix)) {
-               //cerr << "rejected by prefix: " << simplifiedPrefix << "," << prefix << endl;
+            if (!inputColumnName.matchWildcard(simplifiedPrefix)
+                && !inputColumnName.matchWildcard(prefix)) {
+                //cerr << "rejected by prefix: " << simplifiedPrefix << "," << prefix << endl;
                 return ColumnName();
             }
 
@@ -3677,7 +3678,8 @@ bind(SqlBindingScope & scope) const
         std::vector<KnownColumn> knownColumns = {
             KnownColumn(alias, exprBound.info, COLUMN_IS_DENSE) };
         
-        auto info = std::make_shared<RowValueInfo>(knownColumns, SCHEMA_CLOSED);
+        auto info = std::make_shared<RowValueInfo>
+            (knownColumns, SCHEMA_CLOSED);
 
         return BoundSqlExpression(exec, this, info);
     }

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -3737,6 +3737,9 @@ bind(SqlBindingScope & scope) const
         = scope.doGetAllColumns("" /* table name */,
                                   [] (ColumnName n) { return std::move(n); });
     
+    bool hasDynamicColumns
+        = allColumns.info->getSchemaCompletenessRecursive() == SCHEMA_OPEN;
+    
     // Only known columns are kept.  For each one, we filter it then calculate
     // the order by expression.
 
@@ -3834,6 +3837,10 @@ bind(SqlBindingScope & scope) const
         = select->getType() == "function"
         && select->getOperation() == "value";
 
+    bool asColumnPath
+        = as->getType() == "function"
+        && as->getOperation() == "columnPath";
+
     //for (unsigned i = 0;  i < 10 && i < columns.size();  ++i) {
     //    cerr << "column " << i << " name " << columns[i].columnName
     //         << " sort " << jsonEncodeStr(columns[i].sortFields) << endl;
@@ -3864,10 +3871,12 @@ bind(SqlBindingScope & scope) const
     
     auto filterColumns = [=] (const ColumnName & name) -> ColumnName
         {
+            if (hasDynamicColumns)
+                return name;
             auto it = keepColumns.find(name);
-            if (it == keepColumns.end())
+            if (it == keepColumns.end()) {
                 return ColumnName();
-
+            }
             return it->second;
         };
     
@@ -3875,7 +3884,7 @@ bind(SqlBindingScope & scope) const
     auto outputColumns
         = scope.doGetAllColumns("" /* prefix */, filterColumns);
 
-    if (selectValue) {
+    if (selectValue && asColumnPath && !hasDynamicColumns) {
 
         auto exec = [=] (const SqlRowScope & scope,
                          ExpressionValue & storage,
@@ -3909,17 +3918,42 @@ bind(SqlBindingScope & scope) const
                     ExpressionValue in(std::move(val), ts);
                     auto scope = ColumnExpressionBindingScope
                         ::getColumnScope(columnName, in);
-                    
+
+                    bool keep = boundWhere(scope, GET_LATEST).isTrue();
+
+                    if (!keep)
+                        return true;
+
                     ExpressionValue storage;
+                    if (selectValue)
+                        storage = std::move(in);
                     const ExpressionValue & result
-                        = boundSelect(scope, storage, GET_ALL);
+                        = selectValue
+                            ? storage
+                            : boundSelect(scope, storage, GET_ALL);
+
+                    ColumnName columnNameStorage;
+                    ColumnName * columnNameOut = &columnName;
+                    if (!asColumnPath) {
+                        ExpressionValue tmp;
+                        columnNameStorage
+                            = boundAs(scope, tmp, GET_ALL).coerceToPath();
+                        columnNameOut = &columnNameStorage;
+                    }
                     
                     if (&result == &storage) {
-                        // The expression may produce more than one atom as an
-                        // output, so take all of them.
-                        auto onAtom2 = [&] (ColumnName & columnName2,
-                                            CellValue & val,
-                                            Date ts)
+                        if (storage.isAtom()) {
+                            // Put directly in place
+                            output.emplace_back(std::move(*columnNameOut),
+                                                storage.stealAtom(),
+                                                storage.getEffectiveTimestamp());
+                        }
+                        else {
+                            // The expression may produce more than one atom as an
+                            // output, so take all of them.
+                            auto onAtom2 = [&] (ColumnName & columnName2,
+                                                CellValue & val,
+                                                Date ts)
                             {
                                 output.emplace_back(columnName + columnName2,
                                                     std::move(val),
@@ -3927,7 +3961,8 @@ bind(SqlBindingScope & scope) const
                                 return true;
                             };
 
-                        storage.forEachAtomDestructive(onAtom2);
+                            storage.forEachAtomDestructive(onAtom2);
+                        }
                     }
                     else {
 
@@ -3936,7 +3971,8 @@ bind(SqlBindingScope & scope) const
                                             const CellValue & val,
                                             Date ts)
                             {
-                                output.emplace_back(columnName + prefix + suffix,
+                                output.emplace_back((*columnNameOut)
+                                                    + prefix + suffix,
                                                     std::move(val),
                                                     ts);
                                 return true;

--- a/testing/MLDB-1843-select-disappearing-values.js
+++ b/testing/MLDB-1843-select-disappearing-values.js
@@ -11,7 +11,14 @@ function assertEqual(expr, val, msg)
         + " not equal to " + JSON.stringify(val);
 }
 
-var query = "SELECT tokenize('a,b,c') AS *"
+var query = "SELECT tokenize('a,b,c') AS *";
+var tokQuery = "SELECT tokenize('a,b,c') AS tok";
+
+var analysis = mldb.get("/v1/query", { q: "SELECT static_type({tokenize('a,b,c') AS tok}) as *", format: 'aos' });
+
+mldb.log(analysis.json);
+
+assertEqual(analysis.json[0]["hasUnknownColumnsRecursive"], 1);
 
 var resp = mldb.put("/v1/functions/f1", {
     "type": "sql.query",
@@ -44,5 +51,41 @@ var resp2 = mldb.query("SELECT f2() AS *");
 mldb.log(resp2);
 
 assertEqual(resp1, resp2);
+
+resp = mldb.put("/v1/functions/f3", {
+    "type": "sql.query",
+    "params": {
+        "query": "SELECT tok.* as * FROM (" + tokQuery + ")"
+    }
+});
+
+assertEqual(resp.responseCode, 201);
+
+mldb.log("--------------- third query");
+
+var resp3 = mldb.query("SELECT f3() AS *");
+
+mldb.log(resp3);
+
+assertEqual(resp1, resp3);
+
+resp = mldb.put("/v1/functions/f4", {
+    "type": "sql.query",
+    "params": {
+        "query": "SELECT COLUMN EXPR (AS columnName()) FROM (" + query + ")"
+    }
+});
+
+assertEqual(resp.responseCode, 201);
+
+mldb.log("--------------- fourth query");
+
+var resp4 = mldb.query("SELECT f4() AS *");
+
+mldb.log(resp3);
+
+assertEqual(resp1, resp3);
+
+
 
 "success"

--- a/testing/MLDB-1843-select-disappearing-values.js
+++ b/testing/MLDB-1843-select-disappearing-values.js
@@ -82,9 +82,9 @@ mldb.log("--------------- fourth query");
 
 var resp4 = mldb.query("SELECT f4() AS *");
 
-mldb.log(resp3);
+mldb.log(resp4);
 
-assertEqual(resp1, resp3);
+assertEqual(resp1, resp4);
 
 
 

--- a/testing/MLDB-654-classifier-function-info.js
+++ b/testing/MLDB-654-classifier-function-info.js
@@ -116,6 +116,7 @@ plugin.log(functionInfo.json);
 var expected = {
     "input" : {
         "hasUnknownColumns" : false,
+        "hasUnknownColumnsRecursive" : false,
         "kind" : "row",
         "knownColumns" : [
             {
@@ -123,6 +124,7 @@ var expected = {
                 "sparsity" : "dense",
                 "valueInfo" : {
                     "hasUnknownColumns" : false,
+                    "hasUnknownColumnsRecursive" : false,
                     "kind" : "row",
                     "knownColumns" : [
                         {
@@ -170,6 +172,7 @@ var expected = {
     },
     "output" : {
         "hasUnknownColumns" : false,
+        "hasUnknownColumnsRecursive" : false,
         "kind" : "row",
         "knownColumns" : [
             {
@@ -178,6 +181,7 @@ var expected = {
                 "sparsity" : "dense",
                 "valueInfo" : {
                     "hasUnknownColumns" : false,
+                    "hasUnknownColumnsRecursive" : false,
                     "kind" : "row",
                     "knownColumns" : [
                         {

--- a/testing/MLDB-800-nested_sql_query.py
+++ b/testing/MLDB-800-nested_sql_query.py
@@ -54,19 +54,22 @@ mldb.log(res.json())
 expected = {
     "input": {
         "hasUnknownColumns": True, 
+        "hasUnknownColumnsRecursive": True, 
         "type": "Datacratic::MLDB::RowValueInfo", 
         "kind": "row", 
         "knownColumns": []
     }, 
     "output": {
         "hasUnknownColumns": False, 
+        "hasUnknownColumnsRecursive": True, 
         "type": "Datacratic::MLDB::RowValueInfo", 
         "kind": "row", 
         "knownColumns": [
             {
                 "columnName": "patate({*})", 
                 "valueInfo": {
-                    "hasUnknownColumns": False, 
+                    "hasUnknownColumns": True, 
+                    "hasUnknownColumnsRecursive": True, 
                     "type": "Datacratic::MLDB::RowValueInfo", 
                     "kind": "row", 
                     "knownColumns": [


### PR DESCRIPTION
Fixes a typo causing problems with structured selects in the new executor, and a type system bug that was marking an object with fixed fields but variable subfields as having no schema variability.