### PR TITLE
Allow inference and use of type attributes for TF builtins (MLDB-1877)

### DIFF
--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -883,6 +883,7 @@ EmbeddingValueInfo(const std::vector<std::shared_ptr<ExpressionValueInfo> > & in
         }
 
         shape.push_back(input.size());
+        storageType = info->getEmbeddingType();
         return;
     }
 
@@ -894,6 +895,7 @@ EmbeddingValueInfo(const std::vector<std::shared_ptr<ExpressionValueInfo> > & in
         shape.push_back(input.size());
         for (auto & d: emb->shape)
             shape.push_back(d);
+        storageType = emb->getEmbeddingType();
         return;
     }
 
@@ -961,7 +963,7 @@ StorageType
 EmbeddingValueInfo::
 getEmbeddingType() const
 {
-    return ST_ATOM;
+    return storageType;
 }
 
 size_t
@@ -2102,10 +2104,10 @@ ExpressionValue(std::vector<double> values, Date ts,
 ExpressionValue
 ExpressionValue::
 embedding(Date ts,
-       std::shared_ptr<const void> data,
-       StorageType storageType,
-       DimsVector dims,
-       std::shared_ptr<const EmbeddingMetadata> md)
+          std::shared_ptr<const void> data,
+          StorageType storageType,
+          DimsVector dims,
+          std::shared_ptr<const EmbeddingMetadata> md)
 {
     auto embeddingData = std::make_shared<Embedding>();
     embeddingData->data_ = std::move(data);
@@ -4468,8 +4470,34 @@ getSpecializedValueInfo() const
     case Type::NONE:
         return std::make_shared<EmptyValueInfo>();
     case Type::ATOM:
-        // TODO: specialize for concrete type
-        return std::make_shared<AtomValueInfo>();
+        switch (getAtom().cellType()) {
+        case CellValue::EMPTY:
+            return std::make_shared<EmptyValueInfo>();
+        case CellValue::INTEGER:
+            if (getAtom().isInt64()) {
+                return std::make_shared<IntegerValueInfo>();
+            }
+            else {
+                return std::make_shared<Uint64ValueInfo>();
+            }
+        case CellValue::FLOAT:
+            return std::make_shared<Float64ValueInfo>();
+        case CellValue::ASCII_STRING:
+            return std::make_shared<StringValueInfo>();
+        case CellValue::UTF8_STRING:
+            return std::make_shared<Utf8StringValueInfo>();
+        case CellValue::TIMESTAMP:
+            return std::make_shared<TimestampValueInfo>();
+        case CellValue::TIMEINTERVAL:
+            return std::make_shared<AtomValueInfo>();
+        case CellValue::BLOB:
+            return std::make_shared<BlobValueInfo>();
+        case CellValue::PATH:
+            return std::make_shared<PathValueInfo>();
+        case CellValue::NUM_CELL_TYPES:
+            throw HttpReturnException(500, "Can't specialize unknown cell type");
+        }
+        throw HttpReturnException(500, "Can't specialize unknown cell type");
     case Type::STRUCTURED:
         // TODO: specialize for concrete value.  Currently we just say
         // "it's a row with some values we don't know about yet"

--- a/tensorflow/MLDB-1736-tensorflow-builtins.js
+++ b/tensorflow/MLDB-1736-tensorflow-builtins.js
@@ -49,4 +49,13 @@ var op = mldb.get("/v1/plugins/tensorflow/routes/ops/EncodePng");
 
 mldb.log(op);
 
+var png = mldb.query("SELECT tf_EncodePng([[[0,0,0,0]]], {T: { type: 'DT_UINT8'}}) AS png NAMED 'png'");
+mldb.log(png);
+
+var png = mldb.query("SELECT tf_EncodePng([[[1,1,1,0]]], {}) AS png NAMED 'png'");
+mldb.log(png);
+
+var png = mldb.query("SELECT tf_EncodePng([[[1,1,1,0]]]) AS png NAMED 'png'");
+mldb.log(png);
+
 "success"

--- a/testing/MLDB-1486-embedding-types.js
+++ b/testing/MLDB-1486-embedding-types.js
@@ -30,8 +30,8 @@ var expected = [
    [
       "result",
       "scalar",
-      "Datacratic::MLDB::CellValue",
-      "Datacratic::MLDB::AtomValueInfo"
+      "long",
+      "Datacratic::MLDB::IntegerValueInfo"
    ]
 ];
 


### PR DESCRIPTION
Fixes various embedding type inference and maintenance problems to allow TF functions that don't accept doubles to work properly.
