### PR TITLE
MLDB-1735 make ln/log behave like postgresql's

### DIFF
--- a/container_files/public_html/doc/builtin/sql/ValueExpression.md
+++ b/container_files/public_html/doc/builtin/sql/ValueExpression.md
@@ -406,20 +406,22 @@ and the possible values for the `arrays` field are:
 
 ### Numeric functions
 
-- `pow(x, y)`: returns x to the power of y.
-- `exp(x)`: returns **e** (the Euler number) raised to the power x.
-- `ln(x)`: returns the natural logarithm of x.
-- `ceil(x)`: returns the smaller integer not less than x.
-- `floor(x)`: returns the largest integer not greater than x.
-- `mod(x, y)`: returns x modulo y.  The value of x and y must be an integer. Another way to get the modulo is `x % y`.
-- `abs(x)`: returns the absolute value of x.
-- `sqrt(x)`: returns the square root of x.  The value of x must be greater or equal to 0.
-- `sign(x)`: returns the sign of x (-1, 0, +1).
-- `isnan(x)`: return true if x is 'NaN' in the floating point representation.
-- `isinf(x)`: return true if x is +/- infinity in the floating point representation.
-- `isfinite(x)`: return true if x is neither infinite nor not-a-number.
+- `pow(x, y)`: returns `x` to the power of `y`.
+- `exp(x)`: returns _e_ (the Euler number) raised to the power `x`.
+- `ln(x)`: returns the natural logarithm of `x`.
+- `log(x)`: returns the base-10 logarithm of `x`.
+- `log(b, x)`: returns the base-`b` logarithm of `x`.
+- `ceil(x)`: returns the smaller integer not less than `x`.
+- `floor(x)`: returns the largest integer not greater than `x`.
+- `mod(x, y)`: returns `x` modulo `y`.  The value of `x` and `y` must be an integer. Another way to get the modulo is `x % y`.
+- `abs(x)`: returns the absolute value of `x`.
+- `sqrt(x)`: returns the square root of `x`.
+- `sign(x)`: returns the sign of `x` (-1, 0, +1).
+- `isnan(x)`: returns true if `x` is `NaN` in the floating point representation.
+- `isinf(x)`: return true if `x` is +/- infinity in the floating point representation.
+- `isfinite(x)`: returns true if `x` is neither infinite nor `NaN`.
 
-- `quantize(x, y)`: returns x rounded to the precision of y.  Here are some examples:
+- `quantize(x, y)`: returns `x` rounded to the precision of `y`.  Here are some examples:
 
 expression|result
 ----------------------|-----
@@ -441,7 +443,7 @@ expression|result
 - `replace_inf(x, y)`: replace all `Inf`s and `-Inf`s in `x` by `y`.  Works on scalars or rows.
 - `replace_not_finite(x, y)`: replace all `Inf`s, `-Inf`s and `NaN`s in `x` by `y`.  Works on scalars or rows.
 - `replace_null(x, y)`: replace all `null`s in `x` by `y`.  Works on scalars or rows.
-- `clamp(x,lower,upper)` will clamp the value 'x' between the lower and upper bounds.
+- `clamp(x,lower,upper)` will clamp the value `x` between the `lower` and `upper` bounds.
 - `binomial_lb_80(trials, successes)` returns the 80% lower bound using the Wilson score.
 - `binomial_ub_80(trials, successes)` returns the 80% upper bound using the Wilson score.
 

--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -795,6 +795,10 @@ BoundFunction log(const std::vector<BoundSqlExpression> & args)
                     const SqlRowScope & scope) -> ExpressionValue
                 {
                     ExcAssertEqual(args.size(), 1);
+
+                    if (args[0].empty())
+                        return ExpressionValue();
+
                     return ExpressionValue(std::log10(args[0].toDouble()),
                                            args[0].getEffectiveTimestamp());
                 },
