### PR TITLE
MLDB-1913 v8 upgrade

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "ext/highwayhash"]
 	path = ext/highwayhash
 	url = https://github.com/mldbai/highwayhash.git
+[submodule "ext/v8-cross-build-output"]
+	path = ext/v8-cross-build-output
+	url = https://github.com/mldbai/v8-cross-build-output.git

--- a/Building.md
+++ b/Building.md
@@ -12,7 +12,7 @@ For C++ code to compile and the Python modules to install correctly, the followi
 apt-get install -y git valgrind build-essential libboost-all-dev \
 libgoogle-perftools-dev liblzma-dev libcrypto++-dev libblas-dev \
 liblapack-dev python-virtualenv libcurl4-openssl-dev libssh2-1-dev \
-libpython-dev libgit2-dev libv8-dev libarchive-dev libffi-dev \
+libpython-dev libgit2-dev libarchive-dev libffi-dev \
 libfreetype6-dev libpng12-dev libcap-dev autoconf libtool unzip \
 language-pack-en libyaml-cpp-dev
 ```

--- a/base/thread_pool.cc
+++ b/base/thread_pool.cc
@@ -660,6 +660,13 @@ work() const
     itl->work();
 }
 
+size_t
+ThreadPool::
+numThreads() const
+{
+    return itl->workers.size();
+}
+
 uint64_t
 ThreadPool::
 jobsRunning() const

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -57,6 +57,8 @@ struct ThreadPool {
 
     void work() const;
 
+    size_t numThreads() const;
+
     uint64_t jobsRunning() const;
     uint64_t jobsSubmitted() const;
     uint64_t jobsFinished() const;

--- a/mldb_base/docker_create_mldb_base.sh
+++ b/mldb_base/docker_create_mldb_base.sh
@@ -81,7 +81,6 @@ apt-get install -y \
     liblzma5 \
     libbz2-1.0 \
     libcrypto++9 \
-    libv8-3.14.5 \
     libcurlpp0 \
     libcurl3 \
     libssh2-1 \

--- a/plugins/lang/js/dataset_js.cc
+++ b/plugins/lang/js/dataset_js.cc
@@ -90,9 +90,14 @@ recordRow(const v8::FunctionCallbackInfo<v8::Value> & args)
     JsContextScope scope(args.This());
     try {
         Dataset * dataset = getShared(args.This());
-            
-        dataset->recordRow(JS::getArg<RowName>(args, 0, "rowName"),
-                           JS::getArg<std::vector<std::tuple<ColumnName, CellValue, Date> > >(args, 1, "values", {}));
+         
+        auto rowName = JS::getArg<RowName>(args, 0, "rowName");
+        auto values = JS::getArg<std::vector<std::tuple<ColumnName, CellValue, Date> > >(args, 1, "values", {});
+
+        {
+            //v8::Unlocker unlocker(args.GetIsolate());
+            dataset->recordRow(std::move(rowName), std::move(values));
+        }
 
         args.GetReturnValue().Set(args.This());
     } HANDLE_JS_EXCEPTIONS(args);
@@ -105,9 +110,14 @@ recordRows(const v8::FunctionCallbackInfo<v8::Value> & args)
     JsContextScope scope(args.This());
     try {
         Dataset * dataset = getShared(args.This());
-            
-        dataset->recordRows(JS::getArg<std::vector<std::pair<RowName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > >(args, 0, "rows", {}));
+        
+        auto rows = JS::getArg<std::vector<std::pair<RowName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > >(args, 0, "rows", {});
 
+        {
+            //v8::Unlocker unlocker(args.GetIsolate());
+            dataset->recordRows(std::move(rows));
+        }
+        
         args.GetReturnValue().Set(args.This());
     } HANDLE_JS_EXCEPTIONS(args);
 }
@@ -119,9 +129,14 @@ recordColumn(const v8::FunctionCallbackInfo<v8::Value> & args)
     JsContextScope scope(args.This());
     try {
         Dataset * dataset = getShared(args.This());
-            
-        dataset->recordColumn(JS::getArg<ColumnName>(args, 0, "columnName"),
-                              JS::getArg<std::vector<std::tuple<ColumnName, CellValue, Date> > >(args, 1, "values", {}));
+        
+        auto columnName = JS::getArg<ColumnName>(args, 0, "columnName");
+        auto column = JS::getArg<std::vector<std::tuple<ColumnName, CellValue, Date> > >(args, 1, "values", {});
+
+        {
+            //v8::Unlocker unlocker(args.GetIsolate());
+            dataset->recordColumn(std::move(columnName), std::move(column));
+        }
 
         args.GetReturnValue().Set(args.This());
     } HANDLE_JS_EXCEPTIONS(args);
@@ -135,7 +150,8 @@ recordColumns(const v8::FunctionCallbackInfo<v8::Value> & args)
     try {
         Dataset * dataset = getShared(args.This());
             
-        dataset->recordColumns(JS::getArg<std::vector<std::pair<ColumnName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > >(args, 0, "columns", {}));
+        auto columns = JS::getArg<std::vector<std::pair<ColumnName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > >(args, 0, "columns", {});
+        dataset->recordColumns(std::move(columns));
 
         args.GetReturnValue().Set(args.This());
     } HANDLE_JS_EXCEPTIONS(args);

--- a/plugins/lang/js/dataset_js.cc
+++ b/plugins/lang/js/dataset_js.cc
@@ -26,7 +26,8 @@ v8::Handle<v8::Object>
 DatasetJS::
 create(std::shared_ptr<Dataset> dataset, JsPluginContext * context)
 {
-    auto obj = context->Dataset->GetFunction()->NewInstance();
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    auto obj = context->Dataset.Get(isolate)->GetFunction()->NewInstance();
     auto * wrapped = new DatasetJS();
     wrapped->dataset = dataset;
     wrapped->wrap(obj, context);
@@ -48,31 +49,43 @@ registerMe()
 {
     using namespace v8;
 
-    HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    EscapableHandleScope scope(isolate);
 
     auto fntmpl = CreateFunctionTemplate("Dataset");
     auto prototmpl = fntmpl->PrototypeTemplate();
 
-    prototmpl->Set(String::New("recordRow"), FunctionTemplate::New(recordRow));
-    prototmpl->Set(String::New("recordRows"), FunctionTemplate::New(recordRows));
-    prototmpl->Set(String::New("recordColumn"), FunctionTemplate::New(recordColumn));
-    prototmpl->Set(String::New("recordColumns"), FunctionTemplate::New(recordColumns));
+    prototmpl->Set(String::NewFromUtf8(isolate, "recordRow"),
+                   FunctionTemplate::New(isolate, recordRow));
+    prototmpl->Set(String::NewFromUtf8(isolate, "recordRows"),
+                   FunctionTemplate::New(isolate, recordRows));
+    prototmpl->Set(String::NewFromUtf8(isolate, "recordColumn"),
+                   FunctionTemplate::New(isolate, recordColumn));
+    prototmpl->Set(String::NewFromUtf8(isolate, "recordColumns"),
+                   FunctionTemplate::New(isolate, recordColumns));
 
-    prototmpl->Set(String::New("commit"), FunctionTemplate::New(commit));
-    prototmpl->Set(String::New("status"), FunctionTemplate::New(status));
-    prototmpl->Set(String::New("id"), FunctionTemplate::New(id));
-    prototmpl->Set(String::New("type"), FunctionTemplate::New(type));
-    prototmpl->Set(String::New("config"), FunctionTemplate::New(config));
+    prototmpl->Set(String::NewFromUtf8(isolate, "commit"),
+                   FunctionTemplate::New(isolate, commit));
+    prototmpl->Set(String::NewFromUtf8(isolate, "status"),
+                   FunctionTemplate::New(isolate, status));
+    prototmpl->Set(String::NewFromUtf8(isolate, "id"),
+                   FunctionTemplate::New(isolate, id));
+    prototmpl->Set(String::NewFromUtf8(isolate, "type"),
+                   FunctionTemplate::New(isolate, type));
+    prototmpl->Set(String::NewFromUtf8(isolate, "config"),
+                   FunctionTemplate::New(isolate, config));
         
-    prototmpl->Set(String::New("getColumnNames"), FunctionTemplate::New(getColumnNames));
-    prototmpl->Set(String::New("getTimestampRange"), FunctionTemplate::New(getTimestampRange));
+    prototmpl->Set(String::NewFromUtf8(isolate, "getColumnNames"),
+                   FunctionTemplate::New(isolate, getColumnNames));
+    prototmpl->Set(String::NewFromUtf8(isolate, "getTimestampRange"),
+                   FunctionTemplate::New(isolate, getTimestampRange));
         
-    return scope.Close(fntmpl);
+    return scope.Escape(fntmpl);
 }
 
-v8::Handle<v8::Value>
+void
 DatasetJS::
-recordRow(const v8::Arguments & args)
+recordRow(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     JsContextScope scope(args.This());
     try {
@@ -81,13 +94,13 @@ recordRow(const v8::Arguments & args)
         dataset->recordRow(JS::getArg<RowName>(args, 0, "rowName"),
                            JS::getArg<std::vector<std::tuple<ColumnName, CellValue, Date> > >(args, 1, "values", {}));
 
-        return args.This();
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(args.This());
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
-v8::Handle<v8::Value>
+void
 DatasetJS::
-recordRows(const v8::Arguments & args)
+recordRows(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     JsContextScope scope(args.This());
     try {
@@ -95,13 +108,13 @@ recordRows(const v8::Arguments & args)
             
         dataset->recordRows(JS::getArg<std::vector<std::pair<RowName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > >(args, 0, "rows", {}));
 
-        return args.This();
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(args.This());
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
-v8::Handle<v8::Value>
+void
 DatasetJS::
-recordColumn(const v8::Arguments & args)
+recordColumn(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     JsContextScope scope(args.This());
     try {
@@ -110,13 +123,13 @@ recordColumn(const v8::Arguments & args)
         dataset->recordColumn(JS::getArg<ColumnName>(args, 0, "columnName"),
                               JS::getArg<std::vector<std::tuple<ColumnName, CellValue, Date> > >(args, 1, "values", {}));
 
-        return args.This();
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(args.This());
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
-v8::Handle<v8::Value>
+void
 DatasetJS::
-recordColumns(const v8::Arguments & args)
+recordColumns(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     JsContextScope scope(args.This());
     try {
@@ -124,86 +137,86 @@ recordColumns(const v8::Arguments & args)
             
         dataset->recordColumns(JS::getArg<std::vector<std::pair<ColumnName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > >(args, 0, "columns", {}));
 
-        return args.This();
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(args.This());
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
-v8::Handle<v8::Value>
+void
 DatasetJS::
-commit(const v8::Arguments & args)
+commit(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Dataset * dataset = getShared(args.This());
             
         dataset->commit();
             
-        return args.This();
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(args.This());
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
-v8::Handle<v8::Value>
+void
 DatasetJS::
-status(const v8::Arguments & args)
+status(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Dataset * dataset = getShared(args.This());
             
-        return JS::toJS(jsonEncode(dataset->getStatus()));
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(dataset->getStatus())));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
     
-v8::Handle<v8::Value>
+void
 DatasetJS::
-id(const v8::Arguments & args)
+id(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Dataset * dataset = getShared(args.This());
             
-        return JS::toJS(dataset->getId());
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(dataset->getId())));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
     
-v8::Handle<v8::Value>
+void
 DatasetJS::
-type(const v8::Arguments & args)
+type(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Dataset * dataset = getShared(args.This());
             
-        return JS::toJS(dataset->getType());
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(dataset->getType())));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
     
-v8::Handle<v8::Value>
+void
 DatasetJS::
-config(const v8::Arguments & args)
+config(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Dataset * dataset = getShared(args.This());
         
-        return JS::toJS(jsonEncode(dataset->getConfig()));
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(dataset->getConfig())));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
-    
-v8::Handle<v8::Value>
+
+void
 DatasetJS::
-getColumnNames(const v8::Arguments & args)
+getColumnNames(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Dataset * dataset = getShared(args.This());
 
-        return JS::toJS(dataset->getColumnIndex()->getColumnNames());
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(JS::toJS(dataset->getColumnIndex()->getColumnNames()));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
-v8::Handle<v8::Value>
+void
 DatasetJS::
-getTimestampRange(const v8::Arguments & args)
+getTimestampRange(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Dataset * dataset = getShared(args.This());
-        return JS::toJS(dataset->getTimestampRange());
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(JS::toJS(dataset->getTimestampRange()));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
 } // namespace MLDB

--- a/plugins/lang/js/dataset_js.h
+++ b/plugins/lang/js/dataset_js.h
@@ -33,38 +33,38 @@ struct DatasetJS: public JsObjectBase {
     static v8::Local<v8::FunctionTemplate>
     registerMe();
 
-    static v8::Handle<v8::Value>
-    recordRow(const v8::Arguments & args);
+    static void
+    recordRow(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    recordRows(const v8::Arguments & args);
+    static void
+    recordRows(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    recordColumn(const v8::Arguments & args);
+    static void
+    recordColumn(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    recordColumns(const v8::Arguments & args);
+    static void
+    recordColumns(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    commit(const v8::Arguments & args);
+    static void
+    commit(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    status(const v8::Arguments & args);
+    static void
+    status(const v8::FunctionCallbackInfo<v8::Value> & args);
     
-    static v8::Handle<v8::Value>
-    id(const v8::Arguments & args);
+    static void
+    id(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    type(const v8::Arguments & args);
+    static void
+    type(const v8::FunctionCallbackInfo<v8::Value> & args);
     
-    static v8::Handle<v8::Value>
-    config(const v8::Arguments & args);
+    static void
+    config(const v8::FunctionCallbackInfo<v8::Value> & args);
     
-    static v8::Handle<v8::Value>
-    getColumnNames(const v8::Arguments & args);
+    static void
+    getColumnNames(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    getTimestampRange(const v8::Arguments & args);
+    static void
+    getTimestampRange(const v8::FunctionCallbackInfo<v8::Value> & args);
 };
 
 } // namespace MLDB

--- a/plugins/lang/js/function_js.cc
+++ b/plugins/lang/js/function_js.cc
@@ -24,7 +24,8 @@ v8::Handle<v8::Object>
 FunctionJS::
 create(std::shared_ptr<Function> function, JsPluginContext * context)
 {
-    auto obj = context->Function->GetFunction()->NewInstance();
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    auto obj = context->Function.Get(isolate)->GetFunction()->NewInstance();
     auto * wrapped = new FunctionJS();
     wrapped->function = function;
     wrapped->wrap(obj, context);
@@ -46,80 +47,87 @@ registerMe()
 {
     using namespace v8;
 
-    HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    EscapableHandleScope scope(isolate);
 
     auto fntmpl = CreateFunctionTemplate("Function");
     auto prototmpl = fntmpl->PrototypeTemplate();
 
-    prototmpl->Set(String::New("status"), FunctionTemplate::New(status));
-    prototmpl->Set(String::New("details"), FunctionTemplate::New(details));
-    prototmpl->Set(String::New("id"), FunctionTemplate::New(id));
-    prototmpl->Set(String::New("type"), FunctionTemplate::New(type));
-    prototmpl->Set(String::New("config"), FunctionTemplate::New(config));
-    prototmpl->Set(String::New("call"), FunctionTemplate::New(call));
+    prototmpl->Set(String::NewFromUtf8(isolate, "status"),
+                   FunctionTemplate::New(isolate, status));
+    prototmpl->Set(String::NewFromUtf8(isolate, "details"),
+                   FunctionTemplate::New(isolate, details));
+    prototmpl->Set(String::NewFromUtf8(isolate, "id"),
+                   FunctionTemplate::New(isolate, id));
+    prototmpl->Set(String::NewFromUtf8(isolate, "type"),
+                   FunctionTemplate::New(isolate, type));
+    prototmpl->Set(String::NewFromUtf8(isolate, "config"),
+                   FunctionTemplate::New(isolate, config));
+    prototmpl->Set(String::NewFromUtf8(isolate, "call"),
+                   FunctionTemplate::New(isolate, call));
+    
+    return scope.Escape(fntmpl);
+}
+
+
+void
+FunctionJS::
+status(const v8::FunctionCallbackInfo<v8::Value> & args)
+{
+    try {
+        Function * function = getShared(args.This());
+            
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(function->getStatus())));
+    } HANDLE_JS_EXCEPTIONS(args);
+}
+    
+void
+FunctionJS::
+details(const v8::FunctionCallbackInfo<v8::Value> & args)
+{
+    try {
+        Function * function = getShared(args.This());
+            
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(function->getDetails())));
+    } HANDLE_JS_EXCEPTIONS(args);
+}
+
+void
+FunctionJS::
+id(const v8::FunctionCallbackInfo<v8::Value> & args)
+{
+    try {
+        Function * function = getShared(args.This());
+            
+        args.GetReturnValue().Set(JS::toJS(function->getId()));
+    } HANDLE_JS_EXCEPTIONS(args);
+}
+    
+void
+FunctionJS::
+type(const v8::FunctionCallbackInfo<v8::Value> & args)
+{
+    try {
+        Function * function = getShared(args.This());
+            
+        args.GetReturnValue().Set(JS::toJS(function->getType()));
+    } HANDLE_JS_EXCEPTIONS(args);
+}
+    
+void
+FunctionJS::
+config(const v8::FunctionCallbackInfo<v8::Value> & args)
+{
+    try {
+        Function * function = getShared(args.This());
         
-    return scope.Close(fntmpl);
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(function->getConfig())));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
-
-v8::Handle<v8::Value>
+void
 FunctionJS::
-status(const v8::Arguments & args)
-{
-    try {
-        Function * function = getShared(args.This());
-            
-        return JS::toJS(jsonEncode(function->getStatus()));
-    } HANDLE_JS_EXCEPTIONS;
-}
-    
-v8::Handle<v8::Value>
-FunctionJS::
-details(const v8::Arguments & args)
-{
-    try {
-        Function * function = getShared(args.This());
-            
-        return JS::toJS(jsonEncode(function->getDetails()));
-    } HANDLE_JS_EXCEPTIONS;
-}
-
-v8::Handle<v8::Value>
-FunctionJS::
-id(const v8::Arguments & args)
-{
-    try {
-        Function * function = getShared(args.This());
-            
-        return JS::toJS(function->getId());
-    } HANDLE_JS_EXCEPTIONS;
-}
-    
-v8::Handle<v8::Value>
-FunctionJS::
-type(const v8::Arguments & args)
-{
-    try {
-        Function * function = getShared(args.This());
-            
-        return JS::toJS(function->getType());
-    } HANDLE_JS_EXCEPTIONS;
-}
-    
-v8::Handle<v8::Value>
-FunctionJS::
-config(const v8::Arguments & args)
-{
-    try {
-        Function * function = getShared(args.This());
-        
-        return JS::toJS(jsonEncode(function->getConfig()));
-    } HANDLE_JS_EXCEPTIONS;
-}
-
-v8::Handle<v8::Value>
-FunctionJS::
-call(const v8::Arguments & args)
+call(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         JsContextScope scope(args.This());
@@ -137,9 +145,9 @@ call(const v8::Arguments & args)
 
         auto result = function->call(std::move(row));
         
-        return JS::toJS(jsonEncode(result));
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(result)));
 
-    } HANDLE_JS_EXCEPTIONS;
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
 } // namespace MLDB

--- a/plugins/lang/js/function_js.h
+++ b/plugins/lang/js/function_js.h
@@ -33,23 +33,23 @@ struct FunctionJS: public JsObjectBase {
     static v8::Local<v8::FunctionTemplate>
     registerMe();
 
-    static v8::Handle<v8::Value>
-    status(const v8::Arguments & args);
+    static void
+    status(const v8::FunctionCallbackInfo<v8::Value> & args);
     
-    static v8::Handle<v8::Value>
-    details(const v8::Arguments & args);
+    static void
+    details(const v8::FunctionCallbackInfo<v8::Value> & args);
     
-    static v8::Handle<v8::Value>
-    id(const v8::Arguments & args);
+    static void
+    id(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    type(const v8::Arguments & args);
+    static void
+    type(const v8::FunctionCallbackInfo<v8::Value> & args);
     
-    static v8::Handle<v8::Value>
-    config(const v8::Arguments & args);
+    static void
+    config(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    call(const v8::Arguments & args);
+    static void
+    call(const v8::FunctionCallbackInfo<v8::Value> & args);
 };
 
 } // namespace MLDB

--- a/plugins/lang/js/js_common.h
+++ b/plugins/lang/js/js_common.h
@@ -7,7 +7,7 @@
     Common code for JS handling.
 */
 
-#include "v8/v8.h"
+#include "mldb/ext/v8-cross-build-output/include/v8.h"
 #include "js_utils.h"
 #include "mldb/types/value_description.h"
 #include "mldb/logging/logging.h"

--- a/plugins/lang/js/js_common.h
+++ b/plugins/lang/js/js_common.h
@@ -7,7 +7,7 @@
     Common code for JS handling.
 */
 
-#include <v8.h>
+#include "v8/v8.h"
 #include "js_utils.h"
 #include "mldb/types/value_description.h"
 #include "mldb/logging/logging.h"
@@ -218,16 +218,17 @@ public:
         references to it in the javascript. */
     void registerForGarbageCollection();
     
-    static v8::Handle<v8::Value>
-    NoConstructor(const v8::Arguments & args);
+    static void
+    NoConstructor(const v8::FunctionCallbackInfo<v8::Value> & args);
 
     static v8::Handle<v8::FunctionTemplate>
     CreateFunctionTemplate(const char * name,
-                           v8::InvocationCallback constructor = NoConstructor);
+                           v8::FunctionCallback constructor = NoConstructor);
     
 private:
     // Called back once an object is garbage collected.
-    static void garbageCollectionCallback(v8::Persistent<v8::Value> value, void *data);
+    static void
+    garbageCollectionCallback(const v8::WeakCallbackInfo<JsObjectBase> & info);
 };
 
 } // namespace MLDB

--- a/plugins/lang/js/js_common.h
+++ b/plugins/lang/js/js_common.h
@@ -33,6 +33,12 @@ struct LoadedPluginResource;
 extern Logging::Category mldbJsCategory;
 
 struct JsIsolate {
+    JsIsolate()
+        : isolate(nullptr)
+    {
+        // not initialized
+    }
+
     JsIsolate(bool forThisThreadOnly)
     {
         init(forThisThreadOnly);
@@ -68,7 +74,7 @@ struct JsIsolate {
 };
 
 struct V8Init {
-    V8Init();
+    V8Init(MldbServer * server);
 };
 
 void to_js(JS::JSValue & value, const CellValue & val);

--- a/plugins/lang/js/js_function.cc
+++ b/plugins/lang/js/js_function.cc
@@ -17,7 +17,6 @@
 
 using namespace std;
 
-#if 0
 namespace Datacratic {
 namespace MLDB {
 
@@ -79,33 +78,46 @@ initialize(const JsFunctionData & data)
 
     // Enter the created context for compiling and
     // running the hello world script. 
-    Context::Scope context_scope(this->context);
+    Context::Scope context_scope(this->context.Get(this->isolate->isolate));
 
     // Add the mldb object to the context
     auto mldb = MldbJS::registerMe()->NewInstance();
-    mldb->SetInternalField(0, v8::External::New(isolate, data.server));
-    mldb->SetInternalField(1, v8::External::New(isolate, data.context.get()));
-    this->context->Global()->Set(String::NewFromUtf8(isolate, "mldb"), mldb);
-
+    mldb->SetInternalField(0, v8::External::New(this->isolate->isolate,
+                                                data.server));
+    mldb->SetInternalField(1, v8::External::New(this->isolate->isolate,
+                                                data.context.get()));
+    this->context.Get(this->isolate->isolate)
+        ->Global()
+        ->Set(String::NewFromUtf8(this->isolate->isolate,
+                                 "mldb"), mldb);
+    
     Utf8String jsFunctionSource = data.scriptSource;
 
     // Create a string containing the JavaScript source code.
-    Handle<String> source = String::NewFromUtf8(isolate, jsFunctionSource.rawString().c_str());
+    Handle<String> source
+        = String::NewFromUtf8(this->isolate->isolate,
+                              jsFunctionSource.rawString().c_str());
 
     TryCatch trycatch;
     //trycatch.SetVerbose(true);
 
     // This is equivalent to fntocall = new Function('arg1', ..., 'script');
-    v8::Local<v8::Object> function
-        = v8::Local<v8::Object>::Cast(this->context->Global()->Get(v8::String::New(isolate, "Function")));
-
+    auto function
+        = this->context.Get(this->isolate->isolate)
+        ->Global()
+        ->Get(v8::String::NewFromUtf8(this->isolate->isolate, "Function"))
+        .As<v8::Object>();
+    
     std::vector<v8::Handle<v8::Value> > argv;
     for (unsigned i = 0;  i != data.params.size();  ++i)
-        argv.push_back(v8::String::New(data.params[i].c_str()));
+        argv.push_back(v8::String::NewFromUtf8(this->isolate->isolate,
+                                               data.params[i].c_str()));
     argv.push_back(source);
 
-    v8::Local<v8::Function> compiled
-        = v8::Local<v8::Function>::Cast(function->CallAsConstructor(argv.size(), &argv[0]));
+    v8::Local<v8::Function> compiled 
+        = function->CallAsConstructor(argv.size(), &argv[0])
+        .As<v8::Function>();
+
     if (compiled.IsEmpty()) {  
         auto rep = convertException(trycatch, "Compiling jseval script");
         JML_TRACE_EXCEPTIONS(false);
@@ -115,7 +127,7 @@ initialize(const JsFunctionData & data)
                                   "provenance", data.filenameForErrorMessages);
     }
 
-    this->function = v8::Persistent<v8::Function>::New(compiled);
+    this->function.Reset(this->isolate->isolate, compiled);
 }
 
 ExpressionValue
@@ -130,11 +142,11 @@ run(const std::vector<ExpressionValue> & args,
     //v8::Locker locker(this->isolate->isolate);
     v8::Isolate::Scope isolate(this->isolate->isolate);
 
-    HandleScope handle_scope;
+    HandleScope handle_scope(this->isolate->isolate);
 
     // Enter the created context for compiling and
     // running the hello world script. 
-    Context::Scope context_scope(this->context);
+    Context::Scope context_scope(this->context.Get(this->isolate->isolate));
 
     Date ts = Date::negativeInfinity();
 
@@ -154,8 +166,10 @@ run(const std::vector<ExpressionValue> & args,
     TryCatch trycatch;
     //trycatch.SetVerbose(true);
 
-    auto result = this->function->Call(this->context->Global(), argv.size(), &argv[0]);
-
+    auto result = this->function.Get(this->isolate->isolate)
+        ->Call(this->context.Get(this->isolate->isolate)->Global(),
+               argv.size(), &argv[0]);
+    
     if (result.IsEmpty()) {  
         auto rep = convertException(trycatch, "Running jseval script");
         JML_TRACE_EXCEPTIONS(false);
@@ -245,4 +259,3 @@ RegisterFunction registerJs(Utf8String("jseval"), bindJsEval);
 
 } // namespace Datacratic
 } // namespace MLDB
-#endif

--- a/plugins/lang/js/js_loader.cc
+++ b/plugins/lang/js/js_loader.cc
@@ -30,8 +30,6 @@
 
 #include <boost/algorithm/string.hpp>
 
-#if 0
-
 using namespace std;
 
 
@@ -82,28 +80,29 @@ struct JsPluginJS {
     static v8::Local<v8::ObjectTemplate>
     registerMe()
     {
+        v8::Isolate* isolate = v8::Isolate::GetCurrent();
         using namespace v8;
 
-        HandleScope scope;
+        EscapableHandleScope scope(isolate);
 
-        v8::Local<v8::ObjectTemplate> result(ObjectTemplate::New());
+        v8::Local<v8::ObjectTemplate> result(ObjectTemplate::New(isolate));
 
         result->SetInternalFieldCount(2);
 
-        result->Set(String::New("log"),
-                                   FunctionTemplate::New(log));
-        result->Set(String::New("setStatusHandler"),
-                    FunctionTemplate::New(setStatusHandler));
-        result->Set(String::New("setRequestHandler"),
-                    FunctionTemplate::New(setRequestHandler));
-        result->Set(String::New("serveStaticFolder"),
-                    FunctionTemplate::New(serveStaticFolder));
-        result->Set(String::New("serveDocumentationFolder"),
-                    FunctionTemplate::New(serveDocumentationFolder));
-        result->Set(String::New("getPluginDir"),
-                    FunctionTemplate::New(getPluginDir));
+        result->Set(String::NewFromUtf8(isolate, "log"),
+                    FunctionTemplate::New(isolate, log));
+        result->Set(String::NewFromUtf8(isolate, "setStatusHandler"),
+                    FunctionTemplate::New(isolate, setStatusHandler));
+        result->Set(String::NewFromUtf8(isolate, "setRequestHandler"),
+                    FunctionTemplate::New(isolate, setRequestHandler));
+        result->Set(String::NewFromUtf8(isolate, "serveStaticFolder"),
+                    FunctionTemplate::New(isolate, serveStaticFolder));
+        result->Set(String::NewFromUtf8(isolate, "serveDocumentationFolder"),
+                    FunctionTemplate::New(isolate, serveDocumentationFolder));
+        result->Set(String::NewFromUtf8(isolate, "getPluginDir"),
+                    FunctionTemplate::New(isolate, getPluginDir));
         
-        return scope.Close(result);
+        return scope.Escape(result);
     }
 
     static JsPluginContext * getShared(const v8::Handle<v8::Object> & val)
@@ -113,8 +112,8 @@ struct JsPluginJS {
          (val->GetInternalField(0))->Value());
     }
 
-    static v8::Handle<v8::Value>
-    log(const v8::Arguments & args)
+    static void
+    log(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         using namespace v8;
         auto itl = getShared(args.This());
@@ -149,12 +148,12 @@ struct JsPluginJS {
                 itl->logs.emplace_back(Date::now(), "logs", Utf8String(line));
             }
 
-            return args.This();
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(args.This());
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    setStatusHandler(const v8::Arguments & args)
+    static void
+    setStatusHandler(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             if (args.Length() < 1)
@@ -171,19 +170,23 @@ struct JsPluginJS {
 
             std::shared_ptr<Args> shargs(new Args());
 
-            shargs->fn = v8::Persistent<v8::Function>::New(v8::Handle<v8::Function>(v8::Function::Cast(*args[0])));
-            shargs->self = v8::Persistent<v8::Object>::New(args.This());
+            shargs->fn.Reset(itl->isolate.isolate,
+                             args[0].As<v8::Function>());
+            shargs->self.Reset(itl->isolate.isolate,
+                               args.This());
             
             auto getStatus = [itl,shargs] () -> Json::Value
                 {
                     v8::Locker locker(itl->isolate.isolate);
                     v8::Isolate::Scope isolate(itl->isolate.isolate);
-                    v8::HandleScope handle_scope;
-                    v8::Context::Scope context_scope(itl->context);
+                    v8::HandleScope handle_scope(itl->isolate.isolate);
+                    v8::Context::Scope context_scope(itl->context.Get(itl->isolate.isolate));
 
                     v8::TryCatch trycatch;
                     trycatch.SetVerbose(true);
-                    auto result = shargs->fn->Call(shargs->self, 0, nullptr);
+                    auto result = shargs->fn.Get(itl->isolate.isolate)
+                        ->Call(shargs->self.Get(itl->isolate.isolate),
+                               0, nullptr);
 
                     if (result.IsEmpty()) {
                         ScriptException exc = convertException(trycatch,
@@ -208,12 +211,12 @@ struct JsPluginJS {
 
             cerr << "done setting status" << endl;
 
-            return args.This();
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(args.This());
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    serveStaticFolder(const v8::Arguments & args)
+    static void
+    serveStaticFolder(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             if (args.Length() < 1)
@@ -229,12 +232,12 @@ struct JsPluginJS {
                                  getStaticRouteHandler(dir, itl->server),
                                  Json::Value());
 
-            return args.This();
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(args.This());
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    serveDocumentationFolder(const v8::Arguments & args)
+    static void
+    serveDocumentationFolder(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             if (args.Length() < 1)
@@ -247,23 +250,23 @@ struct JsPluginJS {
 
             serveDocumentationDirectory(itl->router, route, dir, itl->server);
 
-            return args.This();
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(args.This());
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    getPluginDir(const v8::Arguments & args)
+    static void
+    getPluginDir(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             JsPluginContext * itl = getShared(args.This());
 
-            return JS::toJS(itl->pluginResource->getPluginDir().string());
+            args.GetReturnValue().Set(JS::toJS(itl->pluginResource->getPluginDir().string()));
 
-        } HANDLE_JS_EXCEPTIONS;
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    setRequestHandler(const v8::Arguments & args)
+    static void
+    setRequestHandler(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             if (args.Length() < 1)
@@ -280,18 +283,21 @@ struct JsPluginJS {
 
             std::shared_ptr<Args> shargs(new Args());
 
-            shargs->fn = v8::Persistent<v8::Function>::New(v8::Handle<v8::Function>(v8::Function::Cast(*args[0])));
-            shargs->self = v8::Persistent<v8::Object>::New(args.This());
+            shargs->fn.Reset(args.GetIsolate(),
+                             args[0].As<v8::Function>());
+            shargs->self.Reset(args.GetIsolate(), args.This());
             
-            auto handleRequest = [itl,shargs] (RestConnection & connection,
-                                                  const RestRequest & request,
-                                                  RestRequestParsingContext & context)
+            auto handleRequest
+                = [itl,shargs] (RestConnection & connection,
+                                const RestRequest & request,
+                                RestRequestParsingContext & context)
                 -> RestRequestMatchResult
                 {
                     v8::Locker locker(itl->isolate.isolate);
                     v8::Isolate::Scope isolate(itl->isolate.isolate);
-                    v8::HandleScope handle_scope;
-                    v8::Context::Scope context_scope(itl->context);
+                    v8::HandleScope handle_scope(itl->isolate.isolate);
+                    v8::Context::Scope context_scope
+                        (itl->context.Get(itl->isolate.isolate));
 
                     // Create some context
                     v8::Handle<v8::Value> args[8] = {
@@ -308,7 +314,8 @@ struct JsPluginJS {
 
                     v8::TryCatch trycatch;
                     trycatch.SetVerbose(true);
-                    auto result = shargs->fn->Call(shargs->self, 8, args);
+                    auto result = shargs->fn.Get(itl->isolate.isolate)
+                        ->Call(shargs->self.Get(itl->isolate.isolate), 8, args);
 
                     if (result.IsEmpty()) {
                         ScriptException exc = convertException(trycatch,
@@ -331,8 +338,8 @@ struct JsPluginJS {
 
             itl->handleRequest = handleRequest;
 
-            return args.This();
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(args.This());
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 };
 
@@ -345,8 +352,7 @@ JsPluginContext::
 JsPluginContext(const Utf8String & pluginName,
                 MldbServer * server,
                 std::shared_ptr<LoadedPluginResource> pluginResource)
-    : isolate(false /* for this thread only */),
-      categoryName(pluginName.rawString() + " plugin"),
+    : categoryName(pluginName.rawString() + " plugin"),
       loaderName(pluginName.rawString() + " loader"),
       category(categoryName.c_str()),
       loader(loaderName.c_str()),
@@ -355,41 +361,48 @@ JsPluginContext(const Utf8String & pluginName,
 {
     using namespace v8;
 
+    static V8Init v8Init(server);
+
+    isolate.init(false /* for this thread only */);
+
     v8::Locker locker(this->isolate.isolate);
     v8::Isolate::Scope isolate(this->isolate.isolate);
 
-    HandleScope handle_scope;
+    HandleScope handle_scope(this->isolate.isolate);
 
     // Create a new context.
-    context = v8::Persistent<v8::Context>::New(Context::New());
-
+    context.Reset(this->isolate.isolate,
+                  Context::New(this->isolate.isolate));
+    
     // Enter the created context for compiling and
     // running the hello world script. 
-    Context::Scope context_scope(context);
+    Context::Scope context_scope(context.Get(this->isolate.isolate));
     
     // This is how we set it
     // https://code.google.com/p/v8/issues/detail?id=54
     v8::Local<v8::Object> globalPrototype
-        = v8::Local<v8::Object>::Cast(context->Global()->GetPrototype());
-
+        = context.Get(this->isolate.isolate)->Global()
+        ->GetPrototype().As<v8::Object>();
+    
     auto plugin = JsPluginJS::registerMe()->NewInstance();
-    plugin->SetInternalField(0, v8::External::New(this));
-    plugin->SetInternalField(1, v8::External::New(this));
+    plugin->SetInternalField(0, v8::External::New(this->isolate.isolate, this));
+    plugin->SetInternalField(1, v8::External::New(this->isolate.isolate, this));
     if (pluginResource)
-        plugin->Set(String::New("args"), JS::toJS(jsonEncode(pluginResource->args)));
-    globalPrototype->Set(String::New("plugin"), plugin);
+        plugin->Set(String::NewFromUtf8(this->isolate.isolate, "args"), JS::toJS(jsonEncode(pluginResource->args)));
+    globalPrototype->Set(String::NewFromUtf8(this->isolate.isolate, "plugin"), plugin);
 
     auto mldb = MldbJS::registerMe()->NewInstance();
-    mldb->SetInternalField(0, v8::External::New(this->server));
-    mldb->SetInternalField(1, v8::External::New(this));
-    globalPrototype->Set(String::New("mldb"), mldb);
+    mldb->SetInternalField(0, v8::External::New(this->isolate.isolate, this->server));
+    mldb->SetInternalField(1, v8::External::New(this->isolate.isolate, this));
+    globalPrototype->Set(String::NewFromUtf8(this->isolate.isolate, "mldb"), mldb);
 
-    Stream = v8::Persistent<v8::FunctionTemplate>::New(StreamJS::registerMe());
-    Dataset = v8::Persistent<v8::FunctionTemplate>::New(DatasetJS::registerMe());
-    Function = v8::Persistent<v8::FunctionTemplate>::New(FunctionJS::registerMe());
-    Procedure = v8::Persistent<v8::FunctionTemplate>::New(ProcedureJS::registerMe());
-    CellValue = v8::Persistent<v8::FunctionTemplate>::New(CellValueJS::registerMe());
-    RandomNumberGenerator = v8::Persistent<v8::FunctionTemplate>::New(RandomNumberGeneratorJS::registerMe());
+    Stream.Reset(this->isolate.isolate, StreamJS::registerMe());
+    Dataset.Reset(this->isolate.isolate, DatasetJS::registerMe());
+    Function.Reset(this->isolate.isolate, FunctionJS::registerMe());
+    Procedure.Reset(this->isolate.isolate, ProcedureJS::registerMe());
+    CellValue.Reset(this->isolate.isolate, CellValueJS::registerMe());
+    RandomNumberGenerator.Reset(this->isolate.isolate,
+                                RandomNumberGeneratorJS::registerMe());
 }
 
 JsPluginContext::
@@ -411,8 +424,6 @@ JavascriptPlugin(MldbServer * server,
 {
     using namespace v8;
 
-    static V8Init v8Init;
-
     PluginResource res = config.params.convert<PluginResource>();
     itl.reset(new JsPluginContext(config.id, this->server,
                                   std::make_shared<LoadedPluginResource>
@@ -426,18 +437,21 @@ JavascriptPlugin(MldbServer * server,
     v8::Locker locker(itl->isolate.isolate);
     v8::Isolate::Scope isolate(itl->isolate.isolate);
 
-    HandleScope handle_scope;
-    Context::Scope context_scope(itl->context);
+    HandleScope handle_scope(itl->isolate.isolate);
+    Context::Scope context_scope(itl->context.Get(itl->isolate.isolate));
     
     // Create a string containing the JavaScript source code.
-    Handle<String> source = String::New(jsFunctionSource.rawData(),
-                                        jsFunctionSource.rawLength());
+    Handle<String> source
+        = String::NewFromUtf8(itl->isolate.isolate, jsFunctionSource.rawData());
 
     // Compile the source code.
     TryCatch trycatch;
     trycatch.SetVerbose(true);
 
-    auto script = Script::Compile(source, v8::String::New(itl->pluginResource->getFilenameForErrorMessages().c_str()));
+    auto script = Script::Compile
+        (source,
+         v8::String::NewFromUtf8(itl->isolate.isolate,
+                                 itl->pluginResource->getFilenameForErrorMessages().c_str()));
     
     if (script.IsEmpty()) {  
         auto rep = convertException(trycatch, "Compiling plugin script");
@@ -451,10 +465,10 @@ JavascriptPlugin(MldbServer * server,
         throw HttpReturnException(400, "Exception compiling plugin script", rep);
     }
 
-    itl->script = v8::Persistent<v8::Script>::New(script);
+    itl->script.Reset(itl->isolate.isolate, script);
 
     // Run the script to get the result.
-    Handle<Value> result = itl->script->Run();
+    Handle<Value> result = itl->script.Get(itl->isolate.isolate)->Run();
 
     if (result.IsEmpty()) {  
         auto rep = convertException(trycatch, "Running plugin script");
@@ -554,22 +568,24 @@ runJavascriptScript(MldbServer * server,
     v8::Locker locker(itl->isolate.isolate);
     v8::Isolate::Scope isolate(itl->isolate.isolate);
 
-    HandleScope handle_scope;
-    Context::Scope context_scope(itl->context);
+    HandleScope handle_scope(itl->isolate.isolate);
+    Context::Scope context_scope(itl->context.Get(itl->isolate.isolate));
         
     v8::Local<v8::Object> globalPrototype
-        = v8::Local<v8::Object>::Cast(itl->context->Global()->GetPrototype());
-    globalPrototype->Set(String::New("args"), JS::toJS(jsonEncode(scriptConfig.args)));
+        = itl->context.Get(itl->isolate.isolate)
+        ->Global()->GetPrototype().As<v8::Object>();
+    globalPrototype->Set(String::NewFromUtf8(itl->isolate.isolate, "args"),
+                         JS::toJS(jsonEncode(scriptConfig.args)));
 
     // Create a string containing the JavaScript source code.
-    Handle<String> source = String::New(jsFunctionSource.rawData(),
-                                        jsFunctionSource.rawLength());
-
+    auto source
+        = String::NewFromUtf8(itl->isolate.isolate, jsFunctionSource.rawData());
+    
     // Compile the source code.
     TryCatch trycatch;
     trycatch.SetVerbose(true);
 
-    auto script = Script::Compile(source, v8::String::New(scriptConfig.address.c_str()));
+    auto script = Script::Compile(source, v8::String::NewFromUtf8(itl->isolate.isolate, scriptConfig.address.c_str()));
     
     ScriptOutput result;
             
@@ -584,10 +600,11 @@ runJavascriptScript(MldbServer * server,
         result.exception.reset(new ScriptException(std::move(rep)));
     }
     else {
-        itl->script = v8::Persistent<v8::Script>::New(script);
+        itl->script.Reset(itl->isolate.isolate, script);
             
         // Run the script to get the result.
-        Handle<Value> scriptResult = itl->script->Run();
+        Handle<Value> scriptResult
+            = itl->script.Get(itl->isolate.isolate)->Run();
             
         if (scriptResult.IsEmpty()) {  
             auto rep = convertException(trycatch, "Running script");
@@ -625,5 +642,3 @@ regJavascript(builtinPackage(),
 
 } // namespace MLDB
 } // namespace Datacratic
-
-#endif

--- a/plugins/lang/js/js_loader.cc
+++ b/plugins/lang/js/js_loader.cc
@@ -24,11 +24,13 @@
 #include "dataset_js.h"
 #include "function_js.h"
 #include "procedure_js.h"
-#include <v8.h>
+#include "v8/v8.h"
 
 #include "mldb/types/string.h"
 
 #include <boost/algorithm/string.hpp>
+
+#if 0
 
 using namespace std;
 
@@ -623,3 +625,5 @@ regJavascript(builtinPackage(),
 
 } // namespace MLDB
 } // namespace Datacratic
+
+#endif

--- a/plugins/lang/js/js_loader.cc
+++ b/plugins/lang/js/js_loader.cc
@@ -24,7 +24,7 @@
 #include "dataset_js.h"
 #include "function_js.h"
 #include "procedure_js.h"
-#include "v8/v8.h"
+#include "mldb/ext/v8-cross-build-output/include/v8.h"
 
 #include "mldb/types/string.h"
 

--- a/plugins/lang/js/js_utils.h
+++ b/plugins/lang/js/js_utils.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "v8/v8.h"
+#include "mldb/ext/v8-cross-build-output/include/v8.h"
 #include <string>
 #include "mldb/arch/exception.h"
 #include "mldb/base/exc_assert.h"

--- a/plugins/lang/js/js_utils.h
+++ b/plugins/lang/js/js_utils.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <v8.h>
+#include "v8/v8.h"
 #include <string>
 #include "mldb/arch/exception.h"
 #include "mldb/base/exc_assert.h"
@@ -48,11 +48,6 @@ std::string cstr(const std::string & str);
 std::string cstr(const JSValue & val);
 
 Utf8String utf8str(const JSValue & val);
-template<typename T>
-std::string cstr(const v8::Local<T> & str)
-{
-    return cstr(JSValue(str));
-}
 
 template<typename T>
 std::string cstr(const v8::Handle<T> & str)
@@ -85,9 +80,10 @@ v8::Handle<v8::Value> injectBacktrace(v8::Handle<v8::Value> value);
 
 /** Macro to use after a try { block to catch and translate javascript
     exceptions. */
-#define HANDLE_JS_EXCEPTIONS                                    \
+#define HANDLE_JS_EXCEPTIONS(args)                              \
     catch (...) {                                               \
-        return Datacratic::JS::translateCurrentException();     \
+        args.GetReturnValue().Set(Datacratic::JS::translateCurrentException()); \
+        return;                                                         \
     }
 
 #define HANDLE_JS_EXCEPTIONS_SETTER                             \
@@ -128,7 +124,7 @@ toArray(v8::Handle<v8::Value> handle)
     ExcAssert(!handle.IsEmpty());
     if (!handle->IsArray())
         throw ML::Exception("value " + cstr(handle) + " is not an array");
-    v8::Handle<v8::Array> array(v8::Array::Cast(*handle));
+    auto array = handle.As<v8::Array>();
     if (array.IsEmpty())
         throw ML::Exception("value " + cstr(handle) + " is not an array");
     return array;
@@ -146,47 +142,52 @@ toJS(const T & t)
 template<typename T>
 void to_js(JSValue & val, const std::vector<T> & v)
 {
-    v8::HandleScope scope;
-    v8::Local<v8::Array> arr(v8::Array::New(v.size()));
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
+    v8::Handle<v8::Array> arr(v8::Array::New(isolate, v.size()));
     for (unsigned i = 0;  i < v.size();  ++i)
-        arr->Set(v8::Uint32::New(i), toJS(v[i]));
-    val = scope.Close(arr);
+        arr->Set(v8::Uint32::New(isolate, i), toJS(v[i]));
+    val = scope.Escape(arr);
 }
 
 template<typename T, std::size_t SIZE>
 void to_js(JSValue & val, const std::array<T, SIZE> & v)
 {
-    v8::HandleScope scope;
-    v8::Local<v8::Array> arr(v8::Array::New(v.size()));
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
+    v8::Local<v8::Array> arr(v8::Array::New(isolate, v.size()));
     for (unsigned i = 0;  i < v.size();  ++i)
-        arr->Set(v8::Uint32::New(i), toJS(v[i]));
-    val = scope.Close(arr);
+        arr->Set(v8::Uint32::New(isolate, i), toJS(v[i]));
+    val = scope.Escape(arr);
 }
 
 template<typename T>
 void to_js(JSValue & val, const std::set<T> & s)
 {
-    v8::HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
     v8::Local<v8::Array> arr(v8::Array::New(s.size()));
     int count = 0;
     for(auto i = s.begin(); i != s.end(); ++i)
     {
-        arr->Set(v8::Uint32::New(count), toJS(*i));
+        arr->Set(v8::Uint32::New(isolate, count), toJS(*i));
         count++;
     }
-    val = scope.Close(arr);
+    val = scope.Escape(arr);
 }
 
 template<typename T>
 void to_js(JSValue & val, const std::map<std::string, T> & s)
 {
-    v8::HandleScope scope;
-    v8::Local<v8::Object> obj= v8::Object::New();
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
+    v8::Local<v8::Object> obj= v8::Object::New(isolate);
     for(auto i = s.begin(); i != s.end(); ++i)
     {
-        obj->Set(v8::String::NewSymbol(i->first.c_str()), toJS(i->second));
+        obj->Set(v8::String::NewFromUtf8(isolate, i->first.c_str()),
+                 toJS(i->second));
     }
-    val = scope.Close(obj);
+    val = scope.Escape(obj);
 }
 
 template<typename T>
@@ -199,7 +200,8 @@ from_js(const JSValue & val, const std::map<std::string, T> * = 0)
     
     std::map<std::string, T> result;
 
-    v8::HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(isolate);
 
     auto objPtr = v8::Object::Cast(*val);
 
@@ -219,14 +221,15 @@ from_js(const JSValue & val, const std::map<std::string, T> * = 0)
 template<typename T, typename Str>
 void to_js(JSValue & val, const std::map<Utf8String, T> & s)
 {
-    v8::HandleScope scope;
-    v8::Local<v8::Object> obj= v8::Object::New();
-    for(auto i = s.begin(); i != s.end(); ++i)
-    {
-        obj->Set(v8::String::NewSymbol(i->first.rawData(), i->first.rawLength()),
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
+    v8::Local<v8::Object> obj= v8::Object::New(isolate);
+    for(auto i = s.begin(); i != s.end(); ++i) {
+        obj->Set(v8::String::NewFromUtf8(i->first.rawData(),
+                                         i->first.rawLength()),
                  toJS(i->second));
     }
-    val = scope.Close(obj);
+    val = scope.Escape(obj);
 }
 
 template<typename T>
@@ -239,7 +242,8 @@ from_js(const JSValue & val, const std::map<Utf8String, T> * = 0)
     
     std::map<Utf8String, T> result;
 
-    v8::HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(isolate);
 
     auto objPtr = v8::Object::Cast(*val);
 
@@ -259,25 +263,27 @@ from_js(const JSValue & val, const std::map<Utf8String, T> * = 0)
 template<typename T>
 void to_js(JSValue & val, const std::unordered_map<std::string, T> & s)
 {
-    v8::HandleScope scope;
-    v8::Local<v8::Object> obj= v8::Object::New();
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
+    v8::Local<v8::Object> obj= v8::Object::New(isolate);
     for(auto i = s.begin(); i != s.end(); ++i)
     {
-        obj->Set(v8::String::NewSymbol(i->first.c_str()), toJS(i->second));
+        obj->Set(v8::String::NewFromUtf8(i->first.c_str()), toJS(i->second));
     }
-    val = scope.Close(obj);
+    val = scope.Escape(obj);
 }
 
 template<typename K, typename V, typename H>
 void to_js(JSValue & val, const std::unordered_map<K, V, H> & s)
 {
-    v8::HandleScope scope;
-    v8::Local<v8::Object> obj= v8::Object::New();
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
+    v8::Local<v8::Object> obj= v8::Object::New(isolate);
     for(auto i = s.begin(); i != s.end(); ++i)
     {
         obj->Set(toJS(i->first), toJS(i->second));
     }
-    val = scope.Close(obj);
+    val = scope.Escape(obj);
 }
 
 template<typename K, typename V, typename H>
@@ -290,7 +296,8 @@ from_js(const JSValue & val, const std::map<K, V, H> * = 0)
     
     std::map<K, V, H> result;
 
-    v8::HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(isolate);
 
     auto objPtr = v8::Object::Cast(*val);
 
@@ -311,21 +318,23 @@ from_js(const JSValue & val, const std::map<K, V, H> * = 0)
 template<typename T, typename V>
 void to_js(JSValue & val, const std::tuple<T, V> & v)
 {
-    v8::HandleScope scope;
-    v8::Local<v8::Array> arr(v8::Array::New(2));
-    arr->Set(v8::Uint32::New(0), toJS(v.template get<0>()));
-    arr->Set(v8::Uint32::New(1), toJS(v.template get<1>()));
-    val = scope.Close(arr);
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
+    v8::Local<v8::Array> arr(v8::Array::New(isolate, 2));
+    arr->Set(v8::Uint32::New(isolate, 0), toJS(v.template get<0>()));
+    arr->Set(v8::Uint32::New(isolate, 1), toJS(v.template get<1>()));
+    val = scope.Escape(arr);
 }
 
 template<typename T, typename V>
 void to_js(JSValue & val, const std::pair<T, V> & v)
 {
-    v8::HandleScope scope;
-    v8::Local<v8::Array> arr(v8::Array::New(2));
-    arr->Set(v8::Uint32::New(0), toJS( v.first  ));
-    arr->Set(v8::Uint32::New(1), toJS( v.second ));
-    val = scope.Close(arr);
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
+    v8::Local<v8::Array> arr(v8::Array::New(isolate, 2));
+    arr->Set(v8::Uint32::New(isolate, 0), toJS( v.first  ));
+    arr->Set(v8::Uint32::New(isolate, 1), toJS( v.second ));
+    val = scope.Escape(arr);
 }
 
 template<typename T, typename V>
@@ -348,13 +357,14 @@ from_js(const JSValue & val, const std::pair<T,V> * = 0)
 template<class Tuple, int Arg, int Size>
 struct TupleOpsJs {
 
-    static void unpack(v8::Local<v8::Array> & arr,
+    static void unpack(v8::Isolate * isolate,
+                       v8::Local<v8::Array> & arr,
                        const Tuple & tuple)
     {
         JSValue val;
         to_js(val, std::get<Arg>(tuple));
-        arr->Set(v8::Uint32::New(Arg), val);
-        TupleOpsJs<Tuple, Arg + 1, Size>::unpack(arr, tuple);
+        arr->Set(v8::Uint32::New(isolate, Arg), val);
+        TupleOpsJs<Tuple, Arg + 1, Size>::unpack(isolate, arr, tuple);
     }
 
     static void pack(v8::Array & array,
@@ -370,7 +380,8 @@ struct TupleOpsJs {
 template<class Tuple, int Size>
 struct TupleOpsJs<Tuple, Size, Size> {
 
-    static void unpack(v8::Local<v8::Array> & array,
+    static void unpack(v8::Isolate * isolate,
+                       v8::Local<v8::Array> & array,
                        const Tuple & tuple)
     {
     }
@@ -384,10 +395,12 @@ struct TupleOpsJs<Tuple, Size, Size> {
 template<typename... Args>
 void to_js(JSValue & val, const std::tuple<Args...> & v)
 {
-    v8::HandleScope scope;
-    v8::Local<v8::Array> arr(v8::Array::New(sizeof...(Args)));
-    TupleOpsJs<std::tuple<Args...>, 0, sizeof...(Args)>::unpack(arr, v);
-    val = scope.Close(arr);
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
+    v8::Local<v8::Array> arr(v8::Array::New(isolate, sizeof...(Args)));
+    TupleOpsJs<std::tuple<Args...>, 0, sizeof...(Args)>
+        ::unpack(isolate, arr, v);
+    val = scope.Escape(arr);
 }
 
 template<typename... Args>
@@ -408,7 +421,7 @@ from_js(const JSValue & val, const std::tuple<Args...> * v = 0)
     structure or from an array of values.
 */
 struct JSArgs {
-    JSArgs(const v8::Arguments & args)
+    JSArgs(const v8::FunctionCallbackInfo<v8::Value> & args)
         : This(args.This()), args1(&args), args2(0), argc(args.Length())
     {
     }
@@ -421,8 +434,9 @@ struct JSArgs {
 
     v8::Handle<v8::Value> operator [] (unsigned index) const
     {
+        v8::Isolate* isolate = v8::Isolate::GetCurrent();
         if (index >= argc)
-            return v8::Undefined();
+            return v8::Undefined(isolate);
 
         if (args1) return (*args1)[index];
         else return args2[index];
@@ -443,7 +457,7 @@ struct JSArgs {
     }
 
     v8::Handle<v8::Object> This;
-    const v8::Arguments * args1;
+    const v8::FunctionCallbackInfo<v8::Value> * args1;
     const v8::Handle<v8::Value> * args2;
     unsigned argc;
 };
@@ -451,10 +465,6 @@ struct JSArgs {
 /** Convert the given value into a persistent v8 function. */
 v8::Persistent<v8::Function>
 from_js(const JSValue & val, v8::Persistent<v8::Function> * = 0);
-
-/** Same, but for a local version */
-v8::Handle<v8::Function>
-from_js(const JSValue & val, v8::Handle<v8::Function> * = 0);
 
 /** Same, but for a local version */
 v8::Local<v8::Function>
@@ -510,12 +520,6 @@ void from_js(const JSValue & jsval, T * value,
 }
 
 template<typename V8Value>
-void to_js(JSValue & val, const v8::Handle<V8Value> & val2)
-{
-    val = val2;
-}
-
-template<typename V8Value>
 void to_js(JSValue & val, const v8::Local<V8Value> & val2)
 {
     val = val2;
@@ -530,12 +534,13 @@ void to_js(JSValue & val, const v8::Persistent<V8Value> & val2)
 template<typename T, size_t I, typename Sz, bool Sf, typename P, class A>
 void to_js(JSValue & val, const compact_vector<T, I, Sz, Sf, P, A> & v)
 {
-    v8::HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
 
     v8::Local<v8::Array> arr(v8::Array::New(v.size()));
     for (unsigned i = 0;  i < v.size();  ++i)
-        arr->Set(v8::Uint32::New(i), toJS(v[i]));
-    val = scope.Close(arr);
+        arr->Set(v8::Uint32::New(isolate, i), toJS(v[i]));
+    val = scope.Escape(arr);
 }
 
 //template<typename T>

--- a/plugins/lang/js/js_value.h
+++ b/plugins/lang/js/js_value.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "js_value_fwd.h"
-#include <v8.h>
+#include "v8/v8.h"
 
 namespace Datacratic {
 namespace JS {

--- a/plugins/lang/js/js_value.h
+++ b/plugins/lang/js/js_value.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "js_value_fwd.h"
-#include "v8/v8.h"
+#include "mldb/ext/v8-cross-build-output/include/v8.h"
 
 namespace Datacratic {
 namespace JS {

--- a/plugins/lang/js/mldb_js.cc
+++ b/plugins/lang/js/mldb_js.cc
@@ -48,7 +48,8 @@ v8::Handle<v8::Object>
 CellValueJS::
 create(CellValue value, JsPluginContext * context)
 {
-    auto obj = context->CellValue->GetFunction()->NewInstance();
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    auto obj = context->CellValue.Get(isolate)->GetFunction()->NewInstance();
     auto * wrapped = new CellValueJS();
     wrapped->val = std::move(value);
     wrapped->wrap(obj, context);
@@ -70,11 +71,12 @@ registerMe()
 {
     using namespace v8;
 
-    HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    EscapableHandleScope scope(isolate);
 
     auto fntmpl = CreateFunctionTemplate("Atom");
 
-    return scope.Close(fntmpl);
+    return scope.Escape(fntmpl);
 }
 
 
@@ -85,8 +87,8 @@ registerMe()
 /** Interface around an istream. */
 
 struct StreamJS::Methods {
-    static v8::Handle<v8::Value>
-    readLine(const v8::Arguments & args)
+    static void
+    readLine(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -98,24 +100,24 @@ struct StreamJS::Methods {
             while (!nextLine.empty() && nextLine[nextLine.size() - 1] == '\r')
                 nextLine.erase(nextLine.size() - 1);
 
-            return JS::toJS(nextLine);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(nextLine));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readJson(const v8::Arguments & args)
+    static void
+    readJson(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
 
             Json::Value val = Json::parse(*stream);
 
-            return JS::toJS(val);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(val));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readU8(const v8::Arguments & args)
+    static void
+    readU8(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -130,12 +132,12 @@ struct StreamJS::Methods {
             if (stream->gcount() < 1)
                 throw ML::Exception("End of file");
             
-            return JS::toJS(u);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(u));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readI8(const v8::Arguments & args)
+    static void
+    readI8(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -148,12 +150,12 @@ struct StreamJS::Methods {
             if (stream->gcount() < 1)
                 throw ML::Exception("End of file");
             
-            return JS::toJS(i);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(i));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readU32LE(const v8::Arguments & args)
+    static void
+    readU32LE(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -166,12 +168,12 @@ struct StreamJS::Methods {
             if (stream->gcount() < 4)
                 throw ML::Exception("End of file");
             
-            return JS::toJS(u);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(u));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readU32BE(const v8::Arguments & args)
+    static void
+    readU32BE(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -190,12 +192,12 @@ struct StreamJS::Methods {
                 | ubytes[1] << 16
                 | ubytes[0] << 24;
 
-            return JS::toJS(u);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(u));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readI32LE(const v8::Arguments & args)
+    static void
+    readI32LE(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -209,12 +211,12 @@ struct StreamJS::Methods {
             if (stream->gcount() < 4)
                 throw ML::Exception("End of file");
             
-            return JS::toJS(u);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(u));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readI32BE(const v8::Arguments & args)
+    static void
+    readI32BE(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -233,12 +235,12 @@ struct StreamJS::Methods {
                 | ubytes[1] << 16
                 | ubytes[0] << 24;
 
-            return JS::toJS(u);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(u));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readU16LE(const v8::Arguments & args)
+    static void
+    readU16LE(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -251,12 +253,12 @@ struct StreamJS::Methods {
             if (stream->gcount() < 2)
                 throw ML::Exception("End of file");
             
-            return JS::toJS(u);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(u));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readU16BE(const v8::Arguments & args)
+    static void
+    readU16BE(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -273,12 +275,12 @@ struct StreamJS::Methods {
                 = ubytes[1] << 0
                 | ubytes[0] << 8;
 
-            return JS::toJS(u);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(u));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readI16LE(const v8::Arguments & args)
+    static void
+    readI16LE(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -292,12 +294,12 @@ struct StreamJS::Methods {
             if (stream->gcount() < 2)
                 throw ML::Exception("End of file");
             
-            return JS::toJS(u);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(u));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readI16BE(const v8::Arguments & args)
+    static void
+    readI16BE(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -314,12 +316,12 @@ struct StreamJS::Methods {
                 = ubytes[1] << 0
                 | ubytes[0] << 8;
 
-            return JS::toJS(u);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(u));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readBytes(const v8::Arguments & args)
+    static void
+    readBytes(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
@@ -337,21 +339,21 @@ struct StreamJS::Methods {
                 bytes.resize(stream->gcount());
             }
             
-            return JS::toJS(bytes);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(bytes));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    eof(const v8::Arguments & args)
+    static void
+    eof(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto stream = getShared(args.This());
-            return JS::toJS(stream->eof());
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(stream->eof()));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    readBlob(const v8::Arguments & args)
+    static void
+    readBlob(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             JsContextScope scope(args.This());
@@ -365,7 +367,7 @@ struct StreamJS::Methods {
                 std::ostringstream buf;
                 buf << stream->rdbuf();
 
-                return JS::toJS(CellValue::blob(std::move(buf.str())));
+                args.GetReturnValue().Set(JS::toJS(CellValue::blob(std::move(buf.str()))));
             }
             else {
                 // Load from the blob
@@ -380,11 +382,11 @@ struct StreamJS::Methods {
                                                   "bytesAvailable", bytesRead);
                 }
                     
-                return JS::toJS(CellValue::blob((const char *)&bytes[0],
-                                                bytesRead));
+                args.GetReturnValue().Set(JS::toJS(CellValue::blob((const char *)&bytes[0],
+                                                                   bytesRead)));
             }
             
-        } HANDLE_JS_EXCEPTIONS;
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 };
 
@@ -392,7 +394,8 @@ v8::Handle<v8::Object>
 StreamJS::
 create(std::shared_ptr<std::istream> stream, JsPluginContext * context)
 {
-    auto obj = context->Stream->GetFunction()->NewInstance();
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    auto obj = context->Stream.Get(isolate)->GetFunction()->NewInstance();
     auto * wrapped = new StreamJS();
     wrapped->stream = stream;
     wrapped->wrap(obj, context);
@@ -414,34 +417,50 @@ registerMe()
 {
     using namespace v8;
 
-    HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    EscapableHandleScope scope(isolate);
 
     auto fntmpl = CreateFunctionTemplate("Stream");
     auto objtmpl = fntmpl->InstanceTemplate();
 
-    objtmpl->Set(String::New("readLine"), FunctionTemplate::New(Methods::readLine));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readLine"),
+                 FunctionTemplate::New(isolate, Methods::readLine));
 
-    objtmpl->Set(String::New("readU8"), FunctionTemplate::New(Methods::readU8));
-    objtmpl->Set(String::New("readI8"), FunctionTemplate::New(Methods::readI8));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readU8"),
+                 FunctionTemplate::New(isolate, Methods::readU8));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readI8"),
+                 FunctionTemplate::New(isolate, Methods::readI8));
 
-    objtmpl->Set(String::New("readU16LE"), FunctionTemplate::New(Methods::readU16LE));
-    objtmpl->Set(String::New("readU16BE"), FunctionTemplate::New(Methods::readU16BE));
-    objtmpl->Set(String::New("readI16LE"), FunctionTemplate::New(Methods::readI16LE));
-    objtmpl->Set(String::New("readI16BE"), FunctionTemplate::New(Methods::readI16BE));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readU16LE"),
+                 FunctionTemplate::New(isolate, Methods::readU16LE));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readU16BE"),
+                 FunctionTemplate::New(isolate, Methods::readU16BE));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readI16LE"),
+                 FunctionTemplate::New(isolate, Methods::readI16LE));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readI16BE"),
+                 FunctionTemplate::New(isolate, Methods::readI16BE));
 
-    objtmpl->Set(String::New("readU32LE"), FunctionTemplate::New(Methods::readU32LE));
-    objtmpl->Set(String::New("readU32BE"), FunctionTemplate::New(Methods::readU32BE));
-    objtmpl->Set(String::New("readI32LE"), FunctionTemplate::New(Methods::readI32LE));
-    objtmpl->Set(String::New("readI32BE"), FunctionTemplate::New(Methods::readI32BE));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readU32LE"),
+                 FunctionTemplate::New(isolate, Methods::readU32LE));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readU32BE"),
+                 FunctionTemplate::New(isolate, Methods::readU32BE));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readI32LE"),
+                 FunctionTemplate::New(isolate, Methods::readI32LE));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readI32BE"),
+                 FunctionTemplate::New(isolate, Methods::readI32BE));
 
-    objtmpl->Set(String::New("readBytes"), FunctionTemplate::New(Methods::readBytes));
-    objtmpl->Set(String::New("readJson"), FunctionTemplate::New(Methods::readJson));
-    objtmpl->Set(String::New("readBlob"), FunctionTemplate::New(Methods::readBlob));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readBytes"),
+                 FunctionTemplate::New(isolate, Methods::readBytes));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readJson"),
+                 FunctionTemplate::New(isolate, Methods::readJson));
+    objtmpl->Set(String::NewFromUtf8(isolate, "readBlob"),
+                 FunctionTemplate::New(isolate, Methods::readBlob));
 
-    objtmpl->Set(String::New("eof"), FunctionTemplate::New(Methods::eof));
+    objtmpl->Set(String::NewFromUtf8(isolate, "eof"),
+                 FunctionTemplate::New(isolate, Methods::eof));
         
 
-    return scope.Close(fntmpl);
+    return scope.Escape(fntmpl);
 }
 
 
@@ -488,8 +507,8 @@ struct RandomNumberGenerator {
 /*****************************************************************************/
 
 struct RandomNumberGeneratorJS::Methods {
-    static v8::Handle<v8::Value>
-    seed(const v8::Arguments & args)
+    static void
+    seed(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto randomNumberGenerator = getShared(args.This());
@@ -497,12 +516,12 @@ struct RandomNumberGeneratorJS::Methods {
             while (randomSeed == 0)
                 randomSeed = random();
             randomNumberGenerator->seed(randomSeed);
-            return args.This();
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(args.This());
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    normal(const v8::Arguments & args)
+    static void
+    normal(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto randomNumberGenerator = getShared(args.This());
@@ -510,12 +529,12 @@ struct RandomNumberGeneratorJS::Methods {
                                      "Mean of distribution");
             double stddev = JS::getArg(args, 1, 1.0,
                                        "Standard deviation of distribution");
-            return JS::toJS(randomNumberGenerator->normal(mean, stddev));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(randomNumberGenerator->normal(mean, stddev)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    uniform(const v8::Arguments & args)
+    static void
+    uniform(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             auto randomNumberGenerator = getShared(args.This());
@@ -523,8 +542,8 @@ struct RandomNumberGeneratorJS::Methods {
                                      "Minimum value of distribution");
             double max = JS::getArg(args, 1, 1.0,
                                     "Maximum value of distribution");
-            return JS::toJS(randomNumberGenerator->uniform(min, max));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(JS::toJS(randomNumberGenerator->uniform(min, max)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 };
 
@@ -533,7 +552,9 @@ RandomNumberGeneratorJS::
 create(std::shared_ptr<RandomNumberGenerator> randomNumberGenerator,
        JsPluginContext * context)
 {
-    auto obj = context->RandomNumberGenerator->GetFunction()->NewInstance();
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    auto obj = context->RandomNumberGenerator.Get(isolate)
+        ->GetFunction()->NewInstance();
     auto * wrapped = new RandomNumberGeneratorJS();
     wrapped->randomNumberGenerator = randomNumberGenerator;
     wrapped->wrap(obj, context);
@@ -555,16 +576,20 @@ registerMe()
 {
     using namespace v8;
 
-    HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    EscapableHandleScope scope(isolate);
 
     auto fntmpl = CreateFunctionTemplate("RandomNumberGenerator");
     auto objtmpl = fntmpl->InstanceTemplate();
 
-    objtmpl->Set(String::New("seed"), FunctionTemplate::New(Methods::seed));
-    objtmpl->Set(String::New("normal"), FunctionTemplate::New(Methods::normal));
-    objtmpl->Set(String::New("uniform"), FunctionTemplate::New(Methods::uniform));
+    objtmpl->Set(String::NewFromUtf8(isolate, "seed"),
+                 FunctionTemplate::New(isolate, Methods::seed));
+    objtmpl->Set(String::NewFromUtf8(isolate, "normal"),
+                 FunctionTemplate::New(isolate, Methods::normal));
+    objtmpl->Set(String::NewFromUtf8(isolate, "uniform"),
+                 FunctionTemplate::New(isolate, Methods::uniform));
 
-    return scope.Close(fntmpl);
+    return scope.Escape(fntmpl);
 }
 
 
@@ -574,20 +599,21 @@ registerMe()
 
 struct MldbJS::Methods {
 
-    static v8::Handle<v8::Value>
-    openStream(const v8::Arguments & args)
+    static void
+    openStream(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             JsPluginContext * context = MldbJS::getContext(args.This());
             auto stream = std::make_shared<filter_istream>(JS::cstr(args[0]));
             
-            return StreamJS::create(stream, context);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(StreamJS::create(stream, context));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    createDataset(const v8::Arguments & args)
+    static void
+    createDataset(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
+        v8::Isolate* isolate = args.GetIsolate();
         try {
             JsPluginContext * context = MldbJS::getContext(args.This());
             MldbServer * server = MldbJS::getShared(args.This());
@@ -603,19 +629,22 @@ struct MldbJS::Methods {
 
             auto objectIn = JS::toObject(args[0]);
 
-            objectIn->Set(v8::String::New("id"), JS::toJS(configOut.id));
+            objectIn->Set(v8::String::NewFromUtf8(isolate, "id"),
+                          JS::toJS(configOut.id));
             Json::Value paramsOut = jsonEncode(configOut.params);
             if (paramsOut != configJson["params"]) {
-                objectIn->Set(v8::String::New("params"), JS::toJS(paramsOut));
+                objectIn->Set(v8::String::NewFromUtf8(isolate, "params"),
+                              JS::toJS(paramsOut));
             }
 
-            return DatasetJS::create(dataset, context);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(DatasetJS::create(dataset, context));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    createFunction(const v8::Arguments & args)
+    static void
+    createFunction(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
+        v8::Isolate* isolate = args.GetIsolate();
         try {
             JsPluginContext * context = MldbJS::getContext(args.This());
             MldbServer * server = MldbJS::getShared(args.This());
@@ -631,19 +660,20 @@ struct MldbJS::Methods {
 
             auto objectIn = JS::toObject(args[0]);
 
-            objectIn->Set(v8::String::New("id"), JS::toJS(configOut.id));
+            objectIn->Set(v8::String::NewFromUtf8(isolate, "id"), JS::toJS(configOut.id));
             Json::Value paramsOut = jsonEncode(configOut.params);
             if (paramsOut != configJson["params"]) {
-                objectIn->Set(v8::String::New("params"), JS::toJS(paramsOut));
+                objectIn->Set(v8::String::NewFromUtf8(isolate, "params"), JS::toJS(paramsOut));
             }
 
-            return FunctionJS::create(function, context);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(FunctionJS::create(function, context));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    createProcedure(const v8::Arguments & args)
+    static void
+    createProcedure(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
+        v8::Isolate* isolate = args.GetIsolate();
         try {
             JsPluginContext * context = MldbJS::getContext(args.This());
             MldbServer * server = MldbJS::getShared(args.This());
@@ -659,26 +689,26 @@ struct MldbJS::Methods {
 
             auto objectIn = JS::toObject(args[0]);
 
-            objectIn->Set(v8::String::New("id"), JS::toJS(configOut.id));
+            objectIn->Set(v8::String::NewFromUtf8(isolate, "id"), JS::toJS(configOut.id));
             Json::Value paramsOut = jsonEncode(configOut.params);
             if (paramsOut != configJson["params"]) {
-                objectIn->Set(v8::String::New("params"), JS::toJS(paramsOut));
+                objectIn->Set(v8::String::NewFromUtf8(isolate, "params"), JS::toJS(paramsOut));
             }
 
-            return ProcedureJS::create(procedure, context);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(ProcedureJS::create(procedure, context));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    createRandomNumberGenerator(const v8::Arguments & args)
+    static void
+    createRandomNumberGenerator(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         try {
             JsPluginContext * context = MldbJS::getContext(args.This());
 
             int seed = JS::getArg(args, random(), 0.0, "Seed of generator");
             auto rng = std::make_shared<RandomNumberGenerator>(seed);
-            return RandomNumberGeneratorJS::create(rng, context);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(RandomNumberGeneratorJS::create(rng, context));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
     static v8::Handle<v8::Object> doPerform(MldbServer * server,
@@ -688,6 +718,7 @@ struct MldbJS::Methods {
                                             Json::Value payload = Json::Value(),
                                             const RestParams & headers = RestParams())
     {
+        v8::Isolate* isolate = v8::Isolate::GetCurrent();
         if (payload.isString()) {
             payload = Json::parse(payload.asString());
         }
@@ -707,27 +738,33 @@ struct MldbJS::Methods {
 
         server->handleRequest(connection, request);
 
-        v8::Handle<v8::Object> result(v8::Object::New());
-        result->Set(v8::String::New("responseCode"), JS::toJS(connection.responseCode));
+        v8::Handle<v8::Object> result(v8::Object::New(isolate));
+        result->Set(v8::String::NewFromUtf8(isolate, "responseCode"),
+                    JS::toJS(connection.responseCode));
 
         if (!connection.contentType.empty())
-            result->Set(v8::String::New("contentType"), JS::toJS(connection.contentType));
+            result->Set(v8::String::NewFromUtf8(isolate, "contentType"),
+                        JS::toJS(connection.contentType));
         if (!connection.headers.empty())
-            result->Set(v8::String::New("headers"), JS::toJS(connection.headers));
+            result->Set(v8::String::NewFromUtf8(isolate, "headers"),
+                        JS::toJS(connection.headers));
         if (!connection.response.empty()) {
-            result->Set(v8::String::New("response"), JS::toJS(connection.response));
+            result->Set(v8::String::NewFromUtf8(isolate, "response"),
+                        JS::toJS(connection.response));
             if (connection.contentType == "application/json") {
-                result->Set(v8::String::New("json"), JS::toJS(Json::parse(connection.response)));
+                result->Set(v8::String::NewFromUtf8(isolate, "json"),
+                            JS::toJS(Json::parse(connection.response)));
             }
         }
 
         return result;
     }
 
-    static v8::Handle<v8::Value>
-    get(const v8::Arguments & args)
+    static void
+    get(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             MldbServer * server = MldbJS::getShared(args.This());
             Utf8String resource = JS::getArg<Utf8String>(args, 0, "resource");
@@ -736,83 +773,89 @@ struct MldbJS::Methods {
 
             RestParams headers = JS::getArg<RestParams>(args, 2, RestParams(), "headers");
 
-            return scope.Close(doPerform(server, "GET", resource, params,
-                                         Json::Value(), headers));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(doPerform(server, "GET", resource, params,
+                                                             Json::Value(), headers)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    put(const v8::Arguments & args)
+    static void
+    put(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             MldbServer * server = MldbJS::getShared(args.This());
             Utf8String resource = JS::getArg<Utf8String>(args, 0, "resource");
             Json::Value payload = JS::getArg<Json::Value>(args, 1, Json::Value(), "payload");
             RestParams headers = JS::getArg<RestParams>(args, 2, RestParams(), "headers");
-            return scope.Close(doPerform(server, "PUT", resource, RestParams(), std::move(payload), headers));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(doPerform(server, "PUT", resource, RestParams(), std::move(payload), headers)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    putAsync(const v8::Arguments & args)
+    static void
+    putAsync(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
-        try {
-            MldbServer * server = MldbJS::getShared(args.This());
-            Utf8String resource = JS::getArg<Utf8String>(args, 0, "resource");
-            Json::Value payload = JS::getArg<Json::Value>(args, 1, Json::Value(), "payload");
-            RestParams headers = JS::getArg<RestParams>(args, 2, RestParams(), "headers");
-            headers.emplace_back("async", "true");
-            return scope.Close(doPerform(server, "PUT", resource, RestParams(), std::move(payload), headers));
-        } HANDLE_JS_EXCEPTIONS;
-    }
-
-    static v8::Handle<v8::Value>
-    post(const v8::Arguments & args)
-    {
-        v8::HandleScope scope;
-        try {
-            MldbServer * server = MldbJS::getShared(args.This());
-            Utf8String resource = JS::getArg<Utf8String>(args, 0, "resource");
-            Json::Value payload = JS::getArg<Json::Value>(args, 1, Json::Value(), "payload");
-            RestParams headers = JS::getArg<RestParams>(args, 2, RestParams(), "headers");
-            return scope.Close(doPerform(server, "POST", resource, RestParams(), std::move(payload), headers));
-        } HANDLE_JS_EXCEPTIONS;
-    }
-
-    static v8::Handle<v8::Value>
-    postAsync(const v8::Arguments & args)
-    {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             MldbServer * server = MldbJS::getShared(args.This());
             Utf8String resource = JS::getArg<Utf8String>(args, 0, "resource");
             Json::Value payload = JS::getArg<Json::Value>(args, 1, Json::Value(), "payload");
             RestParams headers = JS::getArg<RestParams>(args, 2, RestParams(), "headers");
             headers.emplace_back("async", "true");
-            return scope.Close(doPerform(server, "POST", resource, RestParams(), std::move(payload), headers));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(doPerform(server, "PUT", resource, RestParams(), std::move(payload), headers)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    del(const v8::Arguments & args)
+    static void
+    post(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
+        try {
+            MldbServer * server = MldbJS::getShared(args.This());
+            Utf8String resource = JS::getArg<Utf8String>(args, 0, "resource");
+            Json::Value payload = JS::getArg<Json::Value>(args, 1, Json::Value(), "payload");
+            RestParams headers = JS::getArg<RestParams>(args, 2, RestParams(), "headers");
+            args.GetReturnValue().Set(scope.Escape(doPerform(server, "POST", resource, RestParams(), std::move(payload), headers)));
+        } HANDLE_JS_EXCEPTIONS(args);
+    }
+
+    static void
+    postAsync(const v8::FunctionCallbackInfo<v8::Value> & args)
+    {
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
+        try {
+            MldbServer * server = MldbJS::getShared(args.This());
+            Utf8String resource = JS::getArg<Utf8String>(args, 0, "resource");
+            Json::Value payload = JS::getArg<Json::Value>(args, 1, Json::Value(), "payload");
+            RestParams headers = JS::getArg<RestParams>(args, 2, RestParams(), "headers");
+            headers.emplace_back("async", "true");
+            args.GetReturnValue().Set(scope.Escape(doPerform(server, "POST", resource, RestParams(), std::move(payload), headers)));
+        } HANDLE_JS_EXCEPTIONS(args);
+    }
+
+    static void
+    del(const v8::FunctionCallbackInfo<v8::Value> & args)
+    {
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             MldbServer * server = MldbJS::getShared(args.This());
             Utf8String resource = JS::getArg<Utf8String>(args, 0, "resource");
             RestParams headers = JS::getArg<RestParams>(args, 1, RestParams(), "headers");
 
-            return scope.Close(doPerform(server, "DELETE", resource, RestParams(),
-                                         Json::Value(), headers));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(doPerform(server, "DELETE", resource, RestParams(),
+                                                             Json::Value(), headers)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    perform(const v8::Arguments & args)
+    static void
+    perform(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             MldbServer * server = MldbJS::getShared(args.This());
             string verb = JS::getArg<std::string>(args, 0, "verb");
@@ -820,14 +863,15 @@ struct MldbJS::Methods {
             RestParams params = JS::getArg<RestParams>(args, 2, {}, "params");
             Json::Value payload = JS::getArg<Json::Value>(args, 3, Json::Value(), "payload");
             RestParams headers = JS::getArg<RestParams>(args, 4, RestParams(), "headers");
-            return scope.Close(doPerform(server, verb, resource, params, std::move(payload), headers));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(doPerform(server, verb, resource, params, std::move(payload), headers)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    diff(const v8::Arguments & args)
+    static void
+    diff(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             Json::Value val1 = JS::getArg<Json::Value>(args, 0, "val1");
             Json::Value val2 = JS::getArg<Json::Value>(args, 1, "val2");
@@ -842,14 +886,15 @@ struct MldbJS::Methods {
 
             auto result = JS::toJS(jsonEncode(diff));
 
-            return scope.Close(result);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(result));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
     
-    static v8::Handle<v8::Value>
-    patch(const v8::Arguments & args)
+    static void
+    patch(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             Json::Value val = JS::getArg<Json::Value>(args, 0, "val");
             Json::Value patch = JS::getArg<Json::Value>(args, 1, "patch");
@@ -858,14 +903,15 @@ struct MldbJS::Methods {
 
             auto result = JS::toJS(jsonEncode(patched));
             
-            return scope.Close(result);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(result));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    ls(const v8::Arguments & args)
+    static void
+    ls(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
 
             string dir = JS::getArg<Utf8String>(args, 0, "dir").rawString();
@@ -895,12 +941,12 @@ struct MldbJS::Methods {
             result["dirs"] = jsonEncode(dirs);
             result["objects"] = jsonEncode(objects);
             
-            return scope.Close(JS::toJS(result));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(JS::toJS(result)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    log(const v8::Arguments & args)
+    static void
+    log(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         using namespace v8;
         JsPluginContext * context = MldbJS::getContext(args.This());
@@ -942,17 +988,18 @@ struct MldbJS::Methods {
                 context->logs.emplace_back(Date::now(), "log", Utf8String(line));
             }
 
-            return args.This();
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(args.This());
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    createInterval(const v8::Arguments & args)
+    static void
+    createInterval(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         using namespace v8;
         JsPluginContext * context = MldbJS::getContext(args.This());
 
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             int64_t months = 0;
             int64_t days = 0;
@@ -965,7 +1012,7 @@ struct MldbJS::Methods {
                     Json::Value val2;
                     val2["interval"] = val1;
                     CellValue val = jsonDecode<CellValue>(val2);
-                    return scope.Close(CellValueJS::create(val, context));
+                    args.GetReturnValue().Set(scope.Escape(CellValueJS::create(val, context)));
                 }
                 else {
                     for (auto it = val1.begin();  it != val1.end();  ++it) {
@@ -981,7 +1028,7 @@ struct MldbJS::Methods {
                         else if (it.memberName() == "interval") {
                             ExcAssertEqual(val1.size(), 1);
                             CellValue val = jsonDecode<CellValue>(val1);
-                            return scope.Close(CellValueJS::create(val, context));
+                            args.GetReturnValue().Set(scope.Escape(CellValueJS::create(val, context)));
                         }
                         else {
                             throw ML::Exception("Unknown object field for interval: '%s'.  Accepted are months, days, seconds or interval by itself");
@@ -997,62 +1044,66 @@ struct MldbJS::Methods {
 
             CellValue val = CellValue::fromMonthDaySecond(months, days, seconds);
             
-            return scope.Close(CellValueJS::create(val, context));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(CellValueJS::create(val, context)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
     
-    static v8::Handle<v8::Value>
-    createPath(const v8::Arguments & args)
+    static void
+    createPath(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         using namespace v8;
         JsPluginContext * context = MldbJS::getContext(args.This());
 
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             Path val1 = JS::getArg<Path>(args, 0, "argument");
             CellValue val(val1);
-            return scope.Close(CellValueJS::create(val, context));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(CellValueJS::create(val, context)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
     
-    static v8::Handle<v8::Value>
-    sqlEscape(const v8::Arguments & args)
+    static void
+    sqlEscape(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             Utf8String str = JS::getArg<Utf8String>(args, 0, "str");
 
             auto result = JS::toJS(escapeSql(str));
             
-            return scope.Close(result);
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(result));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    query(const v8::Arguments & args)
+    static void
+    query(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             MldbServer * server = MldbJS::getShared(args.This());
             Utf8String query = JS::getArg<Utf8String>(args, 0, "sql");
             std::vector<MatrixNamedRow> result = server->query(query);
 
-            return scope.Close(JS::toJS(jsonEncode(result)));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(JS::toJS(jsonEncode(result))));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    getHttpBoundAddress(const v8::Arguments & args)
+    static void
+    getHttpBoundAddress(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
-        v8::HandleScope scope;
+        v8::Isolate* isolate = args.GetIsolate();
+        v8::EscapableHandleScope scope(isolate);
         try {
             MldbServer * server = MldbJS::getShared(args.This());
-            return scope.Close(JS::toJS(server->httpBoundAddress));
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(scope.Escape(JS::toJS(server->httpBoundAddress)));
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 
-    static v8::Handle<v8::Value>
-    setPathOptimizationLevel(const v8::Arguments & args)
+    static void
+    setPathOptimizationLevel(const v8::FunctionCallbackInfo<v8::Value> & args)
     {
         using namespace v8;
         try {
@@ -1076,8 +1127,8 @@ struct MldbJS::Methods {
 
             OptimizedPath::setDefault(level);
             
-            return args.This();
-        } HANDLE_JS_EXCEPTIONS;
+            args.GetReturnValue().Set(args.This());
+        } HANDLE_JS_EXCEPTIONS(args);
     }
 };
 
@@ -1105,60 +1156,71 @@ registerMe()
 {
     using namespace v8;
 
-    HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    EscapableHandleScope scope(isolate);
 
     v8::Local<v8::ObjectTemplate> result(ObjectTemplate::New());
 
     result->SetInternalFieldCount(2);  // first is mldbServer, second is plugin cxt
 
-    result->Set(String::New("log"), FunctionTemplate::New(Methods::log));
-    result->Set(String::New("openStream"),
-                FunctionTemplate::New(Methods::openStream));
-    result->Set(String::New("createDataset"),
-                FunctionTemplate::New(Methods::createDataset));
-    result->Set(String::New("createFunction"),
-                FunctionTemplate::New(Methods::createFunction));
-    result->Set(String::New("createProcedure"),
-                FunctionTemplate::New(Methods::createProcedure));
-    result->Set(String::New("createInterval"),
-                FunctionTemplate::New(Methods::createInterval));
-    result->Set(String::New("createPath"),
-                FunctionTemplate::New(Methods::createPath));
-    result->Set(String::New("createRandomNumberGenerator"),
-                FunctionTemplate::New(Methods::createRandomNumberGenerator));
-    result->Set(String::New("perform"), FunctionTemplate::New(Methods::perform));
-    result->Set(String::New("get"), FunctionTemplate::New(Methods::get));
-    result->Set(String::New("put"), FunctionTemplate::New(Methods::put));
-    result->Set(String::New("putAsync"), FunctionTemplate::New(Methods::putAsync));
-    result->Set(String::New("post"), FunctionTemplate::New(Methods::post));
-    result->Set(String::New("postAsync"), FunctionTemplate::New(Methods::postAsync));
-    result->Set(String::New("del"), FunctionTemplate::New(Methods::del));
+    result->Set(String::NewFromUtf8(isolate, "log"), FunctionTemplate::New(isolate, Methods::log));
+    result->Set(String::NewFromUtf8(isolate, "openStream"),
+                FunctionTemplate::New(isolate, Methods::openStream));
+    result->Set(String::NewFromUtf8(isolate, "createDataset"),
+                FunctionTemplate::New(isolate, Methods::createDataset));
+    result->Set(String::NewFromUtf8(isolate, "createFunction"),
+                FunctionTemplate::New(isolate, Methods::createFunction));
+    result->Set(String::NewFromUtf8(isolate, "createProcedure"),
+                FunctionTemplate::New(isolate, Methods::createProcedure));
+    result->Set(String::NewFromUtf8(isolate, "createInterval"),
+                FunctionTemplate::New(isolate, Methods::createInterval));
+    result->Set(String::NewFromUtf8(isolate, "createPath"),
+                FunctionTemplate::New(isolate, Methods::createPath));
+    result->Set(String::NewFromUtf8(isolate, "createRandomNumberGenerator"),
+                FunctionTemplate::New(isolate, Methods::createRandomNumberGenerator));
+    result->Set(String::NewFromUtf8(isolate, "perform"),
+                FunctionTemplate::New(isolate, Methods::perform));
+    result->Set(String::NewFromUtf8(isolate, "get"),
+                FunctionTemplate::New(isolate, Methods::get));
+    result->Set(String::NewFromUtf8(isolate, "put"),
+                FunctionTemplate::New(isolate, Methods::put));
+    result->Set(String::NewFromUtf8(isolate, "putAsync"),
+                FunctionTemplate::New(isolate, Methods::putAsync));
+    result->Set(String::NewFromUtf8(isolate, "post"),
+                FunctionTemplate::New(isolate, Methods::post));
+    result->Set(String::NewFromUtf8(isolate, "postAsync"),
+                FunctionTemplate::New(isolate, Methods::postAsync));
+    result->Set(String::NewFromUtf8(isolate, "del"),
+                FunctionTemplate::New(isolate, Methods::del));
 
-    result->Set(String::New("diff"), FunctionTemplate::New(Methods::diff));
-    result->Set(String::New("patch"), FunctionTemplate::New(Methods::patch));
+    result->Set(String::NewFromUtf8(isolate, "diff"),
+                FunctionTemplate::New(isolate, Methods::diff));
+    result->Set(String::NewFromUtf8(isolate, "patch"),
+                FunctionTemplate::New(isolate, Methods::patch));
 
-    result->Set(String::New("query"),
-                FunctionTemplate::New(Methods::query));
-    result->Set(String::New("sqlEscape"),
-                FunctionTemplate::New(Methods::sqlEscape));
+    result->Set(String::NewFromUtf8(isolate, "query"),
+                FunctionTemplate::New(isolate, Methods::query));
+    result->Set(String::NewFromUtf8(isolate, "sqlEscape"),
+                FunctionTemplate::New(isolate, Methods::sqlEscape));
 
-    result->Set(String::New("ls"), FunctionTemplate::New(Methods::ls));
-    result->Set(String::New("getHttpBoundAddress"),
-                FunctionTemplate::New(Methods::getHttpBoundAddress));
+    result->Set(String::NewFromUtf8(isolate, "ls"),
+                FunctionTemplate::New(isolate, Methods::ls));
+    result->Set(String::NewFromUtf8(isolate, "getHttpBoundAddress"),
+                FunctionTemplate::New(isolate, Methods::getHttpBoundAddress));
 
-    result->Set(String::New("debugSetPathOptimizationLevel"),
-                FunctionTemplate::New(Methods::setPathOptimizationLevel));
+    result->Set(String::NewFromUtf8(isolate, "debugSetPathOptimizationLevel"),
+                FunctionTemplate::New(isolate, Methods::setPathOptimizationLevel));
 
-    return scope.Close(result);
+    return scope.Escape(result);
 }
 
-v8::Handle<v8::Value>
+void
 MldbJS::
-New(const v8::Arguments & args)
+New(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         throw ML::Exception("can't create new JS plugins");
-    } HANDLE_JS_EXCEPTIONS;
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
 } // namespace MLDB

--- a/plugins/lang/js/mldb_js.h
+++ b/plugins/lang/js/mldb_js.h
@@ -111,8 +111,8 @@ struct MldbJS: public JsObjectBase {
     static v8::Local<v8::ObjectTemplate>
     registerMe();
 
-    static v8::Handle<v8::Value>
-    New(const v8::Arguments & args);
+    static void
+    New(const v8::FunctionCallbackInfo<v8::Value> & args);
 
     struct Methods;
 };

--- a/plugins/lang/js/mldb_js_plugin.mk
+++ b/plugins/lang/js/mldb_js_plugin.mk
@@ -4,4 +4,18 @@ LIBJS_LINK := jsoncpp $(V8_LIB) arch utils types
 
 # JS plugin loader
 
-$(eval $(call library,mldb_js_plugin,js_utils.cc js_value.cc js_loader.cc js_function.cc js_common.cc mldb_js.cc dataset_js.cc function_js.cc procedure_js.cc,value_description $(LIBJS_LINK) sql_expression))
+JS_PLUGIN_SOURCE := \
+	js_utils.cc \
+	js_value.cc \
+	js_loader.cc \
+	js_function.cc \
+	js_common.cc \
+	dataset_js.cc \
+	function_js.cc \
+	procedure_js.cc \
+	mldb_js.cc \
+
+
+$(eval $(call set_compile_option,$(JS_PLUGIN_SOURCE),-I$(INC)))
+
+$(eval $(call library,mldb_js_plugin,$(JS_PLUGIN_SOURCE),value_description $(LIBJS_LINK) sql_expression))

--- a/plugins/lang/js/mldb_js_plugin.mk
+++ b/plugins/lang/js/mldb_js_plugin.mk
@@ -16,6 +16,6 @@ JS_PLUGIN_SOURCE := \
 	mldb_js.cc \
 
 
-$(eval $(call set_compile_option,$(JS_PLUGIN_SOURCE),-I$(INC)))
+$(eval $(call set_compile_option,$(JS_PLUGIN_SOURCE),-I$(INC) -I$(INC)/v8))
 
 $(eval $(call library,mldb_js_plugin,$(JS_PLUGIN_SOURCE),value_description $(LIBJS_LINK) sql_expression))

--- a/plugins/lang/js/mldb_js_plugin.mk
+++ b/plugins/lang/js/mldb_js_plugin.mk
@@ -1,6 +1,31 @@
 # This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
-LIBJS_LINK := jsoncpp $(V8_LIB) arch utils types
+
+
+V8_ARCH_x86_64:=x64
+V8_ARCH_aarch64:=arm64
+V8_ARCH_ARM:=arm
+
+V8_ARCH:=$(V8_ARCH_$(ARCH))
+
+$(if $(V8_ARCH),,$(error couldnt find v8 architecture for $(ARCH)))
+
+$(LIB)/libv8$(so): mldb/ext/v8-cross-build-output/$(V8_ARCH)/libv8.so
+	@cp $< $@~ && mv $@~ $@
+
+ifneq ($(PREMAKE),1)
+
+$(LIB)/natives_blob.bin: mldb/ext/v8-cross-build-output/$(V8_ARCH)/natives_blob.bin
+	@cp $< $@~ && mv $@~ $@
+
+$(LIB)/snapshot_blob.bin: mldb/ext/v8-cross-build-output/$(V8_ARCH)/snapshot_blob.bin
+	@cp $< $@~ && mv $@~ $@
+
+endif
+
+LIB_v8_DEPS := $(LIB)/libv8$(so) $(LIB)/natives_blob.bin $(LIB)/snapshot_blob.bin
+
+LIBJS_LINK := jsoncpp v8 arch utils types
 
 # JS plugin loader
 
@@ -16,6 +41,6 @@ JS_PLUGIN_SOURCE := \
 	mldb_js.cc \
 
 
-$(eval $(call set_compile_option,$(JS_PLUGIN_SOURCE),-I$(INC) -I$(INC)/v8))
+$(eval $(call set_compile_option,$(JS_PLUGIN_SOURCE),-Imldb/ext/v8-cross-build-output/include))
 
 $(eval $(call library,mldb_js_plugin,$(JS_PLUGIN_SOURCE),value_description $(LIBJS_LINK) sql_expression))

--- a/plugins/lang/js/procedure_js.cc
+++ b/plugins/lang/js/procedure_js.cc
@@ -24,7 +24,8 @@ v8::Handle<v8::Object>
 ProcedureJS::
 create(std::shared_ptr<Procedure> procedure, JsPluginContext * context)
 {
-    auto obj = context->Procedure->GetFunction()->NewInstance();
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    auto obj = context->Procedure.Get(isolate)->GetFunction()->NewInstance();
     auto * wrapped = new ProcedureJS();
     wrapped->procedure = procedure;
     wrapped->wrap(obj, context);
@@ -46,68 +47,74 @@ registerMe()
 {
     using namespace v8;
 
-    HandleScope scope;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    EscapableHandleScope scope(isolate);
 
     auto fntmpl = CreateFunctionTemplate("Procedure");
     auto prototmpl = fntmpl->PrototypeTemplate();
 
-    prototmpl->Set(String::New("status"), FunctionTemplate::New(status));
-    prototmpl->Set(String::New("id"), FunctionTemplate::New(id));
-    prototmpl->Set(String::New("type"), FunctionTemplate::New(type));
-    prototmpl->Set(String::New("config"), FunctionTemplate::New(config));
-    prototmpl->Set(String::New("run"), FunctionTemplate::New(run));
+    prototmpl->Set(String::NewFromUtf8(isolate, "status"),
+                   FunctionTemplate::New(isolate, status));
+    prototmpl->Set(String::NewFromUtf8(isolate, "id"),
+                   FunctionTemplate::New(isolate, id));
+    prototmpl->Set(String::NewFromUtf8(isolate, "type"),
+                   FunctionTemplate::New(isolate, type));
+    prototmpl->Set(String::NewFromUtf8(isolate, "config"),
+                   FunctionTemplate::New(isolate, config));
+    prototmpl->Set(String::NewFromUtf8(isolate, "run"),
+                   FunctionTemplate::New(isolate, run));
         
-    return scope.Close(fntmpl);
+    return scope.Escape(fntmpl);
 }
 
 
-v8::Handle<v8::Value>
+void
 ProcedureJS::
-status(const v8::Arguments & args)
+status(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Procedure * procedure = getShared(args.This());
             
-        return JS::toJS(jsonEncode(procedure->getStatus()));
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(procedure->getStatus())));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
     
-v8::Handle<v8::Value>
+void
 ProcedureJS::
-id(const v8::Arguments & args)
+id(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Procedure * procedure = getShared(args.This());
             
-        return JS::toJS(procedure->getId());
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(JS::toJS(procedure->getId()));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
     
-v8::Handle<v8::Value>
+void
 ProcedureJS::
-type(const v8::Arguments & args)
+type(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Procedure * procedure = getShared(args.This());
             
-        return JS::toJS(procedure->getType());
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(JS::toJS(procedure->getType()));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
     
-v8::Handle<v8::Value>
+void
 ProcedureJS::
-config(const v8::Arguments & args)
+config(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Procedure * procedure = getShared(args.This());
         
-        return JS::toJS(jsonEncode(procedure->getConfig()));
-    } HANDLE_JS_EXCEPTIONS;
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(procedure->getConfig())));
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
-v8::Handle<v8::Value>
+void
 ProcedureJS::
-run(const v8::Arguments & args)
+run(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
         Procedure * procedure = getShared(args.This());
@@ -121,9 +128,9 @@ run(const v8::Arguments & args)
 
         auto result = procedure->run(config, onProgress);
         
-        return JS::toJS(jsonEncode(result));
+        args.GetReturnValue().Set(JS::toJS(jsonEncode(result)));
 
-    } HANDLE_JS_EXCEPTIONS;
+    } HANDLE_JS_EXCEPTIONS(args);
 }
 
 } // namespace MLDB

--- a/plugins/lang/js/procedure_js.h
+++ b/plugins/lang/js/procedure_js.h
@@ -33,20 +33,20 @@ struct ProcedureJS: public JsObjectBase {
     static v8::Local<v8::FunctionTemplate>
     registerMe();
 
-    static v8::Handle<v8::Value>
-    status(const v8::Arguments & args);
+    static void
+    status(const v8::FunctionCallbackInfo<v8::Value> & args);
     
-    static v8::Handle<v8::Value>
-    id(const v8::Arguments & args);
+    static void
+    id(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    type(const v8::Arguments & args);
+    static void
+    type(const v8::FunctionCallbackInfo<v8::Value> & args);
     
-    static v8::Handle<v8::Value>
-    config(const v8::Arguments & args);
+    static void
+    config(const v8::FunctionCallbackInfo<v8::Value> & args);
 
-    static v8::Handle<v8::Value>
-    run(const v8::Arguments & args);
+    static void
+    run(const v8::FunctionCallbackInfo<v8::Value> & args);
 };
 
 } // namespace MLDB

--- a/testing/MLDB-980-unquoted-string-crash.js
+++ b/testing/MLDB-980-unquoted-string-crash.js
@@ -23,6 +23,6 @@ var res = mldb.post('/v1/types/plugins/javascript/routes/run', scriptConfig);
 mldb.log(res);
 
 assertEqual(res.responseCode, 400);
-assertEqual(res.json.exception.message, "Uncaught SyntaxError: Unexpected token ILLEGAL");
+assertEqual(res.json.exception.message, "Uncaught SyntaxError: Invalid or unexpected token");
 
 "success"


### PR DESCRIPTION
Upgrades v8 to the very latest version, removing a system dependency and allowing arm64 builds (the version of v8 we used didn't work on arm64).

This involves the following changes:

1.  Discovered how to build v8 using <strike>scons</strike> <strike>GYP</strike> GN, using the system ICU (which clashes with the one included in v8), and with cross-compilation available.  The results of this work are in the mldbai/v8-cross-build repo, and the output is cached in the v8-cross-build-output repo which is included in MLDB under ext/.
2.  Updated all of the JS code to the latest v8 API.  This was mostly mechanical, and in general the new API is cleaner and better which improved the quality of the JS binding code.
3.   Created a new `Platform` implementation for v8 with access to the thread pool etc inside MLDB, so that it would better integrate.  This should eventually allow us to receive trace messages from V8 directly in MLDB's logging system.
4.  Adjusted the initialization to find the external binary blobs that v8 now needs to be available to the execution.  This may require some adjustments to the packaging.

I will verify that a docker build works before merging.