### PR TITLE
No longer require 128 bit atomics for gc_lock (MLDB-1909)

### DIFF
--- a/arch/arch.mk
+++ b/arch/arch.mk
@@ -2,7 +2,7 @@
 
 LIBARCH_SOURCES := \
         simd_vector.cc \
-	simd_vector_avx.cc \
+        simd_vector_avx.cc \
         demangle.cc \
 	tick_counter.cc \
 	cpuid.cc \
@@ -22,7 +22,6 @@ LIBARCH_SOURCES := \
 	abort.cc \
 	spinlock.cc \
 
-
 LIBARCH_LINK := dl
 
 ifneq ($(BOOST_VERSION),42)
@@ -32,10 +31,8 @@ endif
 $(eval $(call library,arch,$(LIBARCH_SOURCES),$(LIBARCH_LINK)))
 
 LIBGC_SOURCES := \
-	gc_lock.cc 
-
-LIBGC_SOURCES := \
-	gc_lock.cc 
+	gc_lock.cc \
+	shared_gc_lock.cc
 
 $(eval $(call library,gc,$(LIBGC_SOURCES),rt arch))
 

--- a/arch/gc_lock.cc
+++ b/arch/gc_lock.cc
@@ -5,42 +5,28 @@
    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 */
 
-#include "mldb/arch/gc_lock.h"
+// Turn off inline for the gc_lock methods, so that they will be instantiated
+// into the object files.
+#define GC_LOCK_INLINE_OFF 1
+
+#include "gc_lock.h"
+#include "gc_lock_impl.h"
+#include "mldb/arch/arch.h"
 #include "mldb/arch/tick_counter.h"
 #include "mldb/arch/spinlock.h"
 #include "mldb/arch/futex.h"
 #include "mldb/base/exc_check.h"
 #include "mldb/jml/utils/guard.h"
 #include <iterator>
-#include <boost/interprocess/sync/named_mutex.hpp>
-#include <boost/interprocess/sync/scoped_lock.hpp>
-#include <sys/mman.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include <iostream>
+#include <map>
+#include <cstring>
+
 
 using namespace std;
 using namespace ML;
-namespace ipc = boost::interprocess;
 
 namespace Datacratic {
-
-template<class X>
-JML_ALWAYS_INLINE bool cmp_xchg_16b(X & val, X & old, const X & new_val)
-{
-    /* Split new_val into low and high parts. */
-    uint64_t * pold = reinterpret_cast<uint64_t *>(&old);
-    const uint64_t * pnew = reinterpret_cast<const uint64_t *>(&new_val);
-
-    uint8_t result;
-    asm volatile ("lock cmpxchg16b  %[val]\n\t"
-                  "     setz       %[result]\n\t"
-                  : "+a" (pold[0]), "+d" (pold[1]), [result] "=c" (result)
-                  : [val] "m" (val), "b" (pnew[0]), "c" (pnew[1])
-                  : "cc");
-    return result;
-}
-
 
 /*****************************************************************************/
 /* Utility                                                                   */
@@ -54,12 +40,13 @@ int32_t gcLockStartingEpoch = 0;
 int32_t SpeculativeThreshold = 5;
 
 /** A safe comparaison of epochs that deals with potential overflows.
+    returns 0 if equal, -1 if a is earlier than b, or 1 if a is greater than b
     \todo So many possible bit twiddling hacks... Must resist...
 */
-template<typename T, size_t Bits = sizeof(T)*8>
+template<typename T, typename T2, size_t Bits = sizeof(T)*8>
 static inline
 int
-compareEpochs (T a, T b)
+compareEpochs (T a, T2 b)
 {
     static_assert(Bits >= 2, "Bits is too low to guarantee isolation");
 
@@ -259,89 +246,197 @@ print() const
                       inEpoch, readLocked, writeLocked);
 }
 
-inline GcLockBase::Data::
-Data() :
-    bits(0), bits2(0)
+
+/*****************************************************************************/
+/* THREAD GC INFO ENTRY                                                      */
+/*****************************************************************************/
+
+GcLockBase::ThreadGcInfoEntry::
+ThreadGcInfoEntry()
+    : inEpoch(-1), readLocked(0), writeLocked(0),
+      specLocked(0), specUnlocked(0),
+      owner(0)
 {
+}
+
+GcLockBase::ThreadGcInfoEntry::
+~ThreadGcInfoEntry()
+{
+    /* We are not in a speculative critical section, check if
+     * Gc has been left locked
+     */
+    if (!specLocked && !specUnlocked && (readLocked || writeLocked)) {
+        ::fprintf(stderr, "Thread diad but GcLock is still locked");
+        std::terminate();
+    }
+
+    /* We are in a speculative CS but Gc has not beed unlocked
+     */
+    else if (!specLocked && specUnlocked) {
+        unlockShared(RD_YES);
+        specUnlocked = 0;
+    }
+           
+} 
+
+
+/*****************************************************************************/
+/* ATOMIC                                                                    */
+/*****************************************************************************/
+
+struct GcLockBase::Atomic {
+    Atomic();
+
+    Atomic(const Atomic & other);
+
+    Atomic & operator = (const Atomic & other);
+
+    bool operator == (const Atomic & other) const
+    {
+        return bits == other.bits;
+    }
+
+    bool operator != (const Atomic & other) const
+    {
+        return ! operator == (other);
+    }
+
+    bool compareExchange(Atomic & oldValue, const Atomic & newValue)
+    {
+        return atomicBits.compare_exchange_strong
+            (oldValue.bits, newValue.bits,
+             std::memory_order_seq_cst);
+    }
+
+    /** Human readable string. */
+    std::string print() const;
+
+    static constexpr uint16_t EXCLUSIVE_MASK = 0x8000;
+    static constexpr uint16_t IN_MASK        = 0x7fff;
+
+    bool anyInCurrent() const { return in[epoch & 1] & IN_MASK; }
+    bool anyInOld() const { return in[(epoch - 1)&1] & IN_MASK; }
+
+    bool exclusive() const { return in[0] & EXCLUSIVE_MASK; }
+
+    void setExclusive()
+    {
+        in[0] |= EXCLUSIVE_MASK;
+    }
+
+    void resetExclusive()
+    {
+        in[0] &= IN_MASK;
+    }
+
+    void resetExclusiveAtomic()
+    {
+        uint16_t oldExclusive = in[0]
+            .fetch_and(IN_MASK, std::memory_order_seq_cst);
+        ExcAssert(oldExclusive & EXCLUSIVE_MASK);
+    }
+
+    // Atomically decrement the in counter for the given epoch, and
+    // return the in value before the counter was decremented.  If this
+    // returns 1, it means that we are the last one to leave this epoch.
+    uint16_t decrementInAtomic(uint32_t epoch)
+    {
+        return in[epoch & 1]
+            .fetch_add(-1, std::memory_order_seq_cst) & IN_MASK;
+    }
+
+    void setIn(int32_t epoch, int val)
+    {
+        in[epoch & 1] = (in[epoch & 1] & EXCLUSIVE_MASK) | (val & IN_MASK);
+    }
+
+    void addIn(int32_t epoch, int val)
+    {
+        in[epoch & 1] += val;
+    }
+
+    /** Check that the invariants all hold.  Throws an exception if not. */
+    void validate() const;
+
+    typedef uint32_t epoch_t;
+
+    epoch_t visibleEpoch() const
+    {
+        // Set the visible epoch
+        if (!anyInCurrent() && !anyInOld())
+            return epoch;
+        else if (!anyInOld())
+            return epoch - 1;
+        else return epoch - 2;
+    }
+
+    volatile union {
+        struct {
+            epoch_t epoch;         ///< Current epoch number (could be smaller).
+            std::atomic<uint16_t> in[2];         ///< How many threads in each epoch?  High bit of number 0 means exclusive
+        };
+        uint64_t bits;
+        std::atomic<uint64_t> atomicBits;
+    };
+};
+
+struct GcLockBase::Data {
+    Data()
+        : exclusiveFutex(0)
+    {
+        visibleFutex.store(atomic.visibleEpoch());
+    }
+
+    Atomic atomic;
+   
+    std::atomic<int32_t> visibleFutex;
+    std::atomic<int32_t> exclusiveFutex;
+
+    /** Human readable string. */
+    std::string print() const;
+};
+
+inline GcLockBase::Atomic::
+Atomic()
+{
+    std::memset((void *)this, 0, sizeof(*this));
     epoch = gcLockStartingEpoch; // makes it easier to test overflows.
-    visibleEpoch = epoch;
 }
 
-inline GcLockBase::Data::
-Data(const Data & other)
+inline GcLockBase::Atomic::
+Atomic(const Atomic & other)
 {
-    //ML::ticks();
-    q = other.q;
-    //ML::ticks();
+    bits = other.bits;
 }
 
-inline GcLockBase::Data &
-GcLockBase::Data::
-operator = (const Data & other)
+inline GcLockBase::Atomic &
+GcLockBase::Atomic::
+operator = (const Atomic & other)
 {
-    //ML::ticks();
-    this->q = other.q;
-    //ML::ticks();
+    bits = other.bits;
     return *this;
 }
 
 void
-GcLockBase::Data::
+GcLockBase::Atomic::
 validate() const
 {
-    try {
-        // Visible is at most 2 behind current
-        ExcAssertGreaterEqual(compareEpochs(visibleEpoch, epoch - 2), 0);
-
-        // If nothing is in a critical section then only the current is
-        // visible
-        if (inOld() == 0 && inCurrent() == 0)
-            ExcAssertEqual(visibleEpoch, epoch);
-
-        // If nothing is in the old critical section then it's not visible
-        else if (inOld() == 0)
-            ExcAssertEqual(visibleEpoch, epoch - 1);
-
-        else ExcAssertEqual(visibleEpoch, epoch - 2);
-    } catch (const std::exception & exc) {
-        cerr << "exception validating GcLock: " << exc.what() << endl;
-        cerr << "current: " << print() << endl;
-        throw;
-    }
 }
 
-inline bool
-GcLockBase::Data::
-calcVisibleEpoch()
+std::string
+GcLockBase::Atomic::
+print() const
 {
-    Data old = *this;
-
-    int oldValue = visibleEpoch;
-
-    // Set the visible epoch
-    if (inCurrent() == 0 && inOld() == 0)
-        visibleEpoch = epoch;
-    else if (inOld() == 0)
-        visibleEpoch = epoch - 1;
-    else visibleEpoch = epoch - 2;
-
-    if (compareEpochs(visibleEpoch, oldValue) < 0) {
-        cerr << "old = " << old.print() << endl;
-        cerr << "new = " << print() << endl;
-    }
-
-    // Visible epoch must be monotonic increasing
-    ExcAssertGreaterEqual(compareEpochs(visibleEpoch, oldValue), 0);
-
-    return oldValue != visibleEpoch;
+    return ML::format("epoch: %d, in: %d, in-1: %d, visible: %d, exclusive: %d",
+                      epoch, anyInCurrent(), anyInOld(), visibleEpoch(),
+                      (int)exclusive());
 }
-        
+
 std::string
 GcLockBase::Data::
 print() const
 {
-    return ML::format("epoch: %d, in: %d, in-1: %d, visible: %d, exclusive: %d",
-                      epoch, inCurrent(), inOld(), visibleEpoch, exclusive);
+    return atomic.print();
 }
 
 GcLockBase::
@@ -362,12 +457,12 @@ GcLockBase::
 
 bool
 GcLockBase::
-updateData(Data & oldValue, Data & newValue, RunDefer runDefer)
+updateAtomic(Atomic & oldValue, Atomic & newValue, RunDefer runDefer)
 {
     bool wake;
     try {
         ExcAssertGreaterEqual(compareEpochs(newValue.epoch, oldValue.epoch), 0);
-        wake = newValue.calcVisibleEpoch();
+        wake = newValue.visibleEpoch() != oldValue.visibleEpoch();
     } catch (...) {
         cerr << "update: oldValue = " << oldValue.print() << endl;
         cerr << "newValue = " << newValue.print() << endl;
@@ -378,20 +473,28 @@ updateData(Data & oldValue, Data & newValue, RunDefer runDefer)
 
 #if 0
     // Do an extra check before we assert lock
-    Data upToDate = *data;
+    Atomic upToDate = data->atomic;
     if (upToDate != oldValue) {
         oldValue = upToDate;
         return false;
     }
 #endif
 
-    if (!cmp_xchg_16b(data->q, oldValue.q, newValue.q)) return false;
+    if (!data->atomic.compareExchange(oldValue, newValue))
+        return false;
 
     if (wake) {
         // We updated the current visible epoch.  We can now wake up
         // anything that was waiting for it to be visible and run any
         // deferred handlers.
-        futex_wake(data->visibleEpoch);
+        
+        // TODO TODO TODO
+        // There can be races here.  We need to make sure that we
+        // publish the highest visible epoch, which can change
+        // uncontrollably.
+        ++data->visibleFutex;
+        //data->visibleFutex = newValue.visibleEpoch();
+        futex_wake(data->visibleFutex);
         if (runDefer) {
             runDefers();
         }
@@ -425,7 +528,7 @@ checkDefers()
     while (!deferred->entries.empty() &&
             compareEpochs(
                     deferred->entries.begin()->first,
-                    data->visibleEpoch) <= 0)
+                    data->atomic.visibleEpoch()) <= 0)
     {
         result.reserve(deferred->entries.size());
 
@@ -433,7 +536,7 @@ checkDefers()
                  end = deferred->entries.end();
              it != end;  /* no inc */) {
 
-            if (compareEpochs(it->first, data->visibleEpoch) > 0)
+            if (compareEpochs(it->first, data->atomic.visibleEpoch()) > 0)
                 break;  // still visible
 
             ExcAssert(it->second);
@@ -456,31 +559,20 @@ enterCS(ThreadGcInfoEntry * entry, RunDefer runDefer)
         
     ExcAssertEqual(entry->inEpoch, -1);
 
-#if 0 // later...
-    // Be optimistic...
-    int optimisticEpoch = data->epoch;
-    if (__sync_add_and_fetch(data->in + (optimisticEpoch & 1), 1) > 1
-        && data->epoch == optimisticEpoch) {
-        entry->inEpoch = optimisticEpoch & 1;
-        return;
-    }
-
-    // undo optimism
-    __sync_add_and_fetch(data->in + (optimisticEpoch & 1), -1);
-#endif // optimistic
-
-    Data current = *data;
+    Atomic current = data->atomic;
 
     for (;;) {
-        Data newValue = current;
+        Atomic newValue = current;
 
-        if (newValue.exclusive) {
-            futex_wait(data->exclusive, 1);
-            current = *data;
+        if (newValue.exclusive()) {
+            // We don't check the error, as a spurious wakeup will just
+            // make the loop continue.
+            futex_wait(data->exclusiveFutex, 1);
+            current = data->atomic;
             continue;
         }
 
-        if (newValue.inOld() == 0) {
+        if (newValue.anyInOld() == 0) {
             // We're entering a new epoch
             newValue.epoch += 1;
             newValue.setIn(newValue.epoch, 1);
@@ -492,7 +584,7 @@ enterCS(ThreadGcInfoEntry * entry, RunDefer runDefer)
 
         entry->inEpoch = newValue.epoch & 1;
             
-        if (updateData(current, newValue, runDefer)) break;
+        if (updateAtomic(current, newValue, runDefer)) break;
     }
 }
 
@@ -505,23 +597,23 @@ exitCS(ThreadGcInfoEntry * entry, RunDefer runDefer /* = true */)
 
     ExcCheck(entry->inEpoch == 0 || entry->inEpoch == 1,
             "Invalid inEpoch");
+
+#if 0
     // Fast path
-    if (__sync_fetch_and_add(data->in + entry->inEpoch, -1) > 1) {
+    if (data->atomic.decrementInAtomic(entry->inEpoch) > 1) {
         entry->inEpoch = -1;
         return;
     }
+#endif
 
-        
+    Atomic current = data->atomic;
+
     // Slow path; an epoch may have come to an end
-    
-    Data current = *data;
 
     for (;;) {
-        Data newValue = current;
-
-        //newValue.addIn(entry->inEpoch, -1);
-
-        if (updateData(current, newValue, runDefer)) break;
+        Atomic newValue = current;
+        newValue.decrementInAtomic(entry->inEpoch);
+        if (updateAtomic(current, newValue, runDefer)) break;
     }
 
     entry->inEpoch = -1;
@@ -533,66 +625,46 @@ enterCSExclusive(ThreadGcInfoEntry * entry)
 {
     ExcAssertEqual(entry->inEpoch, -1);
 
-    Data current = *data, newValue;
+    Atomic current = data->atomic, newValue;
 
     for (;;) {
-        if (current.exclusive) {
-            futex_wait(data->exclusive, 1);
-            current = *data;
+        if (current.exclusive()) {
+            futex_wait(data->exclusiveFutex, 1);
+            current = data->atomic;
             continue;
         }
 
-        ExcAssertEqual(current.exclusive, 0);
-
-        // TODO: single cmp/xchg on just exclusive rather than the whole lot?
-        //int old = 0;
-        //if (!ML::cmp_xchg(data->exclusive, old, 1))
-        //    continue;
+        ExcAssertEqual(current.exclusive(), 0);
 
         newValue = current;
-        newValue.exclusive = 1;
-        if (updateData(current, newValue, RD_YES)) {
+        newValue.setExclusive();
+        if (updateAtomic(current, newValue, RD_YES)) {
             current = newValue;
             break;
         }
     }
 
-    ExcAssertEqual(data->exclusive, 1);
+    ExcAssertEqual(data->atomic.exclusive(), 1);
+    data->exclusiveFutex.store(1, std::memory_order_release);
 
     // At this point, we have exclusive access... now wait for everything else
     // to exit.  This is kind of a critical section barrier.
     int startEpoch = current.epoch;
     
-#if 1
     visibleBarrier();
-#else
-
-    for (unsigned i = 0;  ;  ++i, current = *data) {
-
-        if (current.visibleEpoch == current.epoch
-            && current.inCurrent() == 0 && current.inOld() == 0)
-            break;
-        
-        long res = futex_wait(data->visibleEpoch, current.visibleEpoch);
-        if (res == -1) {
-            if (errno == EAGAIN) continue;
-            throw ML::Exception(errno, "futex_wait");
-        }
-    }
-#endif
     
-    ExcAssertEqual(data->epoch, startEpoch);
+    ExcAssertEqual(data->atomic.epoch, startEpoch);
 
 
 #if 0
     // Testing
     for (unsigned i = 0;  i < 100;  ++i) {
-        Data current = *data;
+        Atomic current = data->atomic;
 
         try {
-            ExcAssertEqual(current.exclusive, 1);
-            ExcAssertEqual(current.inCurrent(), 0);
-            ExcAssertEqual(current.inOld(), 0);
+            ExcAssertEqual(current.exclusive(), 1);
+            ExcAssertEqual(current.anyInCurrent(), 0);
+            ExcAssertEqual(current.anyInOld(), 0);
         } catch (...) {
             ThreadGcInfoEntry & entry = getEntry();
             cerr << "entry->inEpoch = " << entry->inEpoch << endl;
@@ -605,7 +677,7 @@ enterCSExclusive(ThreadGcInfoEntry * entry)
     }
 #endif
 
-    ExcAssertEqual(data->epoch, startEpoch);
+    ExcAssertEqual(data->atomic.epoch, startEpoch);
 
     entry->inEpoch = startEpoch & 1;
 }
@@ -616,12 +688,12 @@ exitCSExclusive(ThreadGcInfoEntry * entry)
 {
     if (!entry) entry = &getEntry();
 #if 0
-    Data current = *data;
+    Atomic current = data->atomic;
 
     try {
-        ExcAssertEqual(current.exclusive, 1);
-        ExcAssertEqual(current.inCurrent(), 0);
-        ExcAssertEqual(current.inOld(), 0);
+        ExcAssertEqual(current.exclusive(), 1);
+        ExcAssertEqual(current.anyInCurrent(), 0);
+        ExcAssertEqual(current.anyInOld(), 0);
     } catch (...) {
         cerr << "entry->inEpoch = " << entry->inEpoch << endl;
         cerr << "entry->readLocked = " << entry->readLocked << endl;
@@ -631,13 +703,11 @@ exitCSExclusive(ThreadGcInfoEntry * entry)
         throw;
     }
 #endif
-
-    if (!__sync_bool_compare_and_swap(&data->exclusive, 1, 0)) {
-        throw ML::Exception("error exiting exclusive mode");
-    }    
+    data->atomic.resetExclusiveAtomic();
     
     // Wake everything waiting on the exclusive lock
-    futex_wake(data->exclusive);
+    data->exclusiveFutex.store(0, std::memory_order_release);
+    futex_wake(data->exclusiveFutex);
     
     entry->inEpoch = -1;
 }
@@ -654,12 +724,11 @@ visibleBarrier()
         throw ML::Exception("visibleBarrier called in critical section will "
                             "deadlock");
 
-    Data current = *data;
-    int startEpoch = data->epoch;
-    //int startVisible = data.visibleEpoch;
+    Atomic current = data->atomic;
+    int startEpoch = data->atomic.epoch;
     
     // Spin until we're visible
-    for (unsigned i = 0;  ;  ++i, current = *data) {
+    for (unsigned i = 0;  ;  ++i, current = data->atomic) {
         
         //int i = startEpoch & 1;
 
@@ -670,16 +739,18 @@ visibleBarrier()
         }
 
         // If there's nothing in a critical section then we're OK
-        if (current.inCurrent() == 0 && current.inOld() == 0)
+        if (current.anyInCurrent() == 0 && current.anyInOld() == 0)
             return;
 
-        if (current.visibleEpoch == startEpoch)
+        if (current.visibleEpoch() == startEpoch)
             return;
 
         if (i % 128 == 127 || true) {
-            long res = futex_wait(data->visibleEpoch, current.visibleEpoch);
+            // Note that we don't care about the actual value of the visible
+            // epoch, only that it's different from the current one
+            long res = futex_wait(data->visibleFutex, current.visibleEpoch());
             if (res == -1) {
-                if (errno == EAGAIN) continue;
+                if (errno == EAGAIN || errno == EINTR) continue;
                 throw ML::Exception(errno, "futex_wait");
             }
         }
@@ -771,14 +842,14 @@ doDefer(void (fn) (Args...), Args... args)
     // If there are threads in the current epoch (irrespective of the old
     // epoch) then we need to wait until the current epoch is done.
 
-    Data current = *data;
+    Atomic current = data->atomic;
 
     int32_t newestVisibleEpoch = current.epoch;
-    if (current.inCurrent() == 0) --newestVisibleEpoch;
+    if (current.anyInCurrent() == 0) --newestVisibleEpoch;
 
 #if 1
     // Nothing is in a critical section; we can run it inline
-    if (current.inCurrent() + current.inOld() == 0) {
+    if (current.anyInCurrent() + current.anyInOld() == 0) {
         fn(std::forward<Args>(args)...);
         return;
     }
@@ -790,13 +861,13 @@ doDefer(void (fn) (Args...), Args... args)
 
 #if 1
         // Get back to current again
-        current = *data;
+        current = data->atomic;
 
         // Find the oldest live epoch
         int oldestLiveEpoch = -1;
-        if (current.inOld() > 0)
+        if (current.anyInOld() > 0)
             oldestLiveEpoch = current.epoch - 1;
-        else if (current.inCurrent() > 0)
+        else if (current.anyInCurrent() > 0)
             oldestLiveEpoch = current.epoch;
     
         if (oldestLiveEpoch == -1 || 
@@ -807,7 +878,7 @@ doDefer(void (fn) (Args...), Args... args)
         }
     
         // Nothing is in a critical section; we can run it inline
-        if (current.inCurrent() + current.inOld() == 0)
+        if (current.anyInCurrent() + current.anyInOld() == 0)
             break;
 #endif
 
@@ -860,10 +931,10 @@ void
 GcLockBase::
 dump()
 {
-    Data current = *data;
-    cerr << "epoch " << current.epoch << " in " << current.inCurrent()
-         << " in-1 " << current.inOld() << " vis " << current.visibleEpoch
-         << " excl " << current.exclusive << endl;
+    Atomic current = data->atomic;
+    cerr << "epoch " << current.epoch << " in " << current.anyInCurrent()
+         << " in-1 " << current.anyInOld() << " vis " << current.visibleEpoch()
+         << " excl " << current.exclusive() << endl;
     cerr << "deferred: ";
     {
         std::lock_guard<ML::Spinlock> guard(deferred->lock);
@@ -878,6 +949,33 @@ dump()
     cerr << endl;
 }
 
+int
+GcLockBase::
+currentEpoch() const
+{
+    return data->atomic.epoch;
+}
+
+bool
+GcLockBase::
+isLockedByAnyThread() const
+{
+    return data->atomic.in[0] || data->atomic.in[1] ;
+}
+
+size_t 
+GcLockBase::
+dataBytesRequired()
+{
+    return sizeof(Data);
+}
+
+GcLockBase::Data *
+GcLockBase::
+uninitializedConstructData(void * memory)
+{
+    return new (memory) Data();
+}
 
 /*****************************************************************************/
 /* GC LOCK                                                                   */
@@ -885,8 +983,9 @@ dump()
 
 GcLock::
 GcLock()
+    : localData(new Data())
 {
-    data = &localData;
+    data = localData.get();
 }
 
 GcLock::
@@ -903,81 +1002,6 @@ unlink()
 }
 
 
-/*****************************************************************************/
-/* SHARED GC LOCK                                                            */
-/*****************************************************************************/
-
-// We want to mmap the file so it has to be the size of a page.
-
-namespace { size_t GcLockFileSize = 1ULL << 12; }
-
-
-GcCreate GC_CREATE; ///< Open and initialize a new gcource.
-GcOpen GC_OPEN;     ///< Open an existing gcource.
-
-void
-SharedGcLock::
-doOpen(bool create)
-{
-    int flags = O_RDWR | O_CREAT;
-    if (create) flags |= O_EXCL;
-
-    ipc::named_mutex mutex(ipc::open_or_create, name.c_str());
-    {
-        // Lock is used to create and truncate the file atomically.
-        ipc::scoped_lock<ipc::named_mutex> lock(mutex);
-
-        // We don't want the locks to be persisted so an shm_open will do fine.
-        fd = shm_open(name.c_str(), flags, 0644);
-        ExcCheckErrno(fd >= 0, "shm_open failed");
-
-        struct stat stats;
-        int res = fstat(fd, &stats);
-        ExcCheckErrno(!res, "failed to get the file size");
-
-        if (stats.st_size != GcLockFileSize) {
-            int res = ftruncate(fd, GcLockFileSize);
-            ExcCheckErrno(!res, "failed to resize the file.");
-        }
-    }
-
-    // Map the region so that all the processes can see the writes.
-    addr = mmap(0, GcLockFileSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    ExcCheckErrno(addr != MAP_FAILED, "failed to map the shm file");
-
-    // Initialize and set the member used by GcLockBase.
-    if (create) new (addr) Data();
-    data = reinterpret_cast<Data*>(addr);
-}
-
-SharedGcLock::
-SharedGcLock(GcCreate, const string& name) :
-    name("gc." + name)
-{
-    doOpen(true);
-}
-
-SharedGcLock::
-SharedGcLock(GcOpen, const string& name) :
-    name("gc." + name)
-{
-    doOpen(false);
-}
-
-SharedGcLock::
-~SharedGcLock()
-{
-    munmap(addr, GcLockFileSize);
-    close(fd);
-}
-
-void
-SharedGcLock::
-unlink()
-{
-    shm_unlink(name.c_str());
-    (void) ipc::named_mutex::remove(name.c_str());
-}
-
 
 } // namespace Datacratic
+

--- a/arch/gc_lock.h
+++ b/arch/gc_lock.h
@@ -9,16 +9,10 @@
 
 #pragma once
 
-#define GC_LOCK_DEBUG 0
-
 #include "mldb/base/exc_assert.h"
 #include "mldb/arch/thread_specific.h"
 #include <vector>
-#include <iostream>
-
-#if GC_LOCK_DEBUG
-#  include <iostream>
-#endif
+#include <memory>
 
 /** Deterministic memory reclamation is a fundamental problem in lock-free
     algorithms and data structures.
@@ -72,31 +66,8 @@ public:
 
     /// A thread's bookkeeping info about each GC area
     struct ThreadGcInfoEntry {
-        ThreadGcInfoEntry()
-            : inEpoch(-1), readLocked(0), writeLocked(0),
-              specLocked(0), specUnlocked(0),
-              owner(0)
-        {
-        }
-
-        ~ThreadGcInfoEntry() {
-            /* We are not in a speculative critical section, check if
-             * Gc has been left locked
-             */
-            if (!specLocked && !specUnlocked && (readLocked || writeLocked)) {
-                ::fprintf(stderr, "Thread diad but GcLock is still locked");
-                std::terminate();
-            }
-
-            /* We are in a speculative CS but Gc has not beed unlocked
-             */
-            else if (!specLocked && specUnlocked) {
-                unlockShared(RD_YES);
-                specUnlocked = 0;
-            }
-           
-        } 
-
+        ThreadGcInfoEntry();
+        ~ThreadGcInfoEntry();
 
         int inEpoch;  // 0, 1, -1 = not in 
         int readLocked;
@@ -107,78 +78,15 @@ public:
 
         GcLockBase *owner;
 
-        void init(const GcLockBase * const self) {
-            if (!owner) 
-                owner = const_cast<GcLockBase *>(self);
-        }
-                
-
-        void lockShared(RunDefer runDefer) {
-            if (!readLocked && !writeLocked)
-                owner->enterCS(this, runDefer);
-
-            ++readLocked;
-        }
-
-        void unlockShared(RunDefer runDefer) {
-            if (readLocked <= 0)
-                throw ML::Exception("Bad read lock nesting");
-
-            --readLocked;
-            if (!readLocked && !writeLocked) 
-                owner->exitCS(this, runDefer);
-        }
-
-        bool isLockedShared() {
-            return readLocked + writeLocked;
-        }
-
-        void lockExclusive() {
-            if (!writeLocked)
-                owner->enterCSExclusive(this);
-            
-             ++writeLocked;
-        }
-
-        void unlockExclusive() {
-            if (writeLocked <= 0)
-                throw ML::Exception("Bad write lock nesting");
-
-            --writeLocked;
-            if (!writeLocked)
-                owner->exitCSExclusive(this);
-        }
-
-        void lockSpeculative(RunDefer runDefer) {
-            if (!specLocked && !specUnlocked) 
-                lockShared(runDefer);
-
-            ++specLocked;
-        }
-
-        void unlockSpeculative(RunDefer runDefer) {
-            if (!specLocked) 
-                throw ML::Exception("Bad speculative lock nesting");
-
-            --specLocked;
-            if (!specLocked) {
-                if (++specUnlocked == SpeculativeThreshold) {
-                    unlockShared(runDefer);
-                    specUnlocked = 0;
-                }
-            }
-        }
-
-        void forceUnlock(RunDefer runDefer) {
-            ExcCheckEqual(specLocked, 0, "Bad forceUnlock call");
-
-            if (specUnlocked) {
-                unlockShared(runDefer);
-                specUnlocked = 0;
-            }
-        }
-
-
+        void init(const GcLockBase * const self);
+        void lockShared(RunDefer runDefer);
+        void unlockShared(RunDefer runDefer);
+        bool isLockedShared();
+        void lockExclusive();
+        void unlockExclusive();
+        void lockSpeculative(RunDefer runDefer);
+        void unlockSpeculative(RunDefer runDefer);
+        void forceUnlock(RunDefer runDefer);
         std::string print() const;
     };
 
@@ -186,85 +94,16 @@ public:
         GcInfo;
     typedef typename GcInfo::PerThreadInfo ThreadGcInfo;
 
-    struct Data {
-        Data();
-        Data(const Data & other);
-
-        Data & operator = (const Data & other);
-
-        typedef uint64_t q2 __attribute__((__vector_size__(16)));
-        
-        volatile union {
-            struct {
-                int32_t epoch;       ///< Current epoch number (could be smaller).
-                int16_t in[2];       ///< How many threads in each epoch
-                int32_t visibleEpoch;///< Lowest epoch number that's visible
-                int32_t exclusive; ///< Mutex value to lock exclusively
-            };
-            struct {
-                uint64_t bits;
-                uint64_t bits2;
-            };
-            struct {
-                q2 q;
-            };
-        } JML_ALIGNED(16);
-
-        int16_t inCurrent() const { return in[epoch & 1]; }
-        int16_t inOld() const { return in[(epoch - 1)&1]; }
-
-        void setIn(int32_t epoch, int val)
-        {
-            //if (epoch != this->epoch && epoch + 1 != this->epoch)
-            //    throw ML::Exception("modifying wrong epoch");
-            in[epoch & 1] = val;
-        }
-
-        void addIn(int32_t epoch, int val)
-        {
-            //if (epoch != this->epoch && epoch + 1 != this->epoch)
-            //    throw ML::Exception("modifying wrong epoch");
-            in[epoch & 1] += val;
-        }
-
-        /** Check that the invariants all hold.  Throws an exception if not. */
-        void validate() const;
-
-        /** Calculate the appropriate value of visibleEpoch from the rest
-            of the fields.  Returns true if waiters should be woken up.
-        */
-        bool calcVisibleEpoch();
-        
-        /** Human readable string. */
-        std::string print() const;
-
-        bool operator == (const Data & other) const
-        {
-            return bits == other.bits && bits2 == other.bits2;
-        }
-
-        bool operator != (const Data & other) const
-        {
-            return ! operator == (other);
-        }
-
-    } JML_ALIGNED(16);
-
+    struct Atomic;
+    struct Data;
 
     void enterCS(ThreadGcInfoEntry * entry = 0, RunDefer runDefer = RD_YES);
     void exitCS(ThreadGcInfoEntry * entry = 0, RunDefer runDefer = RD_YES);
     void enterCSExclusive(ThreadGcInfoEntry * entry = 0);
     void exitCSExclusive(ThreadGcInfoEntry * entry = 0);
 
-    int myEpoch(GcInfo::PerThreadInfo * threadInfo = 0) const
-    {
-        return getEntry(threadInfo).inEpoch;
-    }
-
-    int currentEpoch() const
-    {
-        return data->epoch;
-    }
+    int myEpoch(GcInfo::PerThreadInfo * threadInfo = 0) const;
+    int currentEpoch() const;
 
     JML_ALWAYS_INLINE ThreadGcInfoEntry &
     getEntry(GcInfo::PerThreadInfo * info = 0) const
@@ -284,36 +123,9 @@ public:
     virtual void unlink() = 0;
 
     void lockShared(GcInfo::PerThreadInfo * info = 0,
-                    RunDefer runDefer = RD_YES)
-    {
-        ThreadGcInfoEntry & entry = getEntry(info);
-
-        entry.lockShared(runDefer);
-
-#if GC_LOCK_DEBUG
-        using namespace std;
-        cerr << "lockShared "
-             << this << " index " << index
-             << ": now " << entry.print() << " data "
-             << data->print() << endl;
-#endif
-    }
-
+                    RunDefer runDefer = RD_YES);
     void unlockShared(GcInfo::PerThreadInfo * info = 0, 
-                      RunDefer runDefer = RD_YES)
-    {
-        ThreadGcInfoEntry & entry = getEntry(info);
-
-        entry.unlockShared(runDefer);
-
-#if GC_LOCK_DEBUG
-        using namespace std;
-        cerr << "unlockShared "
-             << this << " index " << index
-             << ": now " << entry.print() << " data "
-             << data->print() << endl;
-#endif
-    }
+                      RunDefer runDefer = RD_YES);
 
     /** Speculative critical sections should be used for hot loops doing
         repeated but short reads on shared objects where it's acceptable to keep
@@ -345,20 +157,10 @@ public:
         guarantees.
     */
     void lockSpeculative(GcInfo::PerThreadInfo * info = 0,
-                         RunDefer runDefer = RD_YES)
-    {
-        ThreadGcInfoEntry & entry = getEntry(info); 
-
-        entry.lockSpeculative(runDefer);
-    }
+                         RunDefer runDefer = RD_YES);
 
     void unlockSpeculative(GcInfo::PerThreadInfo * info = 0,
-                           RunDefer runDefer = RD_YES)
-    {
-        ThreadGcInfoEntry & entry = getEntry(info);
-
-        entry.unlockSpeculative(runDefer);
-    }
+                           RunDefer runDefer = RD_YES);
 
     /** Ensures that after the call, the Gc is "unlocked".
 
@@ -369,61 +171,19 @@ public:
         called automatically when a thread is destroyed.
      */
     void forceUnlock(GcInfo::PerThreadInfo * info = 0,
-                     RunDefer runDefer = RD_YES) {
-        ThreadGcInfoEntry & entry = getEntry(info);
-
-        entry.forceUnlock(runDefer);
-    }
+                     RunDefer runDefer = RD_YES);
         
-    int isLockedShared(GcInfo::PerThreadInfo * info = 0) const
-    {
-        ThreadGcInfoEntry & entry = getEntry(info);
+    int isLockedShared(GcInfo::PerThreadInfo * info = 0) const;
 
-        return entry.isLockedShared();
-    }
+    int lockedInEpoch(GcInfo::PerThreadInfo * info = 0) const;
 
-    int lockedInEpoch(GcInfo::PerThreadInfo * info = 0) const
-    {
-        ThreadGcInfoEntry & entry = getEntry(info);
+    void lockExclusive(GcInfo::PerThreadInfo * info = 0);
 
-        return entry.inEpoch;
-    }
+    void unlockExclusive(GcInfo::PerThreadInfo * info = 0);
 
-    void lockExclusive(GcInfo::PerThreadInfo * info = 0)
-    {
-        ThreadGcInfoEntry & entry = getEntry(info);
+    int isLockedExclusive(GcInfo::PerThreadInfo * info = 0) const;
 
-        entry.lockExclusive();
-#if GC_LOCK_DEBUG
-        using namespace std;
-        cerr << "lockExclusive "
-             << this << " index " << index
-             << ": now " << entry.print() << " data "
-             << data->print() << endl;
-#endif
-    }
-
-    void unlockExclusive(GcInfo::PerThreadInfo * info = 0)
-    {
-        ThreadGcInfoEntry & entry = getEntry(info);
-
-        entry.unlockExclusive();
-
-#if GC_LOCK_DEBUG
-        using namespace std;
-        cerr << "unlockExclusive"
-             << this << " index " << index
-             << ": now " << entry.print()
-             << " data " << data->print() << endl;
-#endif
-    }
-
-    int isLockedExclusive(GcInfo::PerThreadInfo * info = 0) const
-    {
-        ThreadGcInfoEntry & entry = getEntry(info);
-
-        return entry.writeLocked;
-    }
+    bool isLockedByAnyThread() const;
 
     enum DoLock {
         DONT_LOCK = 0,
@@ -486,9 +246,9 @@ public:
 
     struct SpeculativeGuard {
         SpeculativeGuard(GcLockBase &lock,
-                         RunDefer runDefer = RD_YES) :
-            lock(lock),
-            runDefer_(runDefer) 
+                         RunDefer runDefer = RD_YES)
+            : lock(lock),
+              runDefer_(runDefer) 
         {
             lock.lockSpeculative(0, runDefer_);
         }
@@ -562,7 +322,10 @@ public:
 
 protected:
     Data* data;
-
+    /// How many bytes does data require?
+    static size_t dataBytesRequired();
+    /// Placement construct a data instance
+    static Data* uninitializedConstructData(void * memory);
 private:
     struct Deferred;
     struct DeferredList;
@@ -581,7 +344,7 @@ private:
         on that value, and will run any deferred handlers registered for
         that value.
     */
-    bool updateData(Data & oldValue, Data & newValue, RunDefer runDefer);
+    bool updateAtomic(Atomic & oldValue, Atomic & newValue, RunDefer runDefer);
 
     /** Executes any available deferred work. */
     void runDefers();
@@ -607,43 +370,7 @@ struct GcLock : public GcLockBase
     virtual void unlink();
 
 private:
-
-    Data localData;
-
-};
-
-
-/*****************************************************************************/
-/* SHARED GC LOCK                                                            */
-/*****************************************************************************/
-
-/** Constants that can be used to control how resources are opened.
-    Note that these are structs so we can more easily overload constructors.
-*/
-extern struct GcCreate {} GC_CREATE; ///< Open and initialize a new resource.
-extern struct GcOpen {} GC_OPEN;     ///< Open an existing resource.
-
-
-/** GcLock to be shared among multiple processes. */
-
-struct SharedGcLock : public GcLockBase
-{
-    SharedGcLock(GcCreate, const std::string& name);
-    SharedGcLock(GcOpen, const std::string& name);
-    virtual ~SharedGcLock();
-
-    /** Permanently deletes any resources associated with the gc lock. */
-    virtual void unlink();
-
-private:
-
-    /** mmap an shm file into memory and set the data member of GcLock. */
-    void doOpen(bool create);
-
-    std::string name;
-    int fd;
-    void* addr;
-
+    std::unique_ptr<Data> localData;
 };
 
 } // namespace Datacratic

--- a/arch/gc_lock_impl.h
+++ b/arch/gc_lock_impl.h
@@ -1,0 +1,267 @@
+/* gc_lock_impl.h
+   Jeremy Barnes, 19 November 2011
+   Copyright (c) 2011 Datacratic.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+   Inline method definitions for gc_lock_impl.h
+*/
+
+
+#pragma once
+
+#include "gc_lock.h"
+#include <iostream>
+
+#define GC_LOCK_DEBUG 0
+
+#ifndef GC_LOCK_INLINE_OFF
+# define GC_LOCK_INLINE inline
+#else
+# define GC_LOCK_INLINE 
+#endif
+
+namespace Datacratic {
+
+
+/*****************************************************************************/
+/* THREAD GC INFO ENTRY                                                      */
+/*****************************************************************************/
+
+GC_LOCK_INLINE void
+GcLockBase::ThreadGcInfoEntry::
+init(const GcLockBase * const self)
+{
+    if (!owner) 
+        owner = const_cast<GcLockBase *>(self);
+}
+                
+GC_LOCK_INLINE void
+GcLockBase::ThreadGcInfoEntry::
+lockShared(RunDefer runDefer)
+{
+    if (!readLocked && !writeLocked)
+        owner->enterCS(this, runDefer);
+
+    ++readLocked;
+}
+
+GC_LOCK_INLINE void
+GcLockBase::ThreadGcInfoEntry::
+unlockShared(RunDefer runDefer)
+{
+    if (readLocked <= 0)
+        throw ML::Exception("Bad read lock nesting");
+
+    --readLocked;
+    if (!readLocked && !writeLocked) 
+        owner->exitCS(this, runDefer);
+}
+
+GC_LOCK_INLINE bool
+GcLockBase::ThreadGcInfoEntry::
+isLockedShared()
+{
+    return readLocked + writeLocked;
+}
+
+GC_LOCK_INLINE void
+GcLockBase::ThreadGcInfoEntry::
+lockExclusive()
+{
+    if (!writeLocked)
+        owner->enterCSExclusive(this);
+            
+    ++writeLocked;
+}
+
+GC_LOCK_INLINE void
+GcLockBase::ThreadGcInfoEntry::
+unlockExclusive()
+{
+    if (writeLocked <= 0)
+        throw ML::Exception("Bad write lock nesting");
+
+    --writeLocked;
+    if (!writeLocked)
+        owner->exitCSExclusive(this);
+}
+
+GC_LOCK_INLINE void
+GcLockBase::ThreadGcInfoEntry::
+lockSpeculative(RunDefer runDefer)
+{
+    if (!specLocked && !specUnlocked) 
+        lockShared(runDefer);
+
+    ++specLocked;
+}
+
+GC_LOCK_INLINE void
+GcLockBase::ThreadGcInfoEntry::
+unlockSpeculative(RunDefer runDefer)
+{
+    if (!specLocked) 
+        throw ML::Exception("Bad speculative lock nesting");
+
+    --specLocked;
+    if (!specLocked) {
+        if (++specUnlocked == SpeculativeThreshold) {
+            unlockShared(runDefer);
+            specUnlocked = 0;
+        }
+    }
+}
+
+GC_LOCK_INLINE void
+GcLockBase::ThreadGcInfoEntry::
+forceUnlock(RunDefer runDefer)
+{
+    ExcCheckEqual(specLocked, 0, "Bad forceUnlock call");
+
+    if (specUnlocked) {
+        unlockShared(runDefer);
+        specUnlocked = 0;
+    }
+}
+
+
+/*****************************************************************************/
+/* GC LOCK BASE                                                              */
+/*****************************************************************************/
+
+
+GC_LOCK_INLINE void
+GcLockBase::
+lockShared(GcInfo::PerThreadInfo * info,
+           RunDefer runDefer)
+{
+    ThreadGcInfoEntry & entry = getEntry(info);
+
+    entry.lockShared(runDefer);
+
+#if GC_LOCK_DEBUG
+    using namespace std;
+    cerr << "lockShared "
+         << this << " index " << index
+         << ": now " << entry.print() << " data "
+         << data->print() << endl;
+#endif
+}
+
+GC_LOCK_INLINE void
+GcLockBase::
+unlockShared(GcInfo::PerThreadInfo * info, 
+             RunDefer runDefer)
+{
+    ThreadGcInfoEntry & entry = getEntry(info);
+
+    entry.unlockShared(runDefer);
+
+#if GC_LOCK_DEBUG
+    using namespace std;
+    cerr << "unlockShared "
+         << this << " index " << index
+         << ": now " << entry.print() << " data "
+         << data->print() << endl;
+#endif
+}
+
+GC_LOCK_INLINE void
+GcLockBase::
+lockSpeculative(GcInfo::PerThreadInfo * info,
+                RunDefer runDefer)
+{
+    ThreadGcInfoEntry & entry = getEntry(info); 
+
+    entry.lockSpeculative(runDefer);
+}
+
+GC_LOCK_INLINE void
+GcLockBase::
+unlockSpeculative(GcInfo::PerThreadInfo * info,
+                  RunDefer runDefer)
+{
+    ThreadGcInfoEntry & entry = getEntry(info);
+
+    entry.unlockSpeculative(runDefer);
+}
+
+GC_LOCK_INLINE void
+GcLockBase::
+forceUnlock(GcInfo::PerThreadInfo * info,
+            RunDefer runDefer)
+{
+    ThreadGcInfoEntry & entry = getEntry(info);
+
+    entry.forceUnlock(runDefer);
+}
+        
+GC_LOCK_INLINE int
+GcLockBase::
+isLockedShared(GcInfo::PerThreadInfo * info) const
+{
+    ThreadGcInfoEntry & entry = getEntry(info);
+
+    return entry.isLockedShared();
+}
+
+GC_LOCK_INLINE int
+GcLockBase::
+lockedInEpoch(GcInfo::PerThreadInfo * info) const
+{
+    ThreadGcInfoEntry & entry = getEntry(info);
+
+    return entry.inEpoch;
+}
+
+GC_LOCK_INLINE void
+GcLockBase::
+lockExclusive(GcInfo::PerThreadInfo * info)
+{
+    ThreadGcInfoEntry & entry = getEntry(info);
+
+    entry.lockExclusive();
+#if GC_LOCK_DEBUG
+    using namespace std;
+    cerr << "lockExclusive "
+         << this << " index " << index
+         << ": now " << entry.print() << " data "
+         << data->print() << endl;
+#endif
+}
+
+GC_LOCK_INLINE void
+GcLockBase::
+unlockExclusive(GcInfo::PerThreadInfo * info)
+{
+    ThreadGcInfoEntry & entry = getEntry(info);
+
+    entry.unlockExclusive();
+
+#if GC_LOCK_DEBUG
+    using namespace std;
+    cerr << "unlockExclusive"
+         << this << " index " << index
+         << ": now " << entry.print()
+         << " data " << data->print() << endl;
+#endif
+}
+
+GC_LOCK_INLINE int
+GcLockBase::
+myEpoch(GcInfo::PerThreadInfo * threadInfo) const
+{
+    return getEntry(threadInfo).inEpoch;
+}
+
+GC_LOCK_INLINE int
+GcLockBase::
+isLockedExclusive(GcInfo::PerThreadInfo * info) const
+{
+    ThreadGcInfoEntry & entry = getEntry(info);
+
+    return entry.writeLocked;
+}
+
+} // namespace Datacratic

--- a/arch/shared_gc_lock.cc
+++ b/arch/shared_gc_lock.cc
@@ -1,0 +1,100 @@
+/* gc_lock.cc
+   Jeremy Barnes, 19 November 2011
+   Copyright (c) 2011 Datacratic.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+*/
+
+#include "shared_gc_lock.h"
+#include "gc_lock_impl.h"
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <boost/interprocess/sync/named_mutex.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+
+using namespace std;
+using namespace ML;
+namespace ipc = boost::interprocess;
+
+
+namespace Datacratic {
+
+/*****************************************************************************/
+/* SHARED GC LOCK                                                            */
+/*****************************************************************************/
+
+// We want to mmap the file so it has to be the size of a page.
+
+namespace { size_t GcLockFileSize = 1ULL << 12; }
+
+
+GcCreate GC_CREATE; ///< Open and initialize a new gcource.
+GcOpen GC_OPEN;     ///< Open an existing gcource.
+
+void
+SharedGcLock::
+doOpen(bool create)
+{
+    int flags = O_RDWR | O_CREAT;
+    if (create) flags |= O_EXCL;
+
+    ipc::named_mutex mutex(ipc::open_or_create, name.c_str());
+    {
+        // Lock is used to create and truncate the file atomically.
+        ipc::scoped_lock<ipc::named_mutex> lock(mutex);
+
+        // We don't want the locks to be persisted so an shm_open will do fine.
+        fd = shm_open(name.c_str(), flags, 0644);
+        ExcCheckErrno(fd >= 0, "shm_open failed");
+
+        struct stat stats;
+        int res = fstat(fd, &stats);
+        ExcCheckErrno(!res, "failed to get the file size");
+
+        if (stats.st_size != GcLockFileSize) {
+            int res = ftruncate(fd, GcLockFileSize);
+            ExcCheckErrno(!res, "failed to resize the file.");
+        }
+    }
+
+    // Map the region so that all the processes can see the writes.
+    addr = mmap(0, GcLockFileSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    ExcCheckErrno(addr != MAP_FAILED, "failed to map the shm file");
+
+    // Initialize and set the member used by GcLockBase.
+    if (create) uninitializedConstructData(addr);
+    data = reinterpret_cast<Data*>(addr);
+}
+
+SharedGcLock::
+SharedGcLock(GcCreate, const string& name) :
+    name("gc." + name)
+{
+    doOpen(true);
+}
+
+SharedGcLock::
+SharedGcLock(GcOpen, const string& name) :
+    name("gc." + name)
+{
+    doOpen(false);
+}
+
+SharedGcLock::
+~SharedGcLock()
+{
+    munmap(addr, GcLockFileSize);
+    close(fd);
+}
+
+void
+SharedGcLock::
+unlink()
+{
+    shm_unlink(name.c_str());
+    (void) ipc::named_mutex::remove(name.c_str());
+}
+
+} // namespace Datacratic

--- a/arch/shared_gc_lock.h
+++ b/arch/shared_gc_lock.h
@@ -1,0 +1,49 @@
+/* gc_lock.h                                                       -*- C++ -*-
+   Jeremy Barnes, 19 November 2011
+   Copyright (c) 2011 Datacratic.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+   GcLock that can be shared amongst multiple processes on a machine with
+   a coherent memory architecture.
+*/
+
+#pragma once
+
+#include "gc_lock.h"
+
+namespace Datacratic {
+
+/*****************************************************************************/
+/* SHARED GC LOCK                                                            */
+/*****************************************************************************/
+
+/** Constants that can be used to control how resources are opened.
+    Note that these are structs so we can more easily overload constructors.
+*/
+extern struct GcCreate {} GC_CREATE; ///< Open and initialize a new resource.
+extern struct GcOpen {} GC_OPEN;     ///< Open an existing resource.
+
+
+/** GcLock to be shared among multiple processes. */
+
+struct SharedGcLock : public GcLockBase
+{
+    SharedGcLock(GcCreate, const std::string& name);
+    SharedGcLock(GcOpen, const std::string& name);
+    virtual ~SharedGcLock();
+
+    /** Permanently deletes any resources associated with the gc lock. */
+    virtual void unlink();
+
+private:
+
+    /** mmap an shm file into memory and set the data member of GcLock. */
+    void doOpen(bool create);
+
+    std::string name;
+    int fd;
+    void* addr;
+
+};
+
+} // namespace Datacratic

--- a/arch/testing/arch_testing.mk
+++ b/arch/testing/arch_testing.mk
@@ -13,6 +13,7 @@ $(eval $(call test,info_test,arch,boost))
 $(eval $(call test,rtti_utils_test,arch,boost))
 $(eval $(call test,thread_specific_test,arch,boost))
 $(eval $(call test,gc_test,gc,boost))
+$(eval $(call test,shared_gc_lock_test,gc,boost))
 $(eval $(call test,rcu_protected_test,gc,boost timed))
 
 ifeq ($(ARCH),x86_64)

--- a/arch/testing/gc_lock_test_common.h
+++ b/arch/testing/gc_lock_test_common.h
@@ -1,0 +1,405 @@
+/* gc_lock_test_common.h                                           -*- C++ -*-
+   Jeremy Barnes, 23 February 2010
+   Copyright (c) 2010 Datacratic.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+*/
+
+#include "mldb/arch/gc_lock.h"
+#include <vector>
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <iostream>
+#include <chrono>
+#include "mldb/arch/tick_counter.h"
+#include "mldb/arch/spinlock.h"
+
+#pragma once
+
+struct ThreadGroup {
+    void create_thread(std::function<void ()> fn)
+    {
+        threads.emplace_back(std::move(fn));
+    }
+
+    void join_all()
+    {
+        for (auto & t: threads)
+            t.join();
+        threads.clear();
+    }
+    std::vector<std::thread> threads;
+};
+
+#define USE_MALLOC 1
+
+template<typename T>
+struct Allocator {
+    Allocator(int nblocks, T def = T())
+        : def(def)
+    {
+        init(nblocks);
+        highestAlloc = nallocs = ndeallocs = 0;
+    }
+
+    ~Allocator()
+    {
+#if ( ! USE_MALLOC )
+        delete[] blocks;
+        delete[] free;
+#endif
+    }
+
+    T def;
+    T * blocks;
+    int * free;
+    int nfree;
+    std::atomic<int> highestAlloc;
+    std::atomic<int> nallocs;
+    std::atomic<int> ndeallocs;
+    ML::Spinlock lock;
+
+    void init(int nblocks)
+    {
+#if ( ! USE_MALLOC )
+        blocks = new T[nblocks];
+        free = new int[nblocks];
+
+        std::fill(blocks, blocks + nblocks, def);
+
+        nfree = 0;
+        for (int i = nblocks - 1;  i >= 0;  --i)
+            free[nfree++] = i;
+#endif
+    }
+
+    T * alloc()
+    {
+#if USE_MALLOC
+        nallocs += 1;
+
+        // Atomic max operation
+        {
+            int current = highestAlloc;
+            for (;;) {
+                auto newValue = std::max(current,
+                                         nallocs.load() - ndeallocs.load());
+                if (newValue == current)
+                    break;
+                if (highestAlloc.compare_exchange_weak(current, newValue))
+                    break;
+            }
+        }
+
+        return new T(def);
+#else
+        std::lock_guard<ML::Spinlock> guard(lock);
+        if (nfree == 0)
+            throw ML::Exception("none free");
+        int i = free[nfree - 1];
+        highestAlloc = std::max(highestAlloc, i);
+        T * result = blocks + i;
+        --nfree;
+        ++nallocs;
+        return result;
+#endif
+    }
+
+    void dealloc(T * value)
+    {
+        if (!value) return;
+        *value = def;
+#if USE_MALLOC
+        delete value;
+        ndeallocs += 1;
+        return;
+#else
+        std::lock_guard<ML::Spinlock> guard(lock);
+        int i = value - blocks;
+        free[nfree++] = i;
+        ++ndeallocs;
+#endif
+    }
+
+    static void doDealloc(void * thisptr, void * blockPtr_, void * blockVar_)
+    {
+        int * & blockVar = *reinterpret_cast<int **>(blockVar_);
+        int * blockPtr = reinterpret_cast<int *>(blockPtr_);
+        ExcAssertNotEqual(blockVar, blockPtr);
+        //blockVar = 0;
+        //std::atomic_thread_fence(std::memory_order_seq_cst);
+        //cerr << "blockPtr = " << blockPtr << endl;
+        //int * blockPtr = reinterpret_cast<int *>(block);
+        reinterpret_cast<Allocator *>(thisptr)->dealloc(blockPtr);
+    }
+
+    static void doDeallocAll(void * thisptr, void * blocksPtr_, void * numBlocks_)
+    {
+        size_t numBlocks = reinterpret_cast<size_t>(numBlocks_);
+        int ** blocksPtr = reinterpret_cast<int **>(blocksPtr_);
+        Allocator * alloc = reinterpret_cast<Allocator *>(thisptr);
+
+        for (unsigned i = 0;  i != numBlocks;  ++i) {
+            if (blocksPtr[i])
+                alloc->dealloc(blocksPtr[i]);
+        }
+
+        delete[] blocksPtr;
+    }
+};
+
+struct BlockHolder {
+    BlockHolder(int ** p = nullptr)
+        : block(p)
+    {
+    }
+    
+    BlockHolder & operator = (const BlockHolder & other)
+    {
+        block = other.block.load();
+        return *this;
+    }
+
+    std::atomic<int **> block;
+
+    int ** load() const { return block.load(); }
+
+    operator int ** const () { return load(); }
+};
+
+template<typename Lock>
+struct TestBase {
+    TestBase(int nthreads, int nblocks, int nSpinThreads = 0)
+        : finished(false),
+          nthreads(nthreads),
+          nblocks(nblocks),
+          nSpinThreads(nSpinThreads),
+          allocator(1024 * 1024, -1),
+          nerrors(0),
+          allBlocks(nthreads)
+    {
+        for (unsigned i = 0;  i < nthreads;  ++i) {
+            allBlocks[i] = new int *[nblocks];
+            std::fill(allBlocks[i].load(), allBlocks[i].load() + nblocks, (int *)0);
+        }
+    }
+
+    ~TestBase()
+    {
+        for (unsigned i = 0;  i < nthreads;  ++i)
+            delete[] allBlocks[i].load();
+    }
+
+    std::atomic<bool> finished;
+    std::atomic<int> nthreads;
+    std::atomic<int> nblocks;
+    std::atomic<int> nSpinThreads;
+    Allocator<int> allocator;
+    Lock gc;
+    uint64_t nerrors;
+
+    /* All of the blocks are published here.  Any pointer which is read from
+       here by another thread should always refer to exactly the same
+       value.
+    */
+    std::vector<BlockHolder> allBlocks;
+
+    void checkVisible(int threadNum, unsigned long long start)
+    {
+        using namespace std;
+        // We're reading from someone else's pointers, so we need to lock here
+        //gc.enterCS();
+        gc.lockShared();
+
+        for (unsigned i = 0;  i < nthreads;  ++i) {
+            for (unsigned j = 0;  j < nblocks;  ++j) {
+                //int * val = allBlocks[i][j];
+                int * val = allBlocks[i].load()[j];
+                if (val) {
+                    int atVal = *val;
+                    if (atVal != i) {
+                        cerr << ML::format("%.6f thread %d: invalid value read "
+                                "from thread %d block %d: %d\n",
+                                           (ML::ticks() - start) / ML::ticks_per_second, threadNum,
+                                i, j, atVal);
+                        nerrors += 1;
+                        //abort();
+                    }
+                }
+            }
+        }
+
+        //gc.exitCS();
+        gc.unlockShared();
+    }
+
+    void doReadThread(int threadNum)
+    {
+        gc.getEntry();
+        unsigned long long start = ML::ticks();
+        while (!finished) {
+            checkVisible(threadNum, start);
+        }
+    }
+
+    void doSpinThread()
+    {
+        while (!finished) {
+        }
+    }
+
+    void allocThreadDefer(int threadNum)
+    {
+        using namespace std;
+        gc.getEntry();
+        try {
+            uint64_t nErrors = 0;
+
+            int ** blocks = allBlocks[threadNum];
+
+            while (!finished) {
+
+                int ** oldBlocks = new int * [nblocks];
+
+                //gc.enterCS();
+
+                for (unsigned i = 0;  i < nblocks;  ++i) {
+                    int * block = allocator.alloc();
+                    if (*block != -1) {
+                        cerr << "old block was allocated" << endl;
+                        ++nErrors;
+                    }
+                    *block = threadNum;
+                    std::atomic_thread_fence(std::memory_order_seq_cst);
+                    //rcu_set_pointer_sym((void **)&blocks[i], block);
+                    int * oldBlock = blocks[i];
+                    blocks[i] = block;
+                    std::atomic_thread_fence(std::memory_order_seq_cst);
+                    oldBlocks[i] = oldBlock;
+                }
+
+                gc.defer(Allocator<int>::doDeallocAll, &allocator, oldBlocks,
+                         (void *)(size_t)nblocks);
+
+                //gc.exitCS();
+            }
+
+
+            int * oldBlocks[nblocks];
+
+            for (unsigned i = 0;  i < nblocks;  ++i) {
+                oldBlocks[i] = blocks[i];
+                blocks[i] = 0;
+            }
+
+            gc.visibleBarrier();
+
+            //cerr << "at end" << endl;
+
+            for (unsigned i = 0;  i < nblocks;  ++i)
+                allocator.dealloc(oldBlocks[i]);
+
+            //cerr << "nErrors = " << nErrors << endl;
+        } catch (...) {
+            static ML::Spinlock lock;
+            lock.acquire();
+            //cerr << "threadnum " << threadNum << " inEpoch "
+            //     << gc.getEntry().inEpoch << endl;
+            gc.dump();
+            abort();
+        }
+    }
+
+    void allocThreadSync(int threadNum)
+    {
+        using namespace std;
+        gc.getEntry();
+        try {
+            uint64_t nErrors = 0;
+
+            int ** blocks = allBlocks[threadNum];
+            int * oldBlocks[nblocks];
+
+            while (!finished) {
+
+                for (unsigned i = 0;  i < nblocks;  ++i) {
+                    int * block = allocator.alloc();
+                    if (*block != -1) {
+                        cerr << "old block was allocated" << endl;
+                        ++nErrors;
+                    }
+                    *block = threadNum;
+                    int * oldBlock = blocks[i];
+                    blocks[i] = block;
+                    oldBlocks[i] = oldBlock;
+                }
+
+                std::atomic_thread_fence(std::memory_order_seq_cst);
+                gc.visibleBarrier();
+
+                for (unsigned i = 0;  i < nblocks;  ++i)
+                    if (oldBlocks[i]) *oldBlocks[i] = 1234;
+
+                for (unsigned i = 0;  i < nblocks;  ++i)
+                    if (oldBlocks[i]) allocator.dealloc(oldBlocks[i]);
+            }
+
+            for (unsigned i = 0;  i < nblocks;  ++i) {
+                oldBlocks[i] = blocks[i];
+                blocks[i] = 0;
+            }
+
+            gc.visibleBarrier();
+
+            for (unsigned i = 0;  i < nblocks;  ++i)
+                allocator.dealloc(oldBlocks[i]);
+
+            //cerr << "nErrors = " << nErrors << endl;
+        } catch (...) {
+            static ML::Spinlock lock;
+            lock.acquire();
+            //cerr << "threadnum " << threadNum << " inEpoch "
+            //     << gc.getEntry().inEpoch << endl;
+            gc.dump();
+            abort();
+        }
+    }
+
+    void run(std::function<void (int)> allocFn,
+             int runTime = 1)
+    {
+        using namespace std;
+        gc.getEntry();
+        ThreadGroup tg;
+
+        for (unsigned i = 0;  i < nthreads;  ++i)
+            tg.create_thread(std::bind<void>(&TestBase::doReadThread, this, i));
+
+        for (unsigned i = 0;  i < nthreads;  ++i)
+            tg.create_thread(std::bind<void>(allocFn, i));
+
+        for (unsigned i = 0;  i < nSpinThreads;  ++i)
+            tg.create_thread(std::bind<void>(&TestBase::doSpinThread, this));
+
+        std::this_thread::sleep_for(std::chrono::seconds(runTime));
+
+        finished = true;
+
+        tg.join_all();
+
+        gc.deferBarrier();
+
+        gc.dump();
+
+        cerr << "allocs " << allocator.nallocs
+             << " deallocs " << allocator.ndeallocs << endl;
+        cerr << "highest " << allocator.highestAlloc << endl;
+
+        cerr << "gc.currentEpoch() = " << gc.currentEpoch() << endl;
+
+        ExcAssertEqual(allocator.nallocs, allocator.ndeallocs);
+        ExcAssertEqual(nerrors, 0);
+    }
+};
+

--- a/arch/testing/gc_test.cc
+++ b/arch/testing/gc_test.cc
@@ -10,7 +10,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
-#include "mldb/arch/gc_lock.h"
+#include "gc_lock_test_common.h"
 #include "mldb/jml/utils/string_functions.h"
 #include "mldb/base/exc_assert.h"
 #include "mldb/jml/utils/guard.h"
@@ -32,36 +32,25 @@ namespace Datacratic {
 extern int32_t gcLockStartingEpoch;
 };
 
-struct ThreadGroup {
-    void create_thread(std::function<void ()> fn)
-    {
-        threads.emplace_back(std::move(fn));
-    }
-
-    void join_all()
-    {
-        for (auto & t: threads)
-            t.join();
-        threads.clear();
-    }
-    std::vector<std::thread> threads;
-};
-
 #if 1
 
 BOOST_AUTO_TEST_CASE ( test_gc )
 {
     GcLock gc;
+
+    cerr << endl << "before lock" << endl;
+    gc.dump();
+
     gc.lockShared();
 
     BOOST_CHECK(gc.isLockedShared());
 
-    bool deferred = false;
+    std::atomic<int> deferred(false);
 
     cerr << endl << "before defer" << endl;
     gc.dump();
 
-    gc.defer([&] () { deferred = true; std::atomic_thread_fence(std::memory_order_seq_cst); });
+    gc.defer([&] () { deferred = true; });
 
     cerr << endl << "after defer" << endl;
     gc.dump();
@@ -261,373 +250,6 @@ BOOST_AUTO_TEST_CASE(test_mutual_exclusion)
 
 #endif
 
-#define USE_MALLOC 1
-
-template<typename T>
-struct Allocator {
-    Allocator(int nblocks, T def = T())
-        : def(def)
-    {
-        init(nblocks);
-        highestAlloc = nallocs = ndeallocs = 0;
-    }
-
-    ~Allocator()
-    {
-#if ( ! USE_MALLOC )
-        delete[] blocks;
-        delete[] free;
-#endif
-    }
-
-    T def;
-    T * blocks;
-    int * free;
-    int nfree;
-    std::atomic<int> highestAlloc;
-    std::atomic<int> nallocs;
-    std::atomic<int> ndeallocs;
-    ML::Spinlock lock;
-
-    void init(int nblocks)
-    {
-#if ( ! USE_MALLOC )
-        blocks = new T[nblocks];
-        free = new int[nblocks];
-
-        std::fill(blocks, blocks + nblocks, def);
-
-        nfree = 0;
-        for (int i = nblocks - 1;  i >= 0;  --i)
-            free[nfree++] = i;
-#endif
-    }
-
-    T * alloc()
-    {
-#if USE_MALLOC
-        nallocs += 1;
-
-        // Atomic max operation
-        {
-            int current = highestAlloc;
-            for (;;) {
-                auto newValue = std::max(current,
-                                         nallocs.load() - ndeallocs.load());
-                if (newValue == current)
-                    break;
-                if (highestAlloc.compare_exchange_weak(current, newValue))
-                    break;
-            }
-        }
-
-        return new T(def);
-#else
-        std::lock_guard<ML::Spinlock> guard(lock);
-        if (nfree == 0)
-            throw ML::Exception("none free");
-        int i = free[nfree - 1];
-        highestAlloc = std::max(highestAlloc, i);
-        T * result = blocks + i;
-        --nfree;
-        ++nallocs;
-        return result;
-#endif
-    }
-
-    void dealloc(T * value)
-    {
-        if (!value) return;
-        *value = def;
-#if USE_MALLOC
-        delete value;
-        ndeallocs += 1;
-        return;
-#else
-        std::lock_guard<ML::Spinlock> guard(lock);
-        int i = value - blocks;
-        free[nfree++] = i;
-        ++ndeallocs;
-#endif
-    }
-
-    static void doDealloc(void * thisptr, void * blockPtr_, void * blockVar_)
-    {
-        int * & blockVar = *reinterpret_cast<int **>(blockVar_);
-        int * blockPtr = reinterpret_cast<int *>(blockPtr_);
-        ExcAssertNotEqual(blockVar, blockPtr);
-        //blockVar = 0;
-        //std::atomic_thread_fence(std::memory_order_seq_cst);
-        //cerr << "blockPtr = " << blockPtr << endl;
-        //int * blockPtr = reinterpret_cast<int *>(block);
-        reinterpret_cast<Allocator *>(thisptr)->dealloc(blockPtr);
-    }
-
-    static void doDeallocAll(void * thisptr, void * blocksPtr_, void * numBlocks_)
-    {
-        size_t numBlocks = reinterpret_cast<size_t>(numBlocks_);
-        int ** blocksPtr = reinterpret_cast<int **>(blocksPtr_);
-        Allocator * alloc = reinterpret_cast<Allocator *>(thisptr);
-
-        for (unsigned i = 0;  i != numBlocks;  ++i) {
-            if (blocksPtr[i])
-                alloc->dealloc(blocksPtr[i]);
-        }
-
-        delete[] blocksPtr;
-    }
-};
-
-struct BlockHolder {
-    BlockHolder(int ** p = nullptr)
-        : block(p)
-    {
-    }
-    
-    BlockHolder & operator = (const BlockHolder & other)
-    {
-        block = other.block.load();
-        return *this;
-    }
-
-    std::atomic<int **> block;
-
-    int ** load() const { return block.load(); }
-
-    operator int ** const () { return load(); }
-};
-
-template<typename Lock>
-struct TestBase {
-    TestBase(int nthreads, int nblocks, int nSpinThreads = 0)
-        : finished(false),
-          nthreads(nthreads),
-          nblocks(nblocks),
-          nSpinThreads(nSpinThreads),
-          allocator(1024 * 1024, -1),
-          nerrors(0),
-          allBlocks(nthreads)
-    {
-        for (unsigned i = 0;  i < nthreads;  ++i) {
-            allBlocks[i] = new int *[nblocks];
-            std::fill(allBlocks[i].load(), allBlocks[i].load() + nblocks, (int *)0);
-        }
-    }
-
-    ~TestBase()
-    {
-        for (unsigned i = 0;  i < nthreads;  ++i)
-            delete[] allBlocks[i].load();
-    }
-
-    std::atomic<bool> finished;
-    std::atomic<int> nthreads;
-    std::atomic<int> nblocks;
-    std::atomic<int> nSpinThreads;
-    Allocator<int> allocator;
-    Lock gc;
-    uint64_t nerrors;
-
-    /* All of the blocks are published here.  Any pointer which is read from
-       here by another thread should always refer to exactly the same
-       value.
-    */
-    vector<BlockHolder> allBlocks;
-
-    void checkVisible(int threadNum, unsigned long long start)
-    {
-        // We're reading from someone else's pointers, so we need to lock here
-        //gc.enterCS();
-        gc.lockShared();
-
-        for (unsigned i = 0;  i < nthreads;  ++i) {
-            for (unsigned j = 0;  j < nblocks;  ++j) {
-                //int * val = allBlocks[i][j];
-                int * val = allBlocks[i].load()[j];
-                if (val) {
-                    int atVal = *val;
-                    if (atVal != i) {
-                        cerr << ML::format("%.6f thread %d: invalid value read "
-                                "from thread %d block %d: %d\n",
-                                (ticks() - start) / ticks_per_second, threadNum,
-                                i, j, atVal);
-                        nerrors += 1;
-                        //abort();
-                    }
-                }
-            }
-        }
-
-        //gc.exitCS();
-        gc.unlockShared();
-    }
-
-    void doReadThread(int threadNum)
-    {
-        gc.getEntry();
-        unsigned long long start = ticks();
-        while (!finished) {
-            checkVisible(threadNum, start);
-        }
-    }
-
-    void doSpinThread()
-    {
-        while (!finished) {
-        }
-    }
-
-    void allocThreadDefer(int threadNum)
-    {
-        gc.getEntry();
-        try {
-            uint64_t nErrors = 0;
-
-            int ** blocks = allBlocks[threadNum];
-
-            while (!finished) {
-
-                int ** oldBlocks = new int * [nblocks];
-
-                //gc.enterCS();
-
-                for (unsigned i = 0;  i < nblocks;  ++i) {
-                    int * block = allocator.alloc();
-                    if (*block != -1) {
-                        cerr << "old block was allocated" << endl;
-                        ++nErrors;
-                    }
-                    *block = threadNum;
-                    std::atomic_thread_fence(std::memory_order_seq_cst);
-                    //rcu_set_pointer_sym((void **)&blocks[i], block);
-                    int * oldBlock = blocks[i];
-                    blocks[i] = block;
-                    std::atomic_thread_fence(std::memory_order_seq_cst);
-                    oldBlocks[i] = oldBlock;
-                }
-
-                gc.defer(Allocator<int>::doDeallocAll, &allocator, oldBlocks,
-                         (void *)(size_t)nblocks);
-
-                //gc.exitCS();
-            }
-
-
-            int * oldBlocks[nblocks];
-
-            for (unsigned i = 0;  i < nblocks;  ++i) {
-                oldBlocks[i] = blocks[i];
-                blocks[i] = 0;
-            }
-
-            gc.visibleBarrier();
-
-            //cerr << "at end" << endl;
-
-            for (unsigned i = 0;  i < nblocks;  ++i)
-                allocator.dealloc(oldBlocks[i]);
-
-            //cerr << "nErrors = " << nErrors << endl;
-        } catch (...) {
-            static ML::Spinlock lock;
-            lock.acquire();
-            //cerr << "threadnum " << threadNum << " inEpoch "
-            //     << gc.getEntry().inEpoch << endl;
-            gc.dump();
-            abort();
-        }
-    }
-
-    void allocThreadSync(int threadNum)
-    {
-        gc.getEntry();
-        try {
-            uint64_t nErrors = 0;
-
-            int ** blocks = allBlocks[threadNum];
-            int * oldBlocks[nblocks];
-
-            while (!finished) {
-
-                for (unsigned i = 0;  i < nblocks;  ++i) {
-                    int * block = allocator.alloc();
-                    if (*block != -1) {
-                        cerr << "old block was allocated" << endl;
-                        ++nErrors;
-                    }
-                    *block = threadNum;
-                    int * oldBlock = blocks[i];
-                    blocks[i] = block;
-                    oldBlocks[i] = oldBlock;
-                }
-
-                std::atomic_thread_fence(std::memory_order_seq_cst);
-                gc.visibleBarrier();
-
-                for (unsigned i = 0;  i < nblocks;  ++i)
-                    if (oldBlocks[i]) *oldBlocks[i] = 1234;
-
-                for (unsigned i = 0;  i < nblocks;  ++i)
-                    if (oldBlocks[i]) allocator.dealloc(oldBlocks[i]);
-            }
-
-            for (unsigned i = 0;  i < nblocks;  ++i) {
-                oldBlocks[i] = blocks[i];
-                blocks[i] = 0;
-            }
-
-            gc.visibleBarrier();
-
-            for (unsigned i = 0;  i < nblocks;  ++i)
-                allocator.dealloc(oldBlocks[i]);
-
-            //cerr << "nErrors = " << nErrors << endl;
-        } catch (...) {
-            static ML::Spinlock lock;
-            lock.acquire();
-            //cerr << "threadnum " << threadNum << " inEpoch "
-            //     << gc.getEntry().inEpoch << endl;
-            gc.dump();
-            abort();
-        }
-    }
-
-    void run(std::function<void (int)> allocFn,
-             int runTime = 1)
-    {
-        gc.getEntry();
-        ThreadGroup tg;
-
-        for (unsigned i = 0;  i < nthreads;  ++i)
-            tg.create_thread(std::bind<void>(&TestBase::doReadThread, this, i));
-
-        for (unsigned i = 0;  i < nthreads;  ++i)
-            tg.create_thread(std::bind<void>(allocFn, i));
-
-        for (unsigned i = 0;  i < nSpinThreads;  ++i)
-            tg.create_thread(std::bind<void>(&TestBase::doSpinThread, this));
-
-        sleep(runTime);
-
-        finished = true;
-
-        tg.join_all();
-
-        gc.deferBarrier();
-
-        gc.dump();
-
-        BOOST_CHECK_EQUAL(allocator.nallocs, allocator.ndeallocs);
-        BOOST_CHECK_EQUAL(nerrors, 0);
-
-        cerr << "allocs " << allocator.nallocs
-             << " deallocs " << allocator.ndeallocs << endl;
-        cerr << "highest " << allocator.highestAlloc << endl;
-
-        cerr << "gc.currentEpoch() = " << gc.currentEpoch() << endl;
-    }
-};
-
 #if 1
 BOOST_AUTO_TEST_CASE ( test_gc_sync_many_threads_contention )
 {
@@ -693,50 +315,6 @@ BOOST_AUTO_TEST_CASE ( test_gc_deferred )
     TestBase<GcLock> test(nthreads, nblocks);
     test.run(std::bind(&TestBase<GcLock>::allocThreadDefer, &test,
                        std::placeholders::_1));
-}
-
-
-struct SharedGcLockProxy : public SharedGcLock {
-    static const char* name;
-    SharedGcLockProxy() :
-        SharedGcLock(GC_OPEN, name)
-    {}
-};
-const char* SharedGcLockProxy::name = "gc_test.dat";
-
-BOOST_AUTO_TEST_CASE( test_shared_lock_sync )
-{
-    cerr << "testing contention synchronized GcLock with shared lock" << endl;
-
-    SharedGcLock lockGuard(GC_CREATE, SharedGcLockProxy::name);
-    Call_Guard unlink_guard([&] { lockGuard.unlink(); });
-
-    int nthreads = 8;
-    int nSpinThreads = 16;
-    int nblocks = 2;
-
-    TestBase<SharedGcLockProxy> test(nthreads, nblocks, nSpinThreads);
-    test.run(std::bind(
-                    &TestBase<SharedGcLockProxy>::allocThreadSync, &test,
-                    std::placeholders::_1));
-
-}
-
-BOOST_AUTO_TEST_CASE( test_shared_lock_defer )
-{
-    cerr << "testing contended deferred GcLock with shared lock" << endl;
-
-    SharedGcLock lockGuard(GC_CREATE, SharedGcLockProxy::name);
-    Call_Guard unlink_guard([&] { lockGuard.unlink(); });
-
-    int nthreads = 8;
-    int nSpinThreads = 16;
-    int nblocks = 2;
-
-    TestBase<SharedGcLockProxy> test(nthreads, nblocks, nSpinThreads);
-    test.run(std::bind(
-                    &TestBase<SharedGcLockProxy>::allocThreadSync, &test,
-                    std::placeholders::_1));
 }
 
 BOOST_AUTO_TEST_CASE ( test_defer_race )

--- a/arch/testing/shared_gc_lock_test.cc
+++ b/arch/testing/shared_gc_lock_test.cc
@@ -1,0 +1,77 @@
+/* gc_test.cc
+   Jeremy Barnes, 23 February 2010
+   Copyright (c) 2010 Datacratic.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
+   Test of the garbage collector locking.
+*/
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "mldb/arch/shared_gc_lock.h"
+#include "gc_lock_test_common.h"
+#include "mldb/jml/utils/string_functions.h"
+#include "mldb/base/exc_assert.h"
+#include "mldb/jml/utils/guard.h"
+#include "mldb/arch/thread_specific.h"
+#include "mldb/arch/rwlock.h"
+#include "mldb/arch/spinlock.h"
+#include "mldb/arch/tick_counter.h"
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <atomic>
+
+
+using namespace ML;
+using namespace Datacratic;
+using namespace std;
+
+// Defined in gc_lock.cc
+namespace Datacratic {
+extern int32_t gcLockStartingEpoch;
+};
+
+struct SharedGcLockProxy : public SharedGcLock {
+    static const char* name;
+    SharedGcLockProxy() :
+        SharedGcLock(GC_OPEN, name)
+    {}
+};
+const char* SharedGcLockProxy::name = "gc_test.dat";
+
+BOOST_AUTO_TEST_CASE( test_shared_lock_sync )
+{
+    cerr << "testing contention synchronized GcLock with shared lock" << endl;
+
+    SharedGcLock lockGuard(GC_CREATE, SharedGcLockProxy::name);
+    Call_Guard unlink_guard([&] { lockGuard.unlink(); });
+
+    int nthreads = 8;
+    int nSpinThreads = 16;
+    int nblocks = 2;
+
+    TestBase<SharedGcLockProxy> test(nthreads, nblocks, nSpinThreads);
+    test.run(std::bind(
+                    &TestBase<SharedGcLockProxy>::allocThreadSync, &test,
+                    std::placeholders::_1));
+
+}
+
+BOOST_AUTO_TEST_CASE( test_shared_lock_defer )
+{
+    cerr << "testing contended deferred GcLock with shared lock" << endl;
+
+    SharedGcLock lockGuard(GC_CREATE, SharedGcLockProxy::name);
+    Call_Guard unlink_guard([&] { lockGuard.unlink(); });
+
+    int nthreads = 8;
+    int nSpinThreads = 16;
+    int nblocks = 2;
+
+    TestBase<SharedGcLockProxy> test(nthreads, nblocks, nSpinThreads);
+    test.run(std::bind(
+                    &TestBase<SharedGcLockProxy>::allocThreadSync, &test,
+                    std::placeholders::_1));
+}


### PR DESCRIPTION
This fixes a major portability problem (only x86_64 has 128 bit atomics, whereas basically every interesting platform has 64 bit atomics).

The testing code is pretty comprehensive, but this is a very low-level primitive and so we should keep an eye out for test failures in concurrency.

We now only use std::atomic to implement the functionality; no assembler is required any more.

The changes made were as follows:
1.  The visibleEpoch field was removed, and its value inferred from epoch (saving 32 bits)
2.  The exclusive field was removed, and replaced with a single bit on the "in" counter (saving 32 bits).  Note that this reduces that maximum number of threads that can be simultaneously in a critical section from 65535 to 32767.  It shouldn't be a problem in practice, but it is a limit.
3.  Since we no longer had an exclusive or visibleEpoch field to run a futex over, separate futexes outside of the atomic section were created to handle sleeping and wakeups.  These could in the future be replaced by condition variables with some loss in performance.
4.  std::atomic was used for atomic operations
5.  The code was refactored, to put all of the inline methods in a separate file, remove details of the internal structure from the header, and separate the shared GC lock (for IPC) into a separate file.

