### PR TITLE
removed transitory members from AnnotedJoinCondition::Side

### DIFF
--- a/sql/join_utils.cc
+++ b/sql/join_utils.cc
@@ -273,7 +273,12 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
                                   "on", on);
     }
     
+    // WHERE condition on rows on the left side
+    std::vector<AnnotatedClause> leftWhereClauses;
 
+    // WHERE condition on rows on the right side
+    std::vector<AnnotatedClause> rightWhereClauses;
+        
     auto checkAndClauses = [&] (std::vector<std::shared_ptr<SqlExpression> >::iterator start) {
         // For each one, figure out which tables are referred to
         //for (auto & c: andClauses) {
@@ -299,10 +304,10 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
                 constantConditions.emplace_back(std::move(clauseOut));
                 break;
             case AnnotatedClause::LEFT:
-                left.whereClauses.emplace_back(std::move(clauseOut));
+                leftWhereClauses.emplace_back(std::move(clauseOut));
                 break;
             case AnnotatedClause::RIGHT:
-                right.whereClauses.emplace_back(std::move(clauseOut));
+                rightWhereClauses.emplace_back(std::move(clauseOut));
                 break;
             case AnnotatedClause::CROSS:
                 crossConditions.emplace_back(std::move(clauseOut));
@@ -329,9 +334,9 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
         cerr << jsonEncode(andClauses) << endl;
     }    
 
-    left.where = generateWhereExpression(left.whereClauses,
+    left.where = generateWhereExpression(leftWhereClauses,
                                          leftTable->getAs());
-    right.where = generateWhereExpression(right.whereClauses,
+    right.where = generateWhereExpression(rightWhereClauses,
                                           rightTable->getAs());
 
     // WHEN is not supported in JOIN
@@ -342,12 +347,18 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
 
     std::vector<AnnotatedClause> nonPivotWhere;
 
+    // Left side of equality part of the join expression, for EQUIJOIN
+    std::shared_ptr<SqlExpression> leftEqualExpression;
+
+    // Right side of equality part of the join expression, for EQUIJOIN
+    std::shared_ptr<SqlExpression> rightEqualExpression;
+
     if (crossConditions.size() == 0) {
         // OK, we have a cross join.  Lotsa fun.  Generate all rows from each,
         // with "true" as the join clause
         style = CROSS_JOIN;
-        left.equalExpression
-            = right.equalExpression
+        leftEqualExpression
+            = rightEqualExpression
             = SqlExpression::parse("true");
     }
     else {
@@ -388,8 +399,8 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
                 
                 style = EQUIJOIN;
                 c.pivot = AnnotatedClause::CHOSEN_PIVOT;
-                left.equalExpression = leftAnnotated.expr;
-                right.equalExpression = rightAnnotated.expr;
+                leftEqualExpression = leftAnnotated.expr;
+                rightEqualExpression = rightAnnotated.expr;
             }
             else {
                 nonPivotWhere.push_back(c);
@@ -398,21 +409,21 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
 
         if (style != EQUIJOIN) {
             style = CROSS_JOIN;
-            left.equalExpression
-                = right.equalExpression
+            leftEqualExpression
+                = rightEqualExpression
                 = SqlExpression::parse("true");
         }
     }
 
     crossWhere = generateWhereExpression(nonPivotWhere, "");
 
-    auto doSide = [&] (Side & side)
+    auto doSide = [&] (Side & side, std::shared_ptr<SqlExpression> equalExpression)
         {
             // Remove the "table." from "table.var" as we are running the
             // expression locally to the table, not in the context of the
             // join.
 
-            auto localExpr = removeTableNameFromExpression(*side.equalExpression, side.table->getAs());
+            auto localExpr = removeTableNameFromExpression(*equalExpression, side.table->getAs());
             side.selectExpression = localExpr;
 
             // Construct the select expression.  It's simply the value of
@@ -427,8 +438,8 @@ AnnotatedJoinCondition(std::shared_ptr<TableExpression> leftTable,
             side.orderBy.clauses.emplace_back(localExpr, ASC);
         };
 
-    doSide(left);
-    doSide(right);
+    doSide(left, leftEqualExpression);
+    doSide(right, rightEqualExpression);
 }
 
 void
@@ -460,10 +471,6 @@ AnnotatedJoinConditionSideDescription()
 {
     addField("table", &AnnotatedJoinCondition::Side::table,
              "Table underlying this side");
-    addField("whereClauses", &AnnotatedJoinCondition::Side::whereClauses,
-             "WHERE clauses for the  side");
-    addField("equalExpression", &AnnotatedJoinCondition::Side::equalExpression,
-             "Equality expression for the  side");
     addField("selectExpression", &AnnotatedJoinCondition::Side::selectExpression,
              "Select expression for the equi-join part of the side");
     addField("where", &AnnotatedJoinCondition::Side::where,

--- a/sql/join_utils.h
+++ b/sql/join_utils.h
@@ -143,22 +143,18 @@ struct AnnotatedJoinCondition {
         /// Original table of the join
         std::shared_ptr<TableExpression> table;
 
-        // WHERE condition on rows on the left side
-        std::vector<AnnotatedClause> whereClauses;
-        
-        /// Left side of equality part of the join expression, for EQUIJOIN
-        std::shared_ptr<SqlExpression> equalExpression;
-
-        /// Clause for the select expression
+        /** Clause for the select expression
+            This is used to evaluated each side of an EQUIJOIN.
+        */
         std::shared_ptr<SqlExpression> selectExpression;
 
         /// Expression to select from the table on this side
         SelectExpression select;
 
-        // left side WHEN condition as an SQL expression
+        // left/right side WHEN condition as an SQL expression
         WhenExpression when;
 
-        // left side WHERE condition as an SQL expression
+        // left/right side WHERE condition as an SQL expression
         std::shared_ptr<SqlExpression> where;
 
         /// Order by clause for the table on this side


### PR DESCRIPTION
Trivial simplification of the code to unnecessary AnnotedJoinCondition::Side members.