### PR TITLE
MLDB-1868 path performance regressions

### DIFF
--- a/builtin/transposed_dataset.h
+++ b/builtin/transposed_dataset.h
@@ -47,6 +47,7 @@ struct TransposedDataset: public Dataset {
     virtual std::shared_ptr<MatrixView> getMatrixView() const;
     virtual std::shared_ptr<ColumnIndex> getColumnIndex() const;
     virtual std::shared_ptr<RowStream> getRowStream() const;
+    virtual ExpressionValue getRowExpr(const RowName & row) const;
 
 private:
     TransposedDatasetConfig datasetConfig;

--- a/plugins/sparse_matrix_dataset.cc
+++ b/plugins/sparse_matrix_dataset.cc
@@ -613,7 +613,8 @@ struct SparseMatrixDataset::Itl
                 Date ts = decodeTs(entry.timestamp);
                 ColumnHash col(entry.rowcol);
                 CellValue v = decodeVal(entry.val, entry.tag, *trans);
-                result.emplace_back(getColumnNameTrans(col, *trans), v, ts);
+                result.emplace_back(getColumnNameTrans(col, *trans),
+                                    std::move(v), ts);
                 return true;
             };
 
@@ -629,7 +630,8 @@ struct SparseMatrixDataset::Itl
 
         auto onRow = [&] (const BaseEntry & entry)
             {
-                result = RowName::parse(entry.metadata.at(0));
+                result = RowName::parse(entry.metadata.at(0).data(),
+                                        entry.metadata.at(0).length());
                 return false;
             };
             
@@ -658,7 +660,8 @@ struct SparseMatrixDataset::Itl
 
         auto onRow = [&] (const BaseEntry & entry)
             {
-                result = ColumnName::parse(entry.metadata.at(0));
+                result = ColumnName::parse(entry.metadata.at(0).data(),
+                                           entry.metadata.at(0).length());
                 return false;  // return false to short circuit
             };
             

--- a/server/dataset_context.cc
+++ b/server/dataset_context.cc
@@ -210,21 +210,8 @@ getColumnCount() const
         }
     }
     else {
-        auto onAtom = [&] (const Path & columnName,
-                           const Path & prefix,
-                           const CellValue & val,
-                           Date ts)
-            {
-                if (prefix.empty()) {
-                    columns.insert(columnName);
-                }
-                else {
-                    columns.insert(prefix + columnName);
-                }
-                return true;
-            };
-
-        expr->forEachAtom(onAtom);
+        return ExpressionValue(expr->getUniqueAtomCount(),
+                               expr->getEffectiveTimestamp());
     }
     
     return ExpressionValue(columns.size(), ts);

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -15,7 +15,7 @@
 #include "mldb/types/vector_description.h"
 #include "mldb/types/compact_vector_description.h"
 #include "mldb/types/tuple_description.h"
-#include "ml/value_descriptions.h"
+#include "mldb/ml/value_descriptions.h"
 #include "mldb/http/http_exception.h"
 #include "mldb/jml/stats/distribution.h"
 #include "mldb/utils/json_utils.h"
@@ -1878,7 +1878,8 @@ ExpressionValue(RowValue row) noexcept
             return rowOut;
         };
 
-    initStructured(doLevel(row.begin(), row.end(), 0 /* level */));
+    initStructured(doLevel(row.begin(), row.end(), 0 /* level */),
+                   false /* needs sorting */, true /* has duplicates (TODO) */);
 }
 
 void

--- a/sql/expression_value.h
+++ b/sql/expression_value.h
@@ -982,6 +982,19 @@ struct ExpressionValue {
     */
     ExpressionValue getFilteredDestructive(const VariableFilter & filter);
 
+    /** Returns the number of times that forEachAtom() will return a
+        value to the callback.  In other words, the total number of
+        distinct atoms in this object.  Atoms will return one.
+    */
+    size_t getAtomCount() const;
+
+    /** Returns the number of unique column names that forEachAtom()
+        will return.  In other words, the total number of distinct
+        elements in the flattened representation of the object.
+        Atoms will return one.
+    */
+    size_t getUniqueAtomCount() const;
+    
     typedef std::function<bool (const ColumnName & columnName,
                                 std::pair<CellValue, Date> * vals1,
                                 std::pair<CellValue, Date> * vals2,

--- a/sql/expression_value.h
+++ b/sql/expression_value.h
@@ -659,8 +659,23 @@ struct ExpressionValue {
     ExpressionValue(CellValue atom, Date ts) noexcept;
     ExpressionValue(RowValue row) noexcept;
 
+    enum Sorting {
+        SORTED,
+        MAY_BE_SORTED,
+        NOT_SORTED
+    };
+
+    enum Duplicates {
+        NO_DUPLICATES,
+        MAY_HAVE_DUPLICATES,
+        HAS_DUPLICATES
+    };
+
     // Construct from a set of named values as a row
-    ExpressionValue(StructValue vals) noexcept;
+    ExpressionValue(StructValue vals,
+                    Sorting sorting = MAY_BE_SORTED,
+                    Duplicates duplicates = MAY_HAVE_DUPLICATES) noexcept;
+
     // Construct from JSON.  Will convert to an atom or a row.
     ExpressionValue(const Json::Value & json, Date ts);
     
@@ -1064,6 +1079,7 @@ private:
         type_ = Type::ATOM;
     }
     void initStructured(Structured row) noexcept;
+    void initStructured(Structured value, bool needsSorting, bool hasDuplicates) noexcept;
     void initStructured(std::shared_ptr<const Structured> row) noexcept;
     const Structured & getStructured() const;
 

--- a/sql/path.cc
+++ b/sql/path.cc
@@ -56,7 +56,7 @@ int calcDigits(const char * begin, size_t len)
     return calcDigits(begin, begin + len);
 }
 
-std::pair<size_t, size_t>
+inline std::pair<size_t, size_t>
 countDigits(const char * p, size_t len)
 {
     // Count leading zeros
@@ -1365,7 +1365,7 @@ compareElement(size_t el, const Path & other, size_t otherEl) const
     int d0 = digits(el);
     int d1 = other.digits(otherEl);
 
-    if (d0 == PathElement::NO_DIGITS && d1 == PathElement::NO_DIGITS) {
+    if (JML_LIKELY(d0 == d1 && d0 != PathElement::SOME_DIGITS)) {
         int res = std::memcmp(s0, s1, std::min(l0, l1));
         if (res)
             return res;

--- a/types/json_printing.cc
+++ b/types/json_printing.cc
@@ -845,6 +845,7 @@ StructuredJsonPrintingContext::
 StructuredJsonPrintingContext(Json::Value & output)
     : output(output), current(&output)
 {
+    path.reserve(8);
 }
 
 void


### PR DESCRIPTION
A set of micro-optimizations that take the columnCount() portion of the Reddit benchmark from around 4 seconds to around 1.5 seconds, removing most of the performance loss associated with moving to ExpressionValues.

Primarily this involves reducing the amount of sorting, now that the ExpressionValue itself is always sorted internally, as well as optimizations for less copying in the Transposed dataset, increasing the set of conditions under which memcmp() can be used in path comparisons, and avoiding temporary values when parsing paths in the sparse matrix dataset.