### PR TITLE
Better flattening/unflattening of paths (MLDBFB-666)

### DIFF
--- a/container_files/public_html/doc/builtin/sql/SelectExpression.md
+++ b/container_files/public_html/doc/builtin/sql/SelectExpression.md
@@ -90,6 +90,8 @@ The following functions are available in the context of a column expression:
   will be `x`, `columnPathElement(1)` will be `y` and `columnPathElement(2)` is equivalent 
   to `columnPathElement(-1)` which will be `2`. If n is bigger than the number 
   of elements in the column path, NULL will be returned.
+- `columnPathLength()` is the number of elements in the column path.
+- `value()` is the value of the column.
 - `rowCount()` is the number of rows that have a value for this column, including explicit NULLs.
 
 ## Filtering duplicated rows based on an expression

--- a/container_files/public_html/doc/builtin/sql/ValueExpression.md
+++ b/container_files/public_html/doc/builtin/sql/ValueExpression.md
@@ -332,6 +332,18 @@ will change values on each row under consideration. See the [Intro to Datasets](
   which may be used for example as the result of a `NAMED` clause.  This is the
   inverse of `stringify_path` (above).
 - `path_element(path, n)` will return element `n` of the given `path`.
+- `path_length(path)` will return the number of elements in the given `path`.
+- `flatten_path(path)` will return a path with a single element that encodes
+  the entire `path` passed in, in the same manner as `stringify_path`.  This
+  is useful where a series of nested values need to be turned into a flat set
+  of columns for another function or a vector aggregator.  By using
+  `COLUMN EXPR (AS flatten_path(columnPath()))` an entire object can be
+  flattened in this manner.
+- `unflatten_path(path)` is the inverse of `flatten_path`.  It requires that
+  the input path have a single element, and will turn it back into a variable
+  sized path.  Using `COLUMN EXPR (AS unflatten_path(columnPath()))` an entire
+  object can be unflattened in this manner.
+
 
 ### Encoding and decoding functions
 

--- a/sql/builtin_functions.h
+++ b/sql/builtin_functions.h
@@ -14,13 +14,6 @@
 
 namespace Datacratic {
 namespace MLDB {
-namespace Builtins {
-
-void
-unpackJson(RowValue & row,
-           const std::string & id,
-           const Json::Value & val,
-           const Date & ts);
 
 inline void checkArgsSize(size_t number, size_t expected,
                           std::string fctName="")
@@ -64,6 +57,14 @@ inline Date calcTs(const ExpressionValue & v1,
                              v3.getEffectiveTimestamp()),
                     v4.getEffectiveTimestamp());
 }
+
+namespace Builtins {
+
+void
+unpackJson(RowValue & row,
+           const std::string & id,
+           const Json::Value & val,
+           const Date & ts);
 
 typedef BoundFunction (*BuiltinFunction) (const std::vector<BoundSqlExpression> &);
 

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -3869,22 +3869,20 @@ bind(SqlBindingScope & scope) const
         keepColumns[c.inputColumnName]
             = c.columnName;
     
-    auto filterColumns = [=] (const ColumnName & name) -> ColumnName
-        {
-            if (hasDynamicColumns)
-                return name;
-            auto it = keepColumns.find(name);
-            if (it == keepColumns.end()) {
-                return ColumnName();
-            }
-            return it->second;
-        };
-    
-    // Finally, return a filtered set from the underlying dataset
-    auto outputColumns
-        = scope.doGetAllColumns("" /* prefix */, filterColumns);
-
     if (selectValue && asColumnPath && !hasDynamicColumns) {
+
+        auto filterColumns = [=] (const ColumnName & name) -> ColumnName
+            {
+                auto it = keepColumns.find(name);
+                if (it == keepColumns.end()) {
+                    return ColumnName();
+                }
+                return it->second;
+            };
+    
+        // Finally, return a filtered set from the underlying dataset
+        auto outputColumns
+            = scope.doGetAllColumns("" /* prefix */, filterColumns);
 
         auto exec = [=] (const SqlRowScope & scope,
                          ExpressionValue & storage,
@@ -3899,6 +3897,13 @@ bind(SqlBindingScope & scope) const
         return result;
     }
     else {
+        auto filterColumns = [=] (const ColumnName & name) -> ColumnName
+            {
+                return name;
+            };
+
+        auto outputColumns
+            = scope.doGetAllColumns("" /* prefix */, filterColumns);
 
         BoundSqlExpression boundSelect = select->bind(colScope);
 

--- a/testing/MLDBFB-646-column-expression-select.js
+++ b/testing/MLDBFB-646-column-expression-select.js
@@ -48,4 +48,37 @@ expected = [
 
 assertEqual(resp, expected);
 
+resp = mldb.query("select column expr(as parse_path(parse_path(columnName()))) named 'res' from (select \"x.y.z\":1, \"x.y.y\":2)");
+
+mldb.log(resp);
+
+expected = [
+   {
+      "columns" : [
+         [ "x.y.y", 2, "-Inf" ],
+         [ "x.y.z", 1, "-Inf" ]
+      ],
+      "rowHash" : "4ba25cf9b5244b88",
+      "rowName" : "res"
+   }
+];
+
+assertEqual(resp, expected);
+
+resp = mldb.query("select column expr(as columnPathElement(0)) named 'res' from (select \"x.y.z\":1, \"x.y.y\":2)");
+
+mldb.log(resp);
+
+resp = mldb.query("select column expr(as parse_path(columnPathElement(0))) named 'res' from (select \"x.y.z\":1, \"x.y.y\":2)");
+
+mldb.log(resp);
+
+assertEqual(resp, expected);
+
+resp = mldb.query("select column expr(as unflatten_path(columnPath())) named 'res' from (select \"x.y.z\":1, \"x.y.y\":2)");
+
+mldb.log(resp);
+
+assertEqual(resp, expected);
+
 "success"


### PR DESCRIPTION
Sorts out some of the confusion around using `COLUMN EXPR (AS parse_path(columnName())` by adding `flatten_path` and `unflatten_path` functions that do what would be expected of them and can be used as a matched pair.

Also adds more efficient implementations of the `columnPathElement()` and `columnPathLength()` functions, and fixes an issue where the `AS` expression was applied twice in some dynamic `COLUMN EXPR` contexts.