### PR TITLE
Tweaks to submodule handling code

### DIFF
--- a/jml-build/get_git_revision.sh
+++ b/jml-build/get_git_revision.sh
@@ -86,10 +86,11 @@ if [ $NUMUNCLEAN -gt 0 ]; then
             SMFILESUSED=$FILESUSED
         else
             echo "doing submodule $sm" >> /dev/stderr
-            SMFILESUSED=`pwd`/$BUILD/tmp/files-used-$target-submodule-$1
+            SMFILESUSED=`pwd`/$BUILD/tmp/files-used-$target-submodule-$(echo $1 | tr '/' '-')
             pushd $sm > /dev/null
             echo -n "extracting build files used in dirty submodule $sm..." >> /dev/stderr
-            cat $FILESUSED | grep "^$sm/" | sed "s!^$sm/!!g" | sort > $SMFILESUSED
+            # Allow a leading directory to show up in the submodule path.
+            cat $FILESUSED | grep -E "^[a-zA-Z0-9]*/$sm/" | sed "s!^.*$sm/!!g" | sort > $SMFILESUSED
         fi
 
         cat $SMFILESUSED | wc -l > /dev/stderr

--- a/jml-build/get_git_revision.sh
+++ b/jml-build/get_git_revision.sh
@@ -86,11 +86,12 @@ if [ $NUMUNCLEAN -gt 0 ]; then
             SMFILESUSED=$FILESUSED
         else
             echo "doing submodule $sm" >> /dev/stderr
-            SMFILESUSED=`pwd`/$BUILD/tmp/files-used-$target-submodule-$(echo $1 | tr '/' '-')
+            SMCLEANEDNAME=$(echo $sm | tr '/' '-')
+            SMFILESUSED=`pwd`/$BUILD/tmp/files-used-$target-submodule-$SMCLEANEDNAME
             pushd $sm > /dev/null
             echo -n "extracting build files used in dirty submodule $sm..." >> /dev/stderr
             # Allow a leading directory to show up in the submodule path.
-            cat $FILESUSED | grep -E "^[a-zA-Z0-9]*/$sm/" | sed "s!^.*$sm/!!g" | sort > $SMFILESUSED
+            cat $FILESUSED | grep -E "^([^/]*/)?$sm/" | sed "s!^.*$sm/!!g" | sort > $SMFILESUSED
         fi
 
         cat $SMFILESUSED | wc -l > /dev/stderr


### PR DESCRIPTION
  - Allow submodule build path to have one level of leading directory
    this allows mldb/ext/submodule to be mapped correctly yo etx/submodule
  - Replace / with - in submodule name to avoid `SMFILESUSED` creation problems

