### PR TITLE
Added ValueDescription for std::array (MLDB-1881)

### DIFF
--- a/types/array_description.h
+++ b/types/array_description.h
@@ -1,0 +1,135 @@
+/** array_description.h                                        -*- C++ -*-
+    Jeremy Barnes, 21 August 2015
+    Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+    Value description implementations for arrays.
+*/
+
+#pragma once
+
+#include <array>
+#include "value_description.h"
+
+namespace Datacratic {
+
+
+/*****************************************************************************/
+/* DEFAULT DESCRIPTION FOR ARRAY                                            */
+/*****************************************************************************/
+
+template<typename T, size_t N>
+struct ArrayDescription
+    : public ValueDescriptionI<std::array<T, N>, ValueKind::ARRAY,
+                               ArrayDescription<T, N> > {
+
+    ArrayDescription(ValueDescriptionT<T> * inner)
+        : inner(inner)
+    {
+    }
+
+    ArrayDescription(std::shared_ptr<const ValueDescriptionT<T> > inner
+                       = getDefaultDescriptionShared((T *)0))
+        : inner(inner)
+    {
+    }
+
+    // Constructor to create a partially-evaluated array description.
+    ArrayDescription(ConstructOnly)
+    {
+    }
+
+    std::shared_ptr<const ValueDescriptionT<T> > inner;
+
+    virtual void parseJsonTyped(std::array<T, N> * val,
+                                JsonParsingContext & context) const JML_OVERRIDE
+    {
+        if (!context.isArray())
+            context.exception("expected array of " + inner->typeName);
+        
+        size_t i = 0;
+        auto onElement = [&] ()
+            {
+                if (i >= N)
+                    context.exception("too many elements in array");
+                T el;
+                inner->parseJsonTyped(&el, context);
+                (*val)[i++] = std::move(el);
+            };
+
+        context.forEachElement(onElement);
+
+        if (i != N) {
+            context.exception("not enough elements in array; expecting "
+                              + std::to_string(N) + " but got "
+                              + std::to_string(i));
+        }
+    }
+
+    virtual void printJson(const void * val,
+                           JsonPrintingContext & context) const JML_OVERRIDE
+    {
+        const std::array<T, N> * val2 = reinterpret_cast<const std::array<T, N> *>(val);
+        return printJsonTyped(val2, context);
+    }
+
+    virtual void printJsonTyped(const std::array<T, N> * val,
+                                JsonPrintingContext & context) const JML_OVERRIDE
+    {
+        context.startArray(N);
+
+        for (size_t i = 0;  i < N;  ++i) {
+            context.newArrayElement();
+            inner->printJsonTyped(&(*val)[i], context);
+        }
+        
+        context.endArray();
+    }
+
+    virtual bool isDefault(const void * val) const JML_OVERRIDE
+    {
+        const std::array<T, N> * val2 = reinterpret_cast<const std::array<T, N> *>(val);
+        return isDefaultTyped(val2);
+    }
+
+    virtual bool isDefaultTyped(const std::array<T, N> * val) const JML_OVERRIDE
+    {
+        return val->empty();
+    }
+
+    virtual size_t getArrayLength(void * val) const JML_OVERRIDE
+    {
+        const std::array<T, N> * val2 = reinterpret_cast<const std::array<T, N> *>(val);
+        return val2->size();
+    }
+
+    virtual void *
+    getArrayElement(void * val, uint32_t element) const JML_OVERRIDE
+    {
+        std::array<T, N> * val2 = reinterpret_cast<std::array<T, N> *>(val);
+        return &val2->at(element);
+    }
+
+    virtual const void *
+    getArrayElement(const void * val, uint32_t element) const JML_OVERRIDE
+    {
+        const std::array<T, N> * val2 = reinterpret_cast<const std::array<T, N> *>(val);
+        return &val2->at(element);
+    }
+
+    virtual const ValueDescription & contained() const JML_OVERRIDE
+    {
+        return *this->inner;
+    }
+
+    virtual void initialize() JML_OVERRIDE
+    {
+        this->inner = getDefaultDescriptionSharedT<T>();
+    }
+};
+
+
+DECLARE_TEMPLATE_VALUE_DESCRIPTION_2(ArrayDescription, std::array, typename, T, size_t, N);
+
+} // namespace Datacratic

--- a/types/list_description_base.h
+++ b/types/list_description_base.h
@@ -1,8 +1,10 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+// 
 
 /** list_description_base.h                                        -*- C++ -*-
     Jeremy Barnes, 21 August 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Base class for a list (array, list, vector, ...).
 */
@@ -12,6 +14,13 @@
 #include "value_description.h"
 
 namespace Datacratic {
+
+template<typename T>
+void clearList(T & list)
+{
+    list.clear();
+}
+
 
 /*****************************************************************************/
 /* LIST DESCRIPTION                                                          */
@@ -40,7 +49,7 @@ struct ListDescriptionBase {
     template<typename List>
     void parseJsonTypedList(List * val, JsonParsingContext & context) const
     {
-        val->clear();
+        clearList(*val);
 
         if (!context.isArray())
             context.exception("expected array of " + inner->typeName);

--- a/types/testing/value_description_test.cc
+++ b/types/testing/value_description_test.cc
@@ -22,6 +22,7 @@
 #include "mldb/types/vector_description.h"
 #include "mldb/types/pointer_description.h"
 #include "mldb/types/tuple_description.h"
+#include "mldb/types/array_description.h"
 #include "mldb/types/date.h"
 #include "mldb/types/id.h"
 #include "mldb/base/parse_context.h"
@@ -646,4 +647,57 @@ BOOST_AUTO_TEST_CASE(test_null_parsing)
     BOOST_CHECK_EQUAL(jsonDecode<int>(Json::parse("-1")), -1);
 
     BOOST_CHECK_EQUAL(jsonDecode<unsigned int>(Json::parse("1")), 1);
+}
+
+// MLDB-1265
+BOOST_AUTO_TEST_CASE(test_array_description)
+{
+    ArrayDescription<int, 3> desc;
+    std::array<int, 3> testArray;
+
+    {
+        // 4 elements, but only 3 in tuple
+        string testJson("[ 1, 2, 3, 4 ]");
+        StreamingJsonParsingContext context(testJson,
+                                            testJson.c_str(),
+                                            testJson.c_str()
+                                        + testJson.size());
+        JML_TRACE_EXCEPTIONS(false);
+        BOOST_CHECK_THROW(desc.parseJson(&testArray, context), std::exception);
+    }
+
+    {
+        // 2 elements, but 3 required in tuple
+        string testJson("[ 1, 2 ]");
+        StreamingJsonParsingContext context(testJson,
+                                            testJson.c_str(),
+                                            testJson.c_str()
+                                        + testJson.size());
+        JML_TRACE_EXCEPTIONS(false);
+        BOOST_CHECK_THROW(desc.parseJson(&testArray, context), std::exception);
+    }
+
+    {
+        // 3 elements, wrong type
+        string testJson("[ \"one\", \"two\", 3 ]");
+        StreamingJsonParsingContext context(testJson,
+                                            testJson.c_str(),
+                                            testJson.c_str()
+                                            + testJson.size());
+        JML_TRACE_EXCEPTIONS(false);
+        BOOST_CHECK_THROW(desc.parseJson(&testArray, context), std::exception);
+    }
+
+    {
+        // 3 elements, correct
+        string testJson("[ 1, 2, 3 ]");
+        StreamingJsonParsingContext context(testJson,
+                                            testJson.c_str(),
+                                            testJson.c_str()
+                                            + testJson.size());
+        desc.parseJson(&testArray, context);
+        BOOST_CHECK_EQUAL(std::get<0>(testArray), 1);
+        BOOST_CHECK_EQUAL(std::get<1>(testArray), 2);
+        BOOST_CHECK_EQUAL(std::get<2>(testArray), 3);
+    }
 }


### PR DESCRIPTION
Trivial change to allow std::array to be used in ValueDescriptions.