@@ -808,6 +812,10 @@ BoundFunction log(const std::vector<BoundSqlExpression> & args)
                     const SqlRowScope & scope) -> ExpressionValue
                 {
                     ExcAssertEqual(args.size(), 2);
+
+                    if (args[0].empty() || args[1].empty())
+                        return ExpressionValue();
+
                     double base = args[0].toDouble();
                     double x = args[1].toDouble();
                     return ExpressionValue(std::log(x) / std::log(base),

--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -777,9 +777,6 @@ registerMod(mod, std::make_shared<IntegerValueInfo>(), "mod");
 
 double ln(double v)
 {
-    if (v <= 0)
-        cerr << "negative value encountered in ln" << endl;
-
     return std::log(v);
 }
 
@@ -788,9 +785,6 @@ BoundFunction log(const std::vector<BoundSqlExpression> & args)
 {
     // log(x) (base 10)
     if (args.size() == 1) {
-        if (args[0] <= 0)
-            cerr << "non-positive value encountered in log" << endl;
-
         return {[] (const std::vector<ExpressionValue> & args,
                     const SqlRowScope & scope) -> ExpressionValue
                 {
@@ -805,9 +799,6 @@ BoundFunction log(const std::vector<BoundSqlExpression> & args)
                 std::make_shared<Float64ValueInfo>()};
     // log(base, x)
     } else if (args.size() == 2) {
-        if (args[0] <= 0 || args[1] <= 0)
-            cerr << "non-positive value encountered in log" << endl;
-
         return {[] (const std::vector<ExpressionValue> & args,
                     const SqlRowScope & scope) -> ExpressionValue
                 {
@@ -834,9 +825,6 @@ static RegisterBuiltin registerLog(log, "log");
 
 double sqrt(double v)
 {
-    if (v < 0)
-        cerr << "negative value encountered in sqrt" << endl;
-
     return std::sqrt(v);
 }
 
@@ -2430,8 +2418,8 @@ BoundFunction extract_column(const std::vector<BoundSqlExpression> & args)
                 auto val1 = args[0];
                 auto val2 = args[1];
                 Utf8String fieldName = val1.toUtf8String();
-                cerr << "extracting " << jsonEncodeStr(val1)
-                     << " from " << jsonEncodeStr(val2) << endl;
+                // cerr << "extracting " << jsonEncodeStr(val1)
+                //      << " from " << jsonEncodeStr(val2) << endl;
                 
                 return args[1].getColumn(fieldName);
             },

--- a/testing/MLDB-1336-builtin-checks.py
+++ b/testing/MLDB-1336-builtin-checks.py
@@ -11,9 +11,6 @@ class myTest(unittest.TestCase):
         with self.assertRaisesRegexp(mldb_wrapper.ResponseException, "Executing builtin function exp: Can't convert value 'a' of type 'ASCII_STRING' to double") as re:
             query = "SELECT exp('a')"
             mldb.query(query)
-        with self.assertRaisesRegexp(mldb_wrapper.ResponseException, "Executing builtin function ln: the argument of the ln function must be strictly positive") as re:
-            query = "SELECT ln(-1)"
-            mldb.query(query)
         with self.assertRaisesRegexp(mldb_wrapper.ResponseException, "Binding builtin function sqrt: expected 1 argument, got 3") as re:
             query = "SELECT sqrt(1,2,3)"
             mldb.query(query)

--- a/testing/MLDB-781-numeric-functions.js
+++ b/testing/MLDB-781-numeric-functions.js
@@ -18,6 +18,12 @@ function callAndAssert(func, expected, message)
     assertEqual(resp.json[0].columns[0][1], expected, func + "   " +  message);
 }
 
+function assertError(select, code, error) {
+    var resp = mldb.get('/v1/query', {q:"SELECT " + select});
+    assertEqual(resp.responseCode, code, "wrong code");
+    assertEqual(resp.json.error, error, "wrong error");
+}
+
 /* abs */
 callAndAssert("abs(1)", 1, "failed on positive number");
 callAndAssert("abs(0)", 0, "failed on zero");
@@ -63,17 +69,24 @@ callAndAssert("ln(-1)", {"num":"NaN"}, "failed on positive number");
 callAndAssert("ln(0)", {"num":"-Inf"}, "failed on positive number");
 callAndAssert("ln(1)", 0, "failed on positive number");
 callAndAssert("ln(2)", 0.6931471805599453094172 , "failed on 12.4343454"); 
+callAndAssert("ln(NULL)", null, "failed on null"); 
 
 callAndAssert("log(-1)", {"num":"NaN"}, "log(b,x) failed");
 callAndAssert("log(0)", {"num":"-Inf"}, "log(b,0) failed");
 callAndAssert("log(1)", 0, "log(1) failed");
 callAndAssert("log(1000)", 3, "log(1000) failed");
+callAndAssert("log(NULL)", null, "failed on null"); 
 
 callAndAssert("log(2, -1)", {"num":"NaN"}, "log(b,x) failed");
 callAndAssert("log(2, 0)", {"num":"-Inf"}, "log(b,0) failed");
 callAndAssert("log(2, 1)", 0, "log(b,1) failed");
 callAndAssert("log(2, 16)", 4, "log(b,16) failed");
 callAndAssert("log(2, sqrt(2))", 0.5000000000000001, "log(b,x) failed");
+callAndAssert("log(2, NULL)", null, "failed on null"); 
+callAndAssert("log(NULL, 2)", null, "failed on null"); 
+
+assertError("log(1,2,3)", 400, "Binding builtin function log: the log"
+                               + " function expected 1 or 2 arguments, got 3");
 
 /* exp */
 callAndAssert("exp(1)", 2.718281828459045, "failed on positive number");

--- a/testing/MLDB-781-numeric-functions.js
+++ b/testing/MLDB-781-numeric-functions.js
@@ -1,26 +1,5 @@
 // This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
-var test_data = mldb.createDataset({type:'sparse.mutable',id:'test'});
-
-var ts = new Date("2015-01-01");
-
-function recordExample(dataset, row, x)
-{
-    dataset.recordRow(row, [ [ "value", x, ts ] ]);
-}
-
-recordExample(test_data, "zero", 0);
-recordExample(test_data, "negative", -1);
-recordExample(test_data, "positive", 1);
-recordExample(test_data, "four", 4);
-recordExample(test_data, "float1", "12.4343454");
-recordExample(test_data, "float2", "-12.4343454");
-//recordExample(test_data, "float3", "9.99999999999999999999999999999");
-//recordExample(test_data, "float4", "0.00000000000000000000000000001");
-
-
-test_data.commit()
-
 function assertEqual(expr, val, msg)
 {
     if (expr == val)
@@ -32,88 +11,79 @@ function assertEqual(expr, val, msg)
         + " not equal to " + JSON.stringify(val);
 }
 
-function assertContains(str, val, msg)
+function callAndAssert(func, expected, message)
 {
-    if (str.indexOf(val) != -1)
-        return;
-
-    plugin.log("expected", val);
-    plugin.log("received", str);
-
-    throw "Assertion failure: " + msg + ": string '"
-        + str + "' does not contain '" + val + "'";
-}
-
-function callAndAssert(func, row, expected, message)
-{
-    var resp = mldb.get("/v1/query", {q: "SELECT " + func + " FROM test WHERE rowName()='"+row+"'"});
-    assertEqual(resp.responseCode, 200, "GET failed");
+    var resp = mldb.get('/v1/query', {q:"SELECT " + func});
+    assertEqual(resp.responseCode, 200, "GET /v1/query failed");
     assertEqual(resp.json[0].columns[0][1], expected, func + "   " +  message);
 }
 
 /* abs */
-callAndAssert("abs(1)", "positive", 1, "failed on positive number");
-callAndAssert("abs(0)", "zero", 0, "failed on zero");
-callAndAssert("abs(-1)", "negative", 1, "failed on negative number");
+callAndAssert("abs(1)", 1, "failed on positive number");
+callAndAssert("abs(0)", 0, "failed on zero");
+callAndAssert("abs(-1)", 1, "failed on negative number");
 
 /* power */
-callAndAssert("power(1,2)", "positive", 1, "failed on positive number");
-callAndAssert("power(0,2)", "zero", 0, "failed on zero");
-callAndAssert("power(4,2)", "four", 16, "failed on four");
-callAndAssert("power(-1,2)", "negative", 1, "failed on negative number");
+callAndAssert("power(1,2)", 1, "failed on positive number");
+callAndAssert("power(0,2)", 0, "failed on zero");
+callAndAssert("power(4,2)", 16, "failed on four");
+callAndAssert("power(-1,2)", 1, "failed on negative number");
 
 /* sqrt */
-callAndAssert("sqrt(1)", "positive", 1, "failed on positive number");
-callAndAssert("sqrt(0)", "zero", 0, "failed on zero");
-callAndAssert("sqrt(4)", "four", 2, "failed on four");
-
-/* square root of negative number should be failing */
-var resp = mldb.get("/v1/query", {q:"SELECT sqrt(value) from test where rowName()='negative'"});
-assertEqual(resp.responseCode, 400, "expecting 400 on invalid input");
+callAndAssert("sqrt(-1)", {"num": "-NaN"}, "failed on negative number");
+callAndAssert("sqrt(1)", 1, "failed on positive number");
+callAndAssert("sqrt(0)", 0, "failed on zero");
+callAndAssert("sqrt(4)", 2, "failed on four");
 
 /* sqrt undo power and vice versa */
-callAndAssert("sqrt(power(1, 2))", "positive", 1, "failed on positive number");
-callAndAssert("sqrt(power(0, 2))", "zero", 0, "failed on zero");
-callAndAssert("sqrt(power(4,2))", "four", 4, "failed on four");
+callAndAssert("sqrt(power(1, 2))", 1, "failed on positive number");
+callAndAssert("sqrt(power(0, 2))", 0, "failed on zero");
+callAndAssert("sqrt(power(4,2))", 4, "failed on four");
 
 /* modulus */
-callAndAssert("mod(1, 2)", "positive", 1, "failed on positive number");
-callAndAssert("mod(0, 2)", "zero", 0, "failed on zero");
-callAndAssert("mod(4,2)", "four", 0, "failed on four");
-callAndAssert("mod(-1,2)", "negative", -1, "mod failed on -1");
+callAndAssert("mod(1, 2)", 1, "failed on positive number");
+callAndAssert("mod(0, 2)", 0, "failed on zero");
+callAndAssert("mod(4,2)", 0, "failed on four");
+callAndAssert("mod(-1,2)", -1, "mod failed on -1");
 
 /* ceiling */
-callAndAssert("ceil(1)", "positive", 1, "failed on positive number");
-callAndAssert("ceil(0)", "zero", 0, "failed on zero");
-callAndAssert("ceil(12.4343454)", "float1", 13, "failed on 12.4343454");
-callAndAssert("ceil(-12.4343454)", "float2", -12, "failed on -12.4343454");
+callAndAssert("ceil(1)", 1, "failed on positive number");
+callAndAssert("ceil(0)", 0, "failed on zero");
+callAndAssert("ceil(12.4343454)", 13, "failed on 12.4343454");
+callAndAssert("ceil(-12.4343454)", -12, "failed on -12.4343454");
 
 /* floor */
-callAndAssert("floor(1)", "positive", 1, "failed on positive number");
-callAndAssert("floor(0)", "zero", 0, "failed on zero");
-callAndAssert("floor(12.4343454)", "float1", 12, "failed on 12.4343454");
-callAndAssert("floor(-12.4343454)", "float2", -13, "failed on -12.4343454");
+callAndAssert("floor(1)", 1, "failed on positive number");
+callAndAssert("floor(0)", 0, "failed on zero");
+callAndAssert("floor(12.4343454)", 12, "failed on 12.4343454");
+callAndAssert("floor(-12.4343454)", -13, "failed on -12.4343454");
 
-/* ln */
-callAndAssert("ln(1)", "positive", 0, "failed on positive number");
-callAndAssert("ln(12.4343454)", "float1", 2.5204624341327104, "failed on 12.4343454");
+/* logarithms */
+callAndAssert("ln(-1)", {"num":"NaN"}, "failed on positive number");
+callAndAssert("ln(0)", {"num":"-Inf"}, "failed on positive number");
+callAndAssert("ln(1)", 0, "failed on positive number");
+callAndAssert("ln(2)", 0.6931471805599453094172 , "failed on 12.4343454"); 
 
-/* natural logarithm on non-positive gives an error */
-var resp = mldb.get("/v1/query", {q:"SELECT ln(value) from test where rowName()='zero'"});
-assertContains(resp.json.error, "strictly positive");
-assertEqual(resp.responseCode, 400, "expecting 400 on invalid input");
+callAndAssert("log(-1)", {"num":"NaN"}, "log(b,x) failed");
+callAndAssert("log(0)", {"num":"-Inf"}, "log(b,0) failed");
+callAndAssert("log(1)", 0, "log(1) failed");
+callAndAssert("log(1000)", 3, "log(1000) failed");
+
+callAndAssert("log(2, -1)", {"num":"NaN"}, "log(b,x) failed");
+callAndAssert("log(2, 0)", {"num":"-Inf"}, "log(b,0) failed");
+callAndAssert("log(2, 1)", 0, "log(b,1) failed");
+callAndAssert("log(2, 16)", 4, "log(b,16) failed");
+callAndAssert("log(2, sqrt(2))", 0.5000000000000001, "log(b,x) failed");
 
 /* exp */
-callAndAssert("exp(1)", "positive", 2.718281828459045, "failed on positive number");
-callAndAssert("exp(0)", "zero", 1, "failed on zero");
-callAndAssert("exp(12.4343454)", "float1", 251285.59500936428, "failed on 12.4343454");
-callAndAssert("exp(-12.4343454)", "float2", 0.000003979535714980935, "failed on -12.4343454");
+callAndAssert("exp(1)", 2.718281828459045, "failed on positive number");
+callAndAssert("exp(0)", 1, "failed on zero");
+callAndAssert("exp(12.4343454)", 251285.59500936428, "failed on 12.4343454");
+callAndAssert("exp(-12.4343454)", 0.000003979535714980935, "failed on -12.4343454");
 
 function bark(func)
 {
-    var resp = mldb.get("/v1/query", {q: "SELECT " + func + " FROM test"});
-    assertEqual(resp.responseCode, 200, "GET failed");
-    assertEqual(resp.json[0].columns[0][1], true, func + " failed");
+    callAndAssert(func, true, "quantize failed");
 }
 /* quantize */
 bark("quantize(2.17, 0.001) = 2.17");


### PR DESCRIPTION
- add support for log(x) and log(b,x) that match postgresql's functions
- make log/ln and sqrt not fail on 0/negative values and return nan/-inf instead
- fix a few typos in the doc
- simplify the numeric-functions test file