### PR TITLE
Added optional ordering to string_agg (MLDB-1924)

### DIFF
--- a/container_files/public_html/doc/builtin/sql/ValueExpression.md
+++ b/container_files/public_html/doc/builtin/sql/ValueExpression.md
@@ -595,11 +595,18 @@ The following useful non-standard aggregation functions are also supported:
   column name and value given.  This can be used with a group by clause to
   transform a dense dataset of (actor,action,value) records into a sparse
   dataset with one sparse row per actor, for example to create one-hot feature vectors or term-document or cooccurrence matrices.
-- `string_agg(expr, separator)` will coerce the value of `expr` and that of
-  `separator` to a string, and produce a single string with the concatenation
-  of `expr` separated by `separators` at internal boundaries.  For example,
-  if `expr` is `"one"`, `"two"` and `"three"` in the group, and separator is
-  `', '` the output will be `"one, two, three"`.
+- `string_agg(expr, separator [, sortField])` will coerce the value of `expr`
+   and that of `separator` to a string, create a list of all values sorted 
+   by the `sortField`
+   (which is null if not specified) breaking ties by sorting by `expr` as a
+   string, and produce a single string with the concatenation of `expr`
+   separated by `separator` at internal boundaries on the list.  For example,
+   if `expr` is `"one"`, `"two"` and `"three"` in the group, and `separator` is
+   `', '` the output will be `"one, two, three"`.  The `sortField` can be used
+   to ensure that the values over multiple `string_agg` calls are in the,
+   same order, for example are in order of time or in row order of the
+   underlying dataset.  Note that the `rowPath()` can be used in the
+   `sortField` to achieve that result.
 
 ### Aggregates of rows
 

--- a/sql/builtin_aggregators.cc
+++ b/sql/builtin_aggregators.cc
@@ -70,7 +70,7 @@ struct AggregatorT {
                                  const string & name)
     {
         // These take the number of arguments given in the State class
-        checkArgsSize(args.size(), State::nargs, name);
+        checkArgsSize(args.size(), State::nargs, State::maxArgs, name);
         ExcAssert(args[0].info);
 
         if (args[0].info->isRow()) {
@@ -509,6 +509,7 @@ struct RegisterAggregatorT: public RegisterAggregator {
 
 struct AverageAccum {
     static constexpr int nargs = 1;
+    static constexpr int maxArgs = nargs;
     
     AverageAccum()
         : total(0.0), n(0.0), ts(Date::negativeInfinity())
@@ -554,6 +555,7 @@ static RegisterAggregatorT<AverageAccum> registerAvg("avg", "vertical_avg");
 template<typename Op, int Init>
 struct ValueAccum {
     static constexpr int nargs = 1;
+    static constexpr int maxArgs = nargs;
     ValueAccum()
         : value(Init), ts(Date::negativeInfinity())
     {
@@ -595,8 +597,9 @@ registerSum("sum", "vertical_sum");
 
 struct StringAggAccum {
     static constexpr int nargs = 2;
+    static constexpr int maxArgs = 3;
     StringAggAccum()
-        : first(true), ts(Date::negativeInfinity())
+        : ts(Date::negativeInfinity())
     {
     }
 
@@ -608,52 +611,80 @@ struct StringAggAccum {
 
     void process(const ExpressionValue * args, size_t nargs)
     {
-        checkArgsSize(nargs, 2);
+        if (nargs < 2 || nargs > 3) {
+            checkArgsSize(nargs, 2, 3);
+        }
         const ExpressionValue & val = args[0];
-        const ExpressionValue & separator = args[1];
 
         if (val.empty())
             return;
 
-        if (first) {
-            this->firstSeparator = separator.empty()
-                ? Utf8String()
-                : separator.coerceToString().toUtf8String();
-        }
-        else if (!separator.empty()) {
-            value += separator.coerceToString().toUtf8String();
-        }
-        first = false;
+        const ExpressionValue & separator = args[1];
+        static const CellValue noSort;
+        const CellValue & sort
+            = nargs > 2 ? args[2].getAtom() : noSort;
         
-        value += val.coerceToString().toUtf8String();
+        values.emplace_back(sort, val.coerceToString().toUtf8String(),
+                            separator.empty() 
+                            ? Utf8String()
+                            : separator.coerceToString().toUtf8String());
 
         ts.setMax(val.getEffectiveTimestamp());
+
+        if (isSorted && values.size() > 1
+            && values[values.size() - 2] > values.back())
+            isSorted = false;
     }
      
     ExpressionValue extract()
     {
-        return ExpressionValue(value, ts);
+        if (!isSorted)
+            std::sort(values.begin(), values.end());
+
+        Utf8String result;
+
+        for (size_t i = 0;  i < values.size();  ++i) {
+            if (i != 0)
+                result += std::get<2>(values[i - 1]);
+            result += std::get<1>(values[i]);
+        }
+        
+        return ExpressionValue(std::move(result), ts);
     }
 
     void merge(StringAggAccum* src)
     {
-        if (src->first)
-            return;  // nothing to do
-        else if (first) {
-            value = std::move(src->value);
-            firstSeparator = std::move(src->firstSeparator);
-            first = src->first;
+        ts.setMax(src->ts);
+
+        if (src->values.size() > values.size()) {
+            values.swap(src->values);
+            std::swap(isSorted, src->isSorted);
+        }
+
+        if (values.size() < 3 * src->values.size()) {
+            if (!isSorted)
+                std::sort(values.begin(), values.end());
+            if (!src->isSorted)
+                std::sort(src->values.begin(), src->values.end());
+            size_t before = values.size();
+            values.insert(values.end(),
+                          std::make_move_iterator(src->values.begin()),
+                          std::make_move_iterator(src->values.end()));
+            std::inplace_merge(values.begin(), values.begin() + before,
+                               values.end());
+            isSorted = true;
         }
         else {
-            value += src->firstSeparator;
-            value += src->value;
+            isSorted = isSorted && src->values.empty();
+            values.insert(values.end(),
+                          std::make_move_iterator(src->values.begin()),
+                          std::make_move_iterator(src->values.end()));
         }
-        ts.setMax(src->ts);
     }
 
-    bool first;  ///< Is this the first thing we add?
-    Utf8String firstSeparator;  ///< First separator, used for merging
-    Utf8String value;      ///< Currently accumulated value
+    // sort key, value, separator
+    std::vector<std::tuple<CellValue, Utf8String, Utf8String> > values;      ///< Currently accumulated values with separators
+    bool isSorted = true;   ///< Is values already sorted?
     Date ts;
 };
 
@@ -663,6 +694,7 @@ registerStringAgg("string_agg", "vertical_string_agg");
 template<typename Cmp>
 struct MinMaxAccum {
     static constexpr int nargs = 1;
+    static constexpr int maxArgs = nargs;
     MinMaxAccum()
         : first(true), ts(Date::negativeInfinity())
     {
@@ -727,6 +759,7 @@ registerMax("max", "vertical_max");
 
 struct CountAccum {
     static constexpr int nargs = 1;
+    static constexpr int maxArgs = nargs;
     CountAccum()
         : n(0), ts(Date::negativeInfinity())
     {
@@ -769,6 +802,7 @@ static RegisterAggregatorT<CountAccum> registerCount("count", "vertical_count");
 
 struct DistinctAccum {
     static constexpr int nargs = 1;
+    static constexpr int maxArgs = nargs;
     DistinctAccum()
         : ts(Date::negativeInfinity())
     {
@@ -955,6 +989,7 @@ static RegisterAggregator registerPivot(pivot, "pivot");
 template<typename AccumCmp>
 struct EarliestLatestAccum {
     static constexpr int nargs = 1;
+    static constexpr int maxArgs = nargs;
     EarliestLatestAccum()
         : value(ExpressionValue::null(AccumCmp::getInitialDate()))
     {
@@ -1012,6 +1047,7 @@ static RegisterAggregatorT<EarliestLatestAccum<LaterAccum> > registerLatest("lat
 
 struct VarAccum {
     static constexpr int nargs = 1;
+    static constexpr int maxArgs = nargs;
     int64_t n;
     double mean;
     double M2;

--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -35,6 +35,9 @@ using namespace std;
 
 namespace Datacratic {
 namespace MLDB {
+
+const Utf8String NO_FUNCTION_NAME;
+
 namespace Builtins {
 
 /*****************************************************************************/

--- a/sql/builtin_functions.h
+++ b/sql/builtin_functions.h
@@ -15,10 +15,14 @@
 namespace Datacratic {
 namespace MLDB {
 
+// Empty string to avoid construction of temporary object
+extern const Utf8String NO_FUNCTION_NAME;
+
 inline void checkArgsSize(size_t number, size_t expected,
-                          std::string fctName="")
+                          const Utf8String & fctName_=NO_FUNCTION_NAME)
 {
     if (number != expected) {
+        auto fctName = fctName_;
         if (!fctName.empty()) {
             fctName = "function " + fctName + " ";
         }
@@ -26,6 +30,26 @@ inline void checkArgsSize(size_t number, size_t expected,
             throw HttpReturnException(400, fctName + "expected " + to_string(expected) + " arguments, got " + to_string(number));
         else
             throw HttpReturnException(400, fctName + "expected " + to_string(expected) + " argument, got " + to_string(number));
+    }
+}
+
+inline void checkArgsSize(size_t number, size_t minArgs, size_t maxArgs,
+                          const Utf8String & fctName_=NO_FUNCTION_NAME)
+{
+    if (minArgs == maxArgs) {
+        checkArgsSize(number, minArgs, fctName_);
+        return;
+    }
+    if (number < minArgs || number > maxArgs) {
+        auto fctName = fctName_;
+        if (!fctName.empty()) {
+            fctName = "function " + fctName + " ";
+        }
+        throw HttpReturnException
+            (400, fctName + "expected between "
+             + std::to_string(minArgs) + " and "
+             + std::to_string(maxArgs) + " arguments, got "
+             + std::to_string(number));
     }
 }
 

--- a/testing/MLDB-1554-string-agg.js
+++ b/testing/MLDB-1554-string-agg.js
@@ -31,7 +31,7 @@ recordExample("plum", "died", "stabbed");
 dataset.commit()
 
 var resp = mldb.get("/v1/query", 
-    {q: "SELECT string_agg(what, ', ') AS whats, string_agg(how, '') AS hows NAMED who FROM test GROUP BY who ORDER BY who",
+    {q: "SELECT string_agg(what, ', ', rowName()) AS whats, string_agg(how, '', rowName()) AS hows NAMED who FROM test GROUP BY who ORDER BY who",
     format: 'sparse'});
 
 plugin.log(resp.json);
@@ -41,8 +41,8 @@ assertEqual(resp.responseCode, 200, "Error executing query");
 expected = [
    [
       [ "_rowName", "mustard" ],
-      [ "hows", "plumplumkitchen" ],
-      [ "whats", "killed, stabbed, moved" ]
+      [ "hows", "kitchenplumplum" ],
+      [ "whats", "moved, stabbed, killed" ]
    ],
    [
       [ "_rowName", "plum" ],


### PR DESCRIPTION
The `string_agg` operator will aggregate in whatever order it gets fed values.  While this is sometimes OK, that order happens to depend upon the order that std::unordered_map holds entries, and so varies from compiler to compiler.  This makes unit testing hard and is basically wrong.

This patch changes that to by default sort them alphabetically first.  If that isn't what was wanted, it now accepts a third argument that is the sort key, and the values will be sorted by that first before sorting alphabetically to break ties.  This allows us to pass for example the rowPath() as a sort key and get a consistent ordering across the underlying dataset.

Documentation and tests were updated.