### PR TITLE
MLDB-1923 clang 3.8 compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ TESTS   := $(BUILD)/$(ARCH)/tests
 TMPBIN	:= $(BUILD)/$(ARCH)/tmp
 INC     := $(BUILD)/$(ARCH)/include
 SRC     := .
-TMP     ?= $(BUILD)/$(ARCH)/tmp
+TMP     ?= $(PWD)/$(BUILD)/$(ARCH)/tmp
 
 # These are for cross-compilation, where binaries used in the build need
 # be be built for the host.

--- a/arch/simd_vector.cc
+++ b/arch/simd_vector.cc
@@ -37,7 +37,9 @@ void vec_scale(const float * x, float k, float * r, size_t n)
 {
     size_t i = 0;
 
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else {
         v4sf kkkk = vec_splat(k);
@@ -71,7 +73,9 @@ void vec_add(const float * x, const float * y, float * r, size_t n)
 {
     size_t i = 0;
 
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else {
         //cerr << "unoptimized" << endl;
@@ -110,7 +114,9 @@ void vec_prod(const float * x, const float * y, float * r, size_t n)
 {
     size_t i = 0;
 
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else {
         //cerr << "unoptimized" << endl;
@@ -150,7 +156,9 @@ void vec_prod(const float * x, const double * y, float * r, size_t n)
     size_t i = 0;
 
 #if 0 // TODO: do
-    if (false) ;
+        if (false)
+        ;
+
     else {
         //cerr << "unoptimized" << endl;
         
@@ -366,7 +374,9 @@ void vec_scale(const double * x, double k, double * r, size_t n)
 {
     size_t i = 0;
 
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else {
         v2df kk = vec_splat(k);
@@ -564,7 +574,9 @@ void vec_minus_sse2(const float * x, const float * y, float * r, size_t n)
 {
     size_t i = 0;
 
-    if (false) ;
+        if (false)
+        ;
+
     else {
         //cerr << "unoptimized" << endl;
         
@@ -620,7 +632,9 @@ double vec_dotprod(const double * x, const double * y, size_t n)
 double vec_dotprod(const double * x, const double * y, size_t n)
 {
     // Interrogate the cpuid flags directly to decide which one to use
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else if (has_avx()) {
         return Avx::vec_dotprod(x, y, n);
@@ -639,7 +653,8 @@ double vec_dotprod(const double * x, const double * y, size_t n)
 void vec_minus(const float * x, const float * y, float * r, size_t n)
 {
     // Interrogate the cpuid flags directly to decide which one to use
-    if (false) ;
+    if (false)
+        ;
 #if JML_INTEL_ISA
     if (has_avx()) {
         Avx::vec_minus(x, y, r, n);
@@ -656,7 +671,9 @@ void vec_minus(const float * x, const float * y, float * r, size_t n)
 double vec_euclid(const float * x, const float * y, size_t n)
 {
     // Interrogate the cpuid flags directly to decide which one to use
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     if (has_avx()) {
         return Avx::vec_euclid(x, y, n);
@@ -990,7 +1007,9 @@ double vec_dotprod_dp(const double * x, const float * y, size_t n)
     double res = 0.0;
 
     size_t i = 0;
-    if (false) ;
+        if (false)
+        ;
+
 
 #if JML_INTEL_ISA
     else if (true) {
@@ -1050,7 +1069,9 @@ double vec_dotprod_dp(const double * x, const float * y, size_t n)
 double vec_dotprod_dp(const float * x, const float * y, size_t n)
 {
     // Interrogate the cpuid flags directly to decide which one to use
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else if (has_avx()) {
         return Avx::vec_dotprod_dp(x, y, n);
@@ -1579,7 +1600,9 @@ void vec_add(const float * x, const double * k, const double * y, float * r,
 {
     size_t i = 0;
 
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else {
         for (; i + 4 <= n;  i += 4) {
@@ -1613,7 +1636,9 @@ void vec_add(const float * x, const float * k, const double * y, float * r,
 {
     size_t i = 0;
 
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else {
         for (; i + 4 <= n;  i += 4) {
@@ -1649,7 +1674,9 @@ void vec_add(const double * x, const float * k, const float * y, double * r,
 {
     size_t i = 0;
 
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else {
         for (; i + 4 <= n;  i += 4) {
@@ -1680,7 +1707,9 @@ void vec_add(const double * x, const float * k, const double * y, double * r,
 {
     size_t i = 0;
 
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else {
         for (; i + 4 <= n;  i += 4) {
@@ -1789,7 +1818,9 @@ void vec_min_max_el(const float * x, float * mins, float * maxs, size_t n)
 {
     size_t i = 0;
 
-    if (false) ;
+        if (false)
+        ;
+
 #if JML_INTEL_ISA
     else {
         for (; i + 4 <= n;  i += 4) {

--- a/arch/spinlock.h
+++ b/arch/spinlock.h
@@ -25,7 +25,7 @@ namespace ML {
 
 struct Spinlock {
     Spinlock(int yieldAfter = 100)
-        : value(ATOMIC_FLAG_INIT), yieldAfter(yieldAfter)
+        : yieldAfter(yieldAfter)
     {
     }
 
@@ -66,7 +66,7 @@ struct Spinlock {
     /// way we can avoid including <thread>.
     static void yield();
 
-    std::atomic_flag value;
+    std::atomic_flag value = ATOMIC_FLAG_INIT;
 
     /// How many times to spin before we yield?
     int yieldAfter;

--- a/arch/testing/gc_lock_test_common.h
+++ b/arch/testing/gc_lock_test_common.h
@@ -193,7 +193,7 @@ struct TestBase {
 
     std::atomic<bool> finished;
     std::atomic<int> nthreads;
-    std::atomic<int> nblocks;
+    int nblocks;
     std::atomic<int> nSpinThreads;
     Allocator<int> allocator;
     Lock gc;

--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -318,10 +318,10 @@ struct JoinedDataset::Itl
         RowName rowName;
 
         if (chainedJoinDepth > 0 && !leftName.empty()) {
-            rowName = std::move(RowName(leftName.toUtf8String() + "-" + "[" + rightName.toUtf8String() + "]"));
+            rowName = RowName(leftName.toUtf8String() + "-" + "[" + rightName.toUtf8String() + "]");
         }
         else if (chainedJoinDepth == 0) {
-            rowName = std::move(RowName("[" + leftName.toUtf8String() + "]" + "-" + "[" + rightName.toUtf8String() + "]"));
+            rowName = RowName("[" + leftName.toUtf8String() + "]" + "-" + "[" + rightName.toUtf8String() + "]");
         }
         else {
             Utf8String left;
@@ -329,7 +329,7 @@ struct JoinedDataset::Itl
                 left += "[]-";
             }
 
-            rowName = std::move(RowName(left + "[" + rightName.toUtf8String() + "]"));
+            rowName = RowName(left + "[" + rightName.toUtf8String() + "]");
         }
 
 #if 0

--- a/builtin/merge_hash_entries.h
+++ b/builtin/merge_hash_entries.h
@@ -239,7 +239,7 @@ extractAndMerge(size_t numElementsToMerge,
     // Phase 1: extract each into a lot of buckets
     auto onEntry = [&] (int i)
         {
-            allEntries[i] = std::move(getEntries(i));
+            allEntries[i] = getEntries(i);
         };
 
     parallelMap(0, numElementsToMerge, onEntry);
@@ -281,7 +281,7 @@ extractAndMerge(size_t numElementsToMerge,
 
     parallelMap(0, MergeHashEntries::NBUCKETS, mergeBucket);
 
-    return std::move(result);
+    return result;
 }
 
 

--- a/builtin/merged_dataset.cc
+++ b/builtin/merged_dataset.cc
@@ -232,7 +232,7 @@ struct MergedDataset::Itl
         std::vector<RowName> result;
 
         for (auto & h: getRowHashes(start, limit))
-            result.emplace_back(std::move(getRowName(h)));
+            result.emplace_back(getRowName(h));
 
         return result;
     }
@@ -293,7 +293,7 @@ struct MergedDataset::Itl
             throw ML::Exception("Row not known");
 
         int bit = ML::lowest_bit(bitmap, -1);
-        MatrixNamedRow result = std::move(datasets[bit]->getMatrixView()->getRow(rowName));
+        MatrixNamedRow result = datasets[bit]->getMatrixView()->getRow(rowName);
         bitmap = bitmap & ~(1 << bit);
 
         while (bitmap) {
@@ -381,7 +381,7 @@ struct MergedDataset::Itl
             throw ML::Exception("Column not known");
 
         int bit = ML::lowest_bit(bitmap, -1);
-        MatrixColumn result = std::move(datasets[bit]->getColumnIndex()->getColumn(columnHash));
+        MatrixColumn result = datasets[bit]->getColumnIndex()->getColumn(columnHash);
         bitmap = bitmap & ~(1 << bit);
 
         while (bitmap) {
@@ -409,7 +409,7 @@ struct MergedDataset::Itl
         if (bitmap)
         {
             int bit = ML::lowest_bit(bitmap, -1);
-            result = std::move(datasets[bit]->getColumnIndex()->getColumnValues(columnName, filter));
+            result = datasets[bit]->getColumnIndex()->getColumnValues(columnName, filter);
 
             bitmap = bitmap & ~(1 << bit);
             bool sorted = std::is_sorted(result.begin(), result.end());  // true

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -26,6 +26,11 @@
 #define JML_DEPRECATED __attribute__((__deprecated__))
 #define JML_ALIGNED(x) __attribute__((__aligned__(x)))
 #define JML_FORMAT_STRING(arg1, arg2) __attribute__((__format__ (printf, arg1, arg2)))
+#ifdef __clang__
+#  define JML_UNUSED_PRIVATE_FIELD  __attribute__((__unused__))
+#else
+#  define JML_UNUSED_PRIVATE_FIELD
+#endif
 
 // Macro to catch all exceptions apart from stack unwinding exceptions...
 // it's against the standard to do catch(...) without rethrowing.

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -378,7 +378,7 @@ getColumnValues(const ColumnName & column,
                      result.end());
     }
 
-    return std::move(result);
+    return result;
 }
 
 std::vector<CellValue>
@@ -408,7 +408,7 @@ getColumnDense(const ColumnName & column) const
         result.push_back(values.find(name)->second.first);
     } 
 
-    return std::move(result);
+    return result;
 }
 
 std::tuple<BucketList, BucketDescriptions>
@@ -746,7 +746,7 @@ getRowInfo() const
     std::vector<KnownColumn> knownColumns;
 
     for (auto & c: getColumnNames()) {
-        knownColumns.emplace_back(std::move(getKnownColumnInfo(c)));
+        knownColumns.emplace_back(getKnownColumnInfo(c));
     }
 
     return std::make_shared<RowValueInfo>(std::move(knownColumns),
@@ -930,7 +930,7 @@ executeFilteredColumnExpression(const Dataset & dataset,
         rows.erase(std::unique(rows.begin(), rows.end()),
                    rows.end());
 
-        return std::pair<std::vector<RowName>, Any>(std::move(rows), std::move(Any()));
+        return std::pair<std::vector<RowName>, Any>(std::move(rows), Any());
     }
     else {
         return {};
@@ -1821,7 +1821,7 @@ generateRowsWhere(const SqlBindingScope & scope,
 
                         MatrixNamedRow row;
                         if (needsColumns)
-                            row = std::move(matrix->getRow(r));
+                            row = matrix->getRow(r);
                         else {
                             row.rowHash = row.rowName = r;
                         }
@@ -1865,8 +1865,8 @@ generateRowsWhere(const SqlBindingScope & scope,
                 if (rows.size() == limit)
                     newToken = start;
                 
-                return std::move(make_pair(std::move(rowsToKeep),
-                                           std::move(newToken)));
+                return make_pair(std::move(rowsToKeep),
+                                 std::move(newToken));
             },
             "scan table filtering by where expression"};
 }

--- a/ext/jsoncpp/json_value.cpp
+++ b/ext/jsoncpp/json_value.cpp
@@ -1459,7 +1459,7 @@ Value::toStringNoNewLine() const
     std::string str = toString();
     if (str.back() == '\n')
         str.erase(str.size() - 1);
-    return std::move(str);
+    return str;
 }
 
 

--- a/ext/protobuf.mk
+++ b/ext/protobuf.mk
@@ -20,6 +20,7 @@ define build_protobuf_for_arch
 PROTOC_EXTRA_ARGS_$(1):=$(if $(call sne,$(1),$(HOSTARCH)),--with-protoc=$(PWD)/$(HOSTBIN)/protoc --host=$(1)-linux-gnu --target=$(1)-linux-gnu)$(if $(call seq,$(1),$(ARCH)), CC="$(CC)" CXX="$(CXX)")
 
 $(4)/protoc: $(if $(call sne,$(1),$(HOSTARCH)),$(HOSTBIN)/protoc)
+	@mkdir -p $(TMP)
 	@echo "   $(COLOR_BLUE)[COPY EXTERN]$(COLOR_RESET)                      	protobuf3 $(1)"
 	@mkdir -p $(BUILD)/$(1)/tmp/protobuf-build
 	@cp -rf mldb/ext/protobuf/* $(BUILD)/$(1)/tmp/protobuf-build

--- a/ext/tensorflow.mk
+++ b/ext/tensorflow.mk
@@ -59,7 +59,7 @@ TENSORFLOW_PROTO_TEXT_FILES := $(PROTO_TEXT_CC_FILES)
 
 $(TENSORFLOW_PROTO_TEXT_FILES:%=$(CWD)/%): | $(TENSORFLOW_INCLUDES) $(INC)/external/re2 $(INC)/external/jpeg-9a $(HOSTBIN)/protoc $(LIB)/libprotobuf3.so  $(INC)/google/protobuf
 
-$(eval $(call set_compile_option,$(TENSORFLOW_PROTO_TEXT_FILES),$(TENSORFLOW_BASE_INCLUDE_FLAGS) -Wno-unused-private-field))
+$(eval $(call set_compile_option,$(TENSORFLOW_PROTO_TEXT_FILES),$(TENSORFLOW_BASE_INCLUDE_FLAGS) -Wno-unused-private-field -Wno-unused-const-variable))
 
 $(eval $(call program,proto_text,protobuf3,$(TENSORFLOW_PROTO_TEXT_FILES)))
 
@@ -253,7 +253,7 @@ endif
 ifeq ($(toolchain),clang)
 # -Wno-error should not be used but so far it seems like the only way to mute
 # warning: braces around scalar initializer
-TENSORFLOW_WARNING_FLAGS := -Wno-unused-const-variable -Wno-unused-private-field -Wno-tautological-undefined-compare -Wno-missing-braces -Wno-absolute-value -Wno-unused-function -Wno-inconsistent-missing-override -Wno-constant-conversion -Wno-unused-variable -Wno-error
+TENSORFLOW_WARNING_FLAGS := -Wno-unused-const-variable -Wno-unused-private-field -Wno-tautological-undefined-compare -Wno-missing-braces -Wno-absolute-value -Wno-unused-function -Wno-inconsistent-missing-override -Wno-constant-conversion -Wno-unused-variable -Wno-error -Wno-braced-scalar-init
 endif
 
 # Second, the include directories required

--- a/http/http_rest_proxy.cc
+++ b/http/http_rest_proxy.cc
@@ -204,7 +204,7 @@ struct HttpRestProxy::Itl {
             // Set proxy to this, so when it's destroyed it's put on our list
             ExcAssert(res.proxy == nullptr);
             res.proxy = owner;
-            return std::move(res);
+            return res;
         }
     }
     

--- a/http/testing/http_client_test.cc
+++ b/http/testing/http_client_test.cc
@@ -501,7 +501,7 @@ BOOST_AUTO_TEST_CASE( test_http_client_move_constructor )
     auto makeClient = [&] () {
         return HttpClient(legacyLoop, baseUrl, 1);
     };
-    HttpClient client1(move(makeClient()));
+    HttpClient client1(makeClient());
     doGet(client1);
 
     /* move assignment operator */

--- a/http/testing/http_header_test.cc
+++ b/http/testing/http_header_test.cc
@@ -57,7 +57,7 @@ Datacratic::HttpHeader generateParser(const std::string& q)
     const std::string query = "GET " + q + " HTTP/1.1\r\n\r\n";
     Datacratic::HttpHeader parser;
     parser.parse(query);
-    return std::move(parser);
+    return parser;
 }
 
 void testQueryParam(const Datacratic::HttpHeader& header,

--- a/jml-build/clang.mk
+++ b/jml-build/clang.mk
@@ -1,5 +1,7 @@
-CLANGXX:=clang++-3.6
-CLANG:=clang-3.6
+# Note: clang 3.6 won't compile MLDB if GCC6 is installed
+
+CLANGXX:=clang++-3.8
+CLANG:=clang-3.8
 
 CLANG_VERSION:=$(shell $(CLANGXX) --version | head -n1 | awk '{ print $4; }' | sed 's/-*//g')
 CXX_VERSION?=$(CLANG_VERSION)
@@ -7,7 +9,7 @@ CXX := $(COMPILER_CACHE) $(CLANGXX)
 
 $(warning building with clang++ version $(CLANG_VERSION))
 
-CLANGXXWARNINGFLAGS?=-Wall -Werror -Wno-sign-compare -Woverloaded-virtual -Wno-deprecated-declarations -Wno-deprecated -Winit-self -Qunused-arguments -Wno-mismatched-tags -Wno-unused-function
+CLANGXXWARNINGFLAGS?=-Wall -Werror -Wno-sign-compare -Woverloaded-virtual -Wno-deprecated-declarations -Wno-deprecated -Winit-self -Qunused-arguments -Wno-mismatched-tags -Wno-unused-function -ftemplate-backtrace-limit=0
 
 CXXFLAGS ?= $(ARCHFLAGS) $(INCLUDE) $(CLANGXXWARNINGFLAGS) -pipe -ggdb $(foreach dir,$(LOCAL_INCLUDE_DIR),-I$(dir)) -std=c++0x 
 CXXNODEBUGFLAGS := -O3 -DBOOST_DISABLE_ASSERTS -DNDEBUG 

--- a/jml/utils/csv.cc
+++ b/jml/utils/csv.cc
@@ -84,7 +84,7 @@ std::string expect_csv_field(Parse_Context & context, bool & another,
     if (quoted)
         throw FileFinishInsideQuote("file finished inside quote");
 
-    return std::move(result);
+    return result;
 }
 
 std::vector<std::string>
@@ -101,7 +101,7 @@ expect_csv_row(Parse_Context & context, int length, char separator)
 
     bool another = false;
     while (another || (context && !context.match_eol() && *context != '\r')) {
-        result.emplace_back(std::move(expect_csv_field(context, another, separator)));
+        result.emplace_back(expect_csv_field(context, another, separator));
         //cerr << "read " << result.back() << " another = " << another << endl;
     }
 
@@ -113,7 +113,7 @@ expect_csv_row(Parse_Context & context, int length, char separator)
     
     //cerr << "returning result" << endl;
 
-    return std::move(result);
+    return result;
 }
 
 std::string csv_escape(const std::string & s)

--- a/ml/algebra/irls.cc
+++ b/ml/algebra/irls.cc
@@ -18,6 +18,7 @@
 #include "multi_array_utils.h"
 #include "mldb/jml/utils/string_functions.h"
 #include "mldb/ml/algebra/lapack.h"
+#include <cmath>
 
 using namespace std;
 using namespace ML;
@@ -28,12 +29,14 @@ namespace ML {
 
 double erf(double x)
 {
-    return ::erf(x);
+    return std::erf(x);
 }
 
 double erfinv(double y)
 {
-    return ::erfinv(y);
+    // TODO: if we use boost here, then Valgrind doesn't work
+    throw ML::Exception("no error function inverse available");
+    //return std::erfinv(y);
 }
 
 } // namespace ML

--- a/plugins/embedding.cc
+++ b/plugins/embedding.cc
@@ -31,37 +31,19 @@ using namespace std;
 namespace Datacratic {
 namespace MLDB {
 
-inline ML::DB::Store_Writer &
-operator << (ML::DB::Store_Writer & store, const PathElement & coord)
-{
-    // Currently not used, since we haven't exposed serialization
-    // of embedding datasets.
-    throw ML::Exception("PathElement serialization");
-}
+// Defined in stats_table_procedure.cc, until we move them somewhere
+// more sensible
+ML::DB::Store_Writer &
+operator << (ML::DB::Store_Writer & store, const PathElement & coord);
 
-inline ML::DB::Store_Reader &
-operator >> (ML::DB::Store_Reader & store, PathElement & coord)
-{
-    // Currently not used, since we haven't exposed serialization
-    // of embedding datasets.
-    throw ML::Exception("PathElement deserialization");
-}
+ML::DB::Store_Reader &
+operator >> (ML::DB::Store_Reader & store, PathElement & coord);
 
-inline ML::DB::Store_Writer &
-operator << (ML::DB::Store_Writer & store, const Path & coords)
-{
-    // Currently not used, since we haven't exposed serialization
-    // of embedding datasets.
-    throw ML::Exception("Path serialization");
-}
+ML::DB::Store_Writer &
+operator << (ML::DB::Store_Writer & store, const Path & coords);
 
-inline ML::DB::Store_Reader &
-operator >> (ML::DB::Store_Reader & store, Path & coords)
-{
-    // Currently not used, since we haven't exposed serialization
-    // of embedding datasets.
-    throw ML::Exception("Path deserialization");
-}
+ML::DB::Store_Reader &
+operator >> (ML::DB::Store_Reader & store, Path & coords);
 
 
 /*****************************************************************************/

--- a/plugins/fetcher.cc
+++ b/plugins/fetcher.cc
@@ -108,7 +108,7 @@ struct FetcherFunction: public ValueFunctionT<FetcherArgs, FetcherOutput> {
             else {
                 std::ostringstream streamo;
                 streamo << stream.rdbuf();
-                blob = CellValue::blob(std::move(streamo.str()));
+                blob = CellValue::blob(streamo.str());
             }
 
             result.content = ExpressionValue(std::move(blob), info.lastModified);

--- a/plugins/importtext_procedure.cc
+++ b/plugins/importtext_procedure.cc
@@ -198,7 +198,7 @@ struct SqlCsvScope: public SqlExpressionMldbScope {
                      const VariableFilter & filter) -> const ExpressionValue &
                 {
                     auto & row = scope.as<RowScope>();
-                    return storage = std::move(ExpressionValue(row.row[index], row.ts));
+                    return storage = ExpressionValue(row.row[index], row.ts);
                 },
                 std::make_shared<AtomValueInfo>()};
     }
@@ -246,7 +246,7 @@ struct SqlCsvScope: public SqlExpressionMldbScope {
                         result.emplace_back(columnNames[i], row.row[i], row.ts);
                 }
 
-                return std::move(result);
+                return result;
             };
 
         GetAllColumnsOutput result;

--- a/plugins/lang/js/mldb_js.cc
+++ b/plugins/lang/js/mldb_js.cc
@@ -367,7 +367,7 @@ struct StreamJS::Methods {
                 std::ostringstream buf;
                 buf << stream->rdbuf();
 
-                args.GetReturnValue().Set(JS::toJS(CellValue::blob(std::move(buf.str()))));
+                args.GetReturnValue().Set(JS::toJS(CellValue::blob(buf.str())));
             }
             else {
                 // Load from the blob
@@ -492,7 +492,7 @@ struct RandomNumberGenerator {
 
     double uniform(double min = 0.0, double max = 1.0)
     {
-        return min + (max - min) * uniform();
+        return min + (max - min) * uniform01();
     }
 
     double normal(double mean = 0.0, double stddev = 1.0)

--- a/plugins/lang/python/mldb_python_converters.h
+++ b/plugins/lang/python/mldb_python_converters.h
@@ -177,8 +177,8 @@ struct PathConverter
 
         std::vector<PathElement> el_container;
         for (boost::python::ssize_t i = 0; i < n; ++i){
-            el_container.push_back(std::move(
-                        pyToPathElement(boost::python::object(pyList[i]).ptr())));
+            el_container.emplace_back(
+                        pyToPathElement(boost::python::object(pyList[i]).ptr()));
         }
 
         new (storage) Path(el_container.begin(), el_container.end());

--- a/plugins/matrix.cc
+++ b/plugins/matrix.cc
@@ -160,7 +160,7 @@ classifyColumns(const Dataset & dataset, SelectExpression select)
     result.sparseColumns = std::move(sparseColumns);
     result.sparseIndex = std::move(sparseIndex);
 
-    return std::move(result);
+    return result;
 }
 
 FeatureBuckets 
@@ -284,7 +284,7 @@ extractFeaturesFromRows(const Dataset & dataset,
     }
 #endif
 
-    return std::move(featureBuckets);
+    return featureBuckets;
 }
 
 ColumnIndexEntries
@@ -378,7 +378,7 @@ invertFeatures(const ClassifiedColumns & columns,
     cerr << "done feature matrix inversion" << endl;
     cerr << timer.elapsed() << endl;
 
-    return std::move(result);
+    return result;
 }
 
 ColumnCorrelations
@@ -447,7 +447,7 @@ calculateCorrelations(const ColumnIndexEntries & columnIndex,
 
     cerr << "done processing correlations" << endl;
 
-    return std::move(result);
+    return result;
 }
 
 } // namespace MLDB

--- a/plugins/nlp.cc
+++ b/plugins/nlp.cc
@@ -176,7 +176,7 @@ call(Words input) const
 
             auto it = accum.find(col);
             if(it == accum.end()) {
-                accum.emplace(col, std::move(make_pair(val_as_double, ts)));
+                accum.emplace(col, make_pair(val_as_double, ts));
             }
             else {
                 it->second.first += val_as_double;

--- a/plugins/stats_table_procedure.cc
+++ b/plugins/stats_table_procedure.cc
@@ -35,7 +35,6 @@ using namespace std;
 namespace Datacratic {
 namespace MLDB {
 
-
 inline ML::DB::Store_Writer &
 operator << (ML::DB::Store_Writer & store, const PathElement & coord)
 {
@@ -85,8 +84,8 @@ increment(const CellValue & val, const vector<uint> & outcomes) {
     auto it = counts.find(key);
     if(it == counts.end()) {
         auto rtn = counts.emplace(
-            key, std::move(make_pair(1, vector<int64_t>(outcomes.begin(),
-                                                        outcomes.end()))));
+            key, make_pair(1, vector<int64_t>(outcomes.begin(),
+                                              outcomes.end())));
         // return inserted value
         return (*(rtn.first)).second;
     }

--- a/plugins/svd.cc
+++ b/plugins/svd.cc
@@ -1062,7 +1062,7 @@ SvdEmbedRow(MldbServer * owner,
     : BaseT(owner)
 {
     functionConfig = config.params.convert<SvdEmbedConfig>();
-    svd = std::move(jsonDecodeFile<SvdBasis>(functionConfig.modelFileUrl.toDecodedString()));
+    svd = jsonDecodeFile<SvdBasis>(functionConfig.modelFileUrl.toDecodedString());
 
     std::map<ColumnHash, SvdColumnIndexEntry> columnIndex2;
 

--- a/plugins/svm.cc
+++ b/plugins/svm.cc
@@ -445,7 +445,7 @@ call(SVMFunctionArgs input) const
     Date ts = input.embedding.getEffectiveTimestamp();
 
     svm_node * x = new svm_node[embedding.size()+1];
-    Scope_Exit(delete x);
+    Scope_Exit(delete[] x);
 
     int nbSparse = 0;
     for (size_t i = 0; i < embedding.size(); ++i) {

--- a/plugins/tabular_dataset.cc
+++ b/plugins/tabular_dataset.cc
@@ -134,7 +134,7 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
             const RowName & row = rowName(storage);
             advance();
             if (&storage == &row)
-                return std::move(storage);
+                return storage;
             else return row;
         }
 
@@ -159,7 +159,7 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
 
         static CellValue extractVal(CellValue val, CellValue *)
         {
-            return std::move(val);
+            return val;
         }
 
         template<typename T>

--- a/plugins/tokensplit.cc
+++ b/plugins/tokensplit.cc
@@ -75,7 +75,7 @@ TokenSplit(MldbServer * owner,
             for (auto & c: row.columns) {
                 const CellValue & cellValue = std::get<1>(c);
                 
-                dictionary.emplace_back(std::move(cellValue.toUtf8String()));
+                dictionary.emplace_back(cellValue.toUtf8String());
             }
             
             return true;

--- a/plugins/xlsx_importer.cc
+++ b/plugins/xlsx_importer.cc
@@ -727,7 +727,7 @@ struct XlsxImporter: public Procedure {
                     else {
                         std::ostringstream stream;
                         stream << open({}).buf;
-                        savedRelationships = std::move(stream.str());
+                        savedRelationships = stream.str();
                     }
                 }
                 else if (internalFilename == "xl/styles.xml") {

--- a/postgresql/postgresql_plugin.cc
+++ b/postgresql/postgresql_plugin.cc
@@ -136,24 +136,24 @@ struct PostgresqlDataset: public Dataset {
         return startPostgresqlConnection(config_.databaseName, config_.host, config_.port);
     }
 
-    virtual Any getStatus() const
+    virtual Any getStatus() const override
     {
         return string("ok");
     }
 
     virtual void recordRowItl(const RowName & rowName,
-                              const std::vector<std::tuple<ColumnName, CellValue, Date> > & vals)
+                              const std::vector<std::tuple<ColumnName, CellValue, Date> > & vals) override
     {
         throw HttpReturnException(400, "PostgreSQL dataset is read-only");
     }
     
-    virtual void recordRows(const std::vector<std::pair<RowName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > & rows)
+    virtual void recordRows(const std::vector<std::pair<RowName, std::vector<std::tuple<ColumnName, CellValue, Date> > > > & rows) override
     {
         throw HttpReturnException(400, "PostgreSQL dataset is read-only");
     }
 
     /** Commit changes to the database.  Default is a no-op. */
-    virtual void commit()
+    virtual void commit() override
     {
         throw HttpReturnException(400, "PostgreSQL dataset is read-only");
     }
@@ -244,8 +244,8 @@ struct PostgresqlDataset: public Dataset {
             if (rowsToKeep.size() == limit)
                 newToken = start;
 
-            return std::move(make_pair(std::move(rowsToKeep),
-                                       std::move(newToken)));
+            return make_pair(std::move(rowsToKeep),
+                             std::move(newToken));
         },
         "PostgresqlDataset row generation"};
 
@@ -299,9 +299,9 @@ struct PostgresqlDataset: public Dataset {
 
     }
 
-    /** Return wheter or not all columns names and info are known.
+    /** Return whether or not all columns names and info are known.
     */
-    virtual bool hasColumnNames() const { return false; }
+    virtual bool hasColumnNames() const override { return false; }
 
 };
 

--- a/rest/rest_collection.cc
+++ b/rest/rest_collection.cc
@@ -339,7 +339,7 @@ watchWithPath(const ResourceSpec & spec,
     // 1.  Watch the path, so that we know of any entities that come or
     //     go on the path.
     data->childWatch
-        = std::move(watchChildren(spec[0].filter, true /* catchup */, info));
+        = watchChildren(spec[0].filter, true /* catchup */, info);
 
     ExcAssert(!data->childWatch.bound());
 

--- a/rest/rest_request_params.cc
+++ b/rest/rest_request_params.cc
@@ -27,12 +27,12 @@ Utf8String restDecode(std::string str, Utf8String *)
 
 std::string restDecode(std::string str, std::string *)
 {
-    return std::move(str);
+    return str;
 }
 
 Utf8String restDecode(Utf8String str, Utf8String *)
 {
-    return std::move(str);
+    return str;
 }
 
 std::string restDecode(Utf8String str, std::string *)

--- a/rest/rest_request_params.h
+++ b/rest/rest_request_params.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** rest_request_params.h                                          -*- C++ -*-
     Jeremy Barnes, 24 January 2014
     Copyright (c) 2014 Datacratic Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
 */
 
@@ -112,7 +111,7 @@ struct JsonStrCodec {
         std::ostringstream stream;
         StreamJsonPrintingContext context(stream);
         desc->printJson(&obj, context);
-        return std::move(stream.str());
+        return stream.str();
     }
 
     std::shared_ptr<const ValueDescriptionT<T> > desc;

--- a/rest/rest_request_router.h
+++ b/rest/rest_request_router.h
@@ -266,7 +266,7 @@ struct RestRequestParsingContext {
     struct ObjectEntry {
         ObjectEntry(void * obj = nullptr,
                     const std::type_info * type = nullptr,
-                    std::function<void (void *) noexcept> deleter = nullptr)
+                    std::function<void (void *) noexcept> deleter = nullptr) noexcept
             : obj(obj), type(type), deleter(std::move(deleter))
         {
         }
@@ -281,9 +281,31 @@ struct RestRequestParsingContext {
         const std::type_info * type;
         std::function<void (void *) noexcept> deleter;
 
-        //ObjectEntry(const ObjectEntry &) = delete;
-        //void operator = (const ObjectEntry &) = delete;
+        ObjectEntry(const ObjectEntry &) = delete;
+        void operator = (const ObjectEntry &) = delete;
 
+        ObjectEntry(ObjectEntry && other) noexcept
+            : obj(other.obj), type(other.type), deleter(std::move(other.deleter))
+        {
+            other.obj = nullptr;
+            other.deleter = nullptr;
+        }
+
+        ObjectEntry & operator = (ObjectEntry && other) noexcept
+        {
+            ObjectEntry newMe(std::move(other));
+            swap(newMe);
+            return *this;
+        }
+
+        void swap(ObjectEntry & other) noexcept
+        {
+            std::swap(obj, other.obj);
+            std::swap(type, other.type);
+            std::swap(deleter, other.deleter);
+        }
+
+#if 0
         // Needed for gcc 4.6
         ObjectEntry(const ObjectEntry & other)
             : obj(other.obj), type(other.type)
@@ -299,6 +321,7 @@ struct RestRequestParsingContext {
             ObjectEntry newMe(other);
             *this = std::move(newMe);
         }
+#endif
     };
 
     /// List of extracted objects to which path components refer.  Both the
@@ -345,7 +368,7 @@ struct RestRequestParsingContext {
         RestRequestParsingContext * obj;
 
         StateGuard(RestRequestParsingContext * obj)
-            : state(std::move(obj->saveState())),
+            : state(obj->saveState()),
               obj(obj)
         {
         }

--- a/server/analytics.cc
+++ b/server/analytics.cc
@@ -190,7 +190,7 @@ void iterateDense(const SelectExpression & select,
 
             vector<ExpressionValue> calcd(boundCalc.size());
             for (unsigned i = 0;  i < boundCalc.size();  ++i) {
-                calcd[i] = std::move(boundCalc[i](rowContext, GET_LATEST));
+                calcd[i] = boundCalc[i](rowContext, GET_LATEST);
             }
             
             /* Finally, pass to the aggregator to continue. */

--- a/server/bound_queries.cc
+++ b/server/bound_queries.cc
@@ -347,7 +347,7 @@ struct UnorderedExecutor: public BoundSelectQuery::Executor {
         // Run the extra calculations before the select, as the select may
         // destroy the input if it's a select star.
         for (unsigned i = 0;  i < boundCalc.size();  ++i) {
-            calcd[i] = std::move(boundCalc[i](selectRowScope, GET_LATEST));
+            calcd[i] = boundCalc[i](selectRowScope, GET_LATEST);
         }
 
         if (selectStar) {
@@ -470,7 +470,7 @@ struct OrderedExecutor: public BoundSelectQuery::Executor {
 
                 vector<ExpressionValue> calcd(boundCalc.size());
                 for (unsigned i = 0;  i < boundCalc.size();  ++i) {
-                    calcd[i] = std::move(boundCalc[i](selectRowScope, GET_LATEST));
+                    calcd[i] = boundCalc[i](selectRowScope, GET_LATEST);
                 }
 
                 // Get the order by context, which can read from both the result
@@ -699,8 +699,7 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
                 //         << minRowNum << " maxRowNumNeeded " << maxRowNumNeeded
                 //         << " maxRowNum " << maxRowNum << endl;
 
-                QueryThreadTracker childTracker
-                    = std::move(parentTracker.child());
+                QueryThreadTracker childTracker = parentTracker.child();
 
                 ExpressionValue row;
                 try {
@@ -745,7 +744,7 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
 
                     vector<ExpressionValue> calcd(boundCalc.size());
                     for (unsigned i = 0;  i < boundCalc.size();  ++i) {
-                        calcd[i] = std::move(boundCalc[i](rowContext, GET_LATEST));
+                        calcd[i] = boundCalc[i](rowContext, GET_LATEST);
                     }
 
                     if (selectStar) {
@@ -1013,7 +1012,7 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
 
             vector<ExpressionValue> calcd(boundCalc.size());
             for (unsigned i = 0;  i < boundCalc.size();  ++i) {
-                calcd[i] = std::move(boundCalc[i](rowContext, GET_LATEST));
+                calcd[i] = boundCalc[i](rowContext, GET_LATEST);
             }
 
             if (selectStar) {

--- a/server/bound_queries.h
+++ b/server/bound_queries.h
@@ -37,7 +37,7 @@ struct QueryThreadTracker {
         QueryThreadTracker result;
         result.inParent = false;
         ++depth;
-        return std::move(result);
+        return result;
     }
 
     // Destructor, which undoes the increment from the desctructor

--- a/server/column_scope.cc
+++ b/server/column_scope.cc
@@ -107,7 +107,7 @@ run(const std::vector<BoundSqlExpression> & exprs) const
 
     runIncremental(exprs, onVal);
     
-    return std::move(results);
+    return results;
 }
 
 /// Allow control over whether the given optimization path is run

--- a/server/dataset_context.cc
+++ b/server/dataset_context.cc
@@ -191,7 +191,7 @@ getColumn(const ColumnName & columnName,
         if (fromOutput)
             return *fromOutput;
         
-        return storage = std::move(ExpressionValue::null(Date::negativeInfinity()));
+        return storage = ExpressionValue::null(Date::negativeInfinity());
     }
 }
 
@@ -415,7 +415,7 @@ doGetBoundParameter(const Utf8String & paramName)
                 auto & row = context.as<RowScope>();
                 if (!row.params || !*row.params)
                     throw HttpReturnException(400, "Bound parameters requested but none passed");
-                return storage = std::move((*row.params)(paramName));
+                return storage = (*row.params)(paramName);
             },
             std::make_shared<AnyValueInfo>()};
 }
@@ -455,7 +455,7 @@ doGetAllColumns(const Utf8String & tableName,
                 }
                 // Otherwise, check if we need it
                 ColumnName result = keep(inputColumnName);
-                return std::move(result);
+                return result;
             }
 
             return keep(inputColumnName);

--- a/server/parallel_merge_sort.h
+++ b/server/parallel_merge_sort.h
@@ -48,7 +48,7 @@ void parallelMergeSortRecursive(VecOfVecs & range, unsigned first, unsigned last
                 };
 
                 if (totalToDo > threadThreshold) {
-                    t = std::move(std::thread(run));
+                    t = std::thread(run);
                 }
                 else run();
 

--- a/server/plugin_resource.cc
+++ b/server/plugin_resource.cc
@@ -411,7 +411,7 @@ getScript(PackageElement elem) const
     std::ostringstream out;
     out << stream.rdbuf();
     stream.close();
-    return Utf8String(std::move(out.str()));
+    return Utf8String(out.str());
 }
 
 Utf8String LoadedPluginResource::

--- a/server/script_output.cc
+++ b/server/script_output.cc
@@ -92,7 +92,7 @@ struct ScriptLogContentDescription: public ValueDescriptionT<ScriptLogContent> {
             *val = ScriptLogContent();
         }
         else if (context.isString()) {
-            val->rawBytes = std::move(context.expectStringUtf8().stealRawString());
+            val->rawBytes = context.expectStringUtf8().stealRawString();
         }
         else if (context.isArray()) {
             Json::Value jval = context.expectJson();

--- a/server/script_output.h
+++ b/server/script_output.h
@@ -127,7 +127,9 @@ struct ScriptLogEntry {
     }
 
     ScriptLogEntry(Date ts, std::string stream, Utf8String content) noexcept
-        : ts(ts), stream(std::move(stream)), content(std::move(content.stealRawString())),
+        : ts(ts),
+          stream(std::move(stream)),
+          content(content.stealRawString()),
           closed(false)
     {
     }

--- a/server/static_content_macro.cc
+++ b/server/static_content_macro.cc
@@ -500,10 +500,10 @@ void availabletypesMacro(MacroContext & context,
                         filteredParams.append(p);
                     }
                 }
-                return std::move(filteredParams);
+                return filteredParams;
             }
             else
-                return std::move(params);
+                return params;
         };
 
         Json::Value params = internalEntitiesFilter(Json::parse(connection.response));

--- a/soa/service/stat_aggregator.cc
+++ b/soa/service/stat_aggregator.cc
@@ -106,7 +106,7 @@ GaugeAggregator(Verbosity verbosity, const std::vector<int>& extra)
 GaugeAggregator::
 ~GaugeAggregator()
 {
-    delete values;
+    delete values.load();
 }
 
 void

--- a/sql/binding_contexts.cc
+++ b/sql/binding_contexts.cc
@@ -36,7 +36,7 @@ doGetFunction(const Utf8String & tableName,
         if (arg.metadata.isConstant)  //don't rebind constant expression since they don't need to access the row
             outerArgs.emplace_back(std::move(arg));		
         else		
-            outerArgs.emplace_back(std::move(rebind(arg)));		
+            outerArgs.emplace_back(rebind(arg));
     }
 
     // Get function from the outer scope

--- a/sql/builtin_aggregators.cc
+++ b/sql/builtin_aggregators.cc
@@ -45,7 +45,7 @@ struct RegisterAggregator {
                        SqlBindingScope & context)
             -> BoundAggregator
             {
-                return std::move(aggregator(args, name));
+                return aggregator(args, name);
             };
         handles.push_back(registerAggregator(Utf8String(name), fn));
         doRegister(aggregator, std::forward<Names>(names)...);

--- a/sql/builtin_dataset_functions.cc
+++ b/sql/builtin_dataset_functions.cc
@@ -55,7 +55,7 @@ struct RegisterBuiltin {
             -> BoundTableExpression
             {
                 try {
-                    return std::move(function(context, args, options, alias));
+                    return function(context, args, options, alias);
                 } JML_CATCH_ALL {
                     rethrowHttpException(-1, "Binding builtin Dataset function "
                                          + str + ": " + ML::getExceptionString(),

--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -1431,7 +1431,7 @@ struct Min {
 
     static ExpressionValue extract(ExpressionValue val)
     {
-        return std::move(val);
+        return val;
     }
 };
 
@@ -1452,7 +1452,7 @@ struct Max {
     }
     static ExpressionValue extract(ExpressionValue val)
     {
-        return std::move(val);
+        return val;
     }
 };
 
@@ -1476,7 +1476,7 @@ struct Sum {
 
     static ExpressionValue extract(ExpressionValue val)
     {
-        return std::move(val);
+        return val;
     }
 };
 
@@ -1532,7 +1532,7 @@ struct Count {
 
     static ExpressionValue extract(ExpressionValue val)
     {
-        return std::move(val);
+        return val;
     }
 };
 
@@ -1724,7 +1724,7 @@ void normalize(ML::distribution<double>& val, double p)
                                                 ts,
                                                 args.at(0).getEmbeddingShape());
 
-                         return std::move(result);
+                         return result;
 
                      },
                      std::make_shared<EmbeddingValueInfo>
@@ -1758,7 +1758,7 @@ void normalize(ML::distribution<double>& val, double p)
 
                          ExpressionValue result(std::move(val), columnNames,  ts);
 
-                         return std::move(result);
+                         return result;
                      },
                      std::make_shared<EmbeddingValueInfo>(numDims)};
          }
@@ -2483,11 +2483,11 @@ BoundFunction length(const std::vector<BoundSqlExpression> & args)
                     //throw ML::Exception("The parameter passed to the length "
                             //"function must be a string");
 
-                return std::move(
-                        ExpressionValue(args[0].getAtom().toUtf8String().length(), 
-                                        args[0].getEffectiveTimestamp()));
-            },
-            std::make_shared<IntegerValueInfo>()
+                return ExpressionValue
+                    (args[0].getAtom().toUtf8String().length(), 
+                     args[0].getEffectiveTimestamp());
+             },
+             std::make_shared<IntegerValueInfo>()
     };
 }
 
@@ -2535,8 +2535,8 @@ BoundFunction levenshtein_distance(const std::vector<BoundSqlExpression> & args)
                 if(bestScore == -1)
                     throw ML::Exception("Error computing Levenshtein distance");
 
-                return std::move(ExpressionValue(bestScore,
-                                       args[0].getEffectiveTimestamp()));
+                return ExpressionValue(bestScore,
+                                       args[0].getEffectiveTimestamp());
             },
             std::make_shared<IntegerValueInfo>()
     };
@@ -3031,11 +3031,11 @@ BoundFunction tryFct(const std::vector<BoundSqlExpression> & args)
             {
                 ExcAssertEqual(boundArgs.size(), 2);
                 try {
-                    return storage = std::move(boundArgs[0](row, GET_LATEST));
+                    return storage = boundArgs[0](row, GET_LATEST);
                 }
                 catch (const std::exception & exc) {
                 }
-                return storage = std::move(boundArgs[1](row, GET_LATEST));
+                return storage = boundArgs[1](row, GET_LATEST);
             },
             expr,
             outputInfo};
@@ -3058,11 +3058,12 @@ BoundFunction tryFct(const std::vector<BoundSqlExpression> & args)
         {
             ExcAssertEqual(boundArgs.size(), 1);
             try {
-                return storage = std::move(boundArgs[0](row, GET_LATEST));
+                return storage = boundArgs[0](row, GET_LATEST);
             }
             catch (const std::exception & exc) {
-                return storage = std::move(ExpressionValue(
-                    ML::getExceptionString(), Date::negativeInfinity()));
+                return storage
+                = ExpressionValue(ML::getExceptionString(),
+                                  Date::negativeInfinity());
             }
         },
         expr,

--- a/sql/builtin_functions.h
+++ b/sql/builtin_functions.h
@@ -113,7 +113,7 @@ struct RegisterBuiltin {
             -> BoundFunction
             {
                 try {
-                    BoundFunction result = std::move(function(args));
+                    BoundFunction result = function(args);
                     auto fn = result.exec;
                     result.exec = [=] (const std::vector<ExpressionValue> & args,
                                        const SqlRowScope & scope)

--- a/sql/eval_sql.h
+++ b/sql/eval_sql.h
@@ -71,7 +71,7 @@ inline ExpressionValue bindSqlArg(T && val)
 */
 inline ExpressionValue bindSqlArg(ExpressionValue val)
 {
-    return std::move(val);
+    return val;
 }
 
 /** Evaluate the given SQL expression, within the given scope (which is

--- a/sql/execution_pipeline.cc
+++ b/sql/execution_pipeline.cc
@@ -267,7 +267,7 @@ doGetBoundParameter(const Utf8String & paramName)
                      const VariableFilter & filter) -> const ExpressionValue &
         {
             auto & row = rowScope.as<PipelineResults>();
-            return storage = std::move(row.getParam(paramName));
+            return storage = row.getParam(paramName);
         };
         
     return { exec, info };

--- a/sql/execution_pipeline_impl.cc
+++ b/sql/execution_pipeline_impl.cc
@@ -69,8 +69,8 @@ doGetColumn(const ColumnName & columnName, int fieldOffset)
                 //     << " returns " << rowContents.getField(columnName)
                 //     << endl;
 
-                return storage = std::move(rowContents.getNestedColumn(columnName,
-                                                                       filter));
+                return storage = rowContents.getNestedColumn(columnName,
+                                                             filter);
             },
             std::make_shared<AtomValueInfo>()};
 
@@ -334,7 +334,7 @@ Bound(const GenerateRowsElement * parent,
     : parent(std::dynamic_pointer_cast<const GenerateRowsElement>
              (parent->shared_from_this())),
       source_(std::move(source)),
-      inputScope_(std::move(source_->outputScope())),
+      inputScope_(source_->outputScope()),
       outputScope_(/* Add a table to the outer scope */
                    inputScope_->tableScope
                    (std::make_shared<TableLexicalScope>
@@ -1196,7 +1196,7 @@ take()
                 alreadySeenLeftRow = true;
 
             DEBUG_MSG(logger) << "returning the row";
-            return std::move(result);
+            return result;
         }
         else if (lField < rField) {
             // loop until left field value is equal to the right field value
@@ -1211,7 +1211,7 @@ take()
                     DEBUG_MSG(logger) << "returning left outer row [" 
                                       << result->values[0].coerceToPath()
                                       << "]";
-                    return std::move(result);
+                    return result;
                 } else {
                     DEBUG_MSG(logger) << "skipping left row [" 
                                       << result->values[0].coerceToPath()
@@ -1245,7 +1245,7 @@ take()
                             DEBUG_MSG(logger) << "returning right outer row [" 
                                               << result->values[0].coerceToPath()
                                               << "]";
-                            return std::move(result);
+                            return result;
                         } else {
                             DEBUG_MSG(logger) << "skipping right row [" 
                                               << r->values[0].coerceToPath()

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -1517,7 +1517,7 @@ ExpressionValue(RowValue row) noexcept
                     ++it2;
 
                 Structured newValue = doLevel(it, it2, level + 1);
-                rowOut.emplace_back(std::move(std::get<0>(*it).at(level)),
+                rowOut.emplace_back(std::get<0>(*it).at(level),
                                     std::move(newValue));
 
                 it = it2;
@@ -2279,7 +2279,7 @@ getColumn(const PathElement & columnName, const VariableFilter & filter) const
     if (!val)
         return ExpressionValue();
     else if (val == &storage)
-        return std::move(storage);
+        return storage;
     else return *val;
 }
 
@@ -2366,7 +2366,7 @@ getNestedColumn(const ColumnName & columnName, const VariableFilter & filter) co
     if (!val)
         return ExpressionValue();
     else if (val == &storage)
-        return std::move(storage);
+        return storage;
     else return *val;
 }
 
@@ -2744,7 +2744,7 @@ appendToRow(const Path & columnName, StructValue & row) const
                               ssize_t scope) -> ExpressionValue
             {
                 if (scope == columnName.size()) {
-                    return std::move(inner);
+                    return inner;
                 }
                 else {
                     StructValue row;
@@ -2785,7 +2785,7 @@ appendToRowDestructive(const Path & columnName, StructValue & row)
                               ssize_t scope) -> ExpressionValue
             {
                 if (scope == columnName.size()) {
-                    return std::move(inner);
+                    return inner;
                 }
                 else {
                     StructValue row;
@@ -3344,7 +3344,7 @@ getFilteredDestructive(const VariableFilter & filter)
         const ExpressionValue * output = atoms.extract(storage);
         if (output) {
             if (output == &storage)
-                return std::move(storage);
+                return storage;
             else return *output;
         }
     }
@@ -4526,8 +4526,8 @@ doSearchRow(const RowValue & columns,
     if (index == -1)
         return nullptr;
     
-    return &(storage = std::move(ExpressionValue(std::get<1>(columns[index]),
-                                                 std::get<2>(columns[index]))));
+    return &(storage = ExpressionValue(std::get<1>(columns[index]),
+                                       std::get<2>(columns[index])));
 }
 
 const ExpressionValue *

--- a/sql/expression_value.h
+++ b/sql/expression_value.h
@@ -1401,7 +1401,7 @@ struct AnyValueInfo: public ExpressionValueInfoT<ExpressionValue> {
 /// For an embedding
 struct EmbeddingValueInfo: public ExpressionValueInfoT<ML::distribution<CellValue, std::vector<CellValue> > > {
     EmbeddingValueInfo(StorageType storageType = ST_ATOM)
-        : EmbeddingValueInfo({-1}, storageType)
+        : EmbeddingValueInfo(std::vector<ssize_t>({-1}), storageType)
     {
     }
 

--- a/sql/expression_value_conversions.cc
+++ b/sql/expression_value_conversions.cc
@@ -263,7 +263,7 @@ std::vector<uint8_t> coerceTo(const CellValue & v, std::vector<uint8_t> *)
     std::copy(v.blobData(),
               v.blobData() + result.size(),
               result.data());
-    return std::move(result);
+    return result;
 }
 
 template<typename T>
@@ -279,7 +279,7 @@ std::string coerceTo(const CellValue & t, std::string *)
 
 std::string coerceTo(std::string t, std::string *)
 {
-    return std::move(t);
+    return t;
 }
 
 std::string coerceTo(const Utf8String & v, std::string *)

--- a/sql/join_utils.cc
+++ b/sql/join_utils.cc
@@ -87,7 +87,7 @@ removeTableNameFromExpression(const SqlExpression & expr, const Utf8String & tab
                 a = doArg(a);
             }
             
-            return std::move(args);
+            return args;
         };
 
     doArg = [&] (std::shared_ptr<SqlExpression> a)

--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -1794,7 +1794,7 @@ shallowCopy() const
     auto onArgs = [] (std::vector<std::shared_ptr<SqlExpression> > args)
         -> std::vector<std::shared_ptr<SqlExpression> >
         {
-            return std::move(args);
+            return args;
         };
 
     return transform(onArgs);
@@ -1949,7 +1949,7 @@ findAggregators(std::vector<std::shared_ptr<SqlExpression> >& children, bool wit
                                         "' with aggregators is not allowed"));
     }
     
-    return std::move(output);
+    return output;
 }
 
 template <class T>
@@ -2512,7 +2512,7 @@ apply(const SqlRowScope & context) const
 {
     std::vector<ExpressionValue> sortFields(clauses.size());
     for (unsigned i = 0;  i < clauses.size();  ++i) {
-        sortFields[i] = std::move(clauses[i].expr(context, GET_LATEST));
+        sortFields[i] = clauses[i].expr(context, GET_LATEST);
     }
     return sortFields;
 }
@@ -2778,7 +2778,7 @@ transform(const TransformArgs & transformArgs) const
     for (auto & clause: result.clauses)
         clause.first = transformArgs({clause.first})[0];
   
-    return std::move(result);
+    return result;
 }
     
 OrderByExpression
@@ -2790,7 +2790,7 @@ substitute(const SelectExpression & select) const
     for (auto & clause: result.clauses)
         clause.first = clause.first->substitute(select);
     
-    return std::move(result);
+    return result;
 }
 
 const OrderByExpression ORDER_BY_NOTHING;
@@ -2979,7 +2979,7 @@ SelectExpression(const std::string & exprToParse,
                  const std::string & filename,
                  int row, int col)
 {
-    *this = std::move(parse(exprToParse, filename, row, col));
+    *this = parse(exprToParse, filename, row, col);
     ExcAssertEqual(this->surface, exprToParse);
 }
 
@@ -2988,7 +2988,7 @@ SelectExpression(const char * exprToParse,
                  const std::string & filename,
                  int row, int col)
 {
-    *this = std::move(parse(exprToParse, filename, row, col));
+    *this = parse(exprToParse, filename, row, col);
     ExcAssertEqual(this->surface, exprToParse);
 }
 
@@ -2997,7 +2997,7 @@ SelectExpression(const Utf8String & exprToParse,
                  const std::string & filename,
                  int row, int col)
 {
-    *this = std::move(parse(exprToParse, filename, row, col));
+    *this = parse(exprToParse, filename, row, col);
     ExcAssertEqual(this->surface, exprToParse);
 }
 
@@ -3095,7 +3095,7 @@ bind(SqlBindingScope & context) const
 {
     vector<BoundSqlExpression> boundClauses;
     for (auto & c: clauses)
-        boundClauses.emplace_back(std::move(c->bind(context)));
+        boundClauses.emplace_back(c->bind(context));
 
     std::vector<KnownColumn> outputColumns;
 
@@ -3135,7 +3135,7 @@ bind(SqlBindingScope & context) const
                 else v.appendToRow(Path(), result);
             }
             
-            return storage = std::move(ExpressionValue(std::move(result)));
+            return storage = ExpressionValue(std::move(result));
         };
 
     return BoundSqlExpression(exec, this, outputInfo, isConstant);
@@ -3271,7 +3271,7 @@ parseJsonTyped(SelectExpression * val,
                JsonParsingContext & context) const
 {
     Utf8String s = context.expectStringUtf8();
-    *val = std::move(SelectExpression::parse(s));
+    *val = SelectExpression::parse(s);
 }
 
 void
@@ -3884,7 +3884,7 @@ parse(const std::string& body)
 
     context.expect_eof();
 
-    return std::move(stm);
+    return stm;
 }
 
 SelectStatement
@@ -3996,7 +3996,7 @@ SelectStatement::parse(ML::Parse_Context& context, bool acceptUtf8)
     skip_whitespace(context);
 
     //cerr << jsonEncode(statement) << endl;
-    return std::move(statement);
+    return statement;
 }
 
 Utf8String

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -195,7 +195,7 @@ struct BoundSqlExpression {
         ExpressionValue storage;
         const ExpressionValue & res = exec(context, storage, filter);
         if (&res == &storage)
-            return std::move(storage);
+            return storage;
         return res;
     }
 

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -69,9 +69,9 @@ doComparison(const SqlExpression * expr,
                 // cerr << "left " << l << " " << "right " << r << endl;
                 Date ts = calcTs(l, r);
                 if (l.empty() || r.empty())
-                    return storage = std::move(ExpressionValue::null(ts));
+                    return storage = ExpressionValue::null(ts);
  
-                return storage = std::move(ExpressionValue((l .* op)(r), ts));
+                return storage = ExpressionValue((l .* op)(r), ts);
             },
             expr,
             std::make_shared<BooleanValueInfo>()};
@@ -897,9 +897,9 @@ doBinaryArithmetic(const SqlExpression * expr,
                 const ExpressionValue & r = boundRhs(row, rstorage, filter);
                 Date ts = calcTs(l, r);
                 if (l.empty() || r.empty())
-                    return storage = std::move(ExpressionValue::null(ts));
-                return storage = std::move(ExpressionValue(op(l.getAtom(),
-                                                              r.getAtom()), ts));
+                    return storage = ExpressionValue::null(ts);
+                return storage = ExpressionValue(op(l.getAtom(),
+                                                    r.getAtom()), ts);
             },
             expr,
             std::make_shared<ReturnInfo>()};
@@ -919,7 +919,7 @@ doUnaryArithmetic(const SqlExpression * expr,
                 ExpressionValue rstorage;
                 const ExpressionValue & r = boundRhs(row, rstorage, filter);
                 if (r.empty())
-                    return storage = std::move(ExpressionValue::null(r.getEffectiveTimestamp()));
+                    return storage = ExpressionValue::null(r.getEffectiveTimestamp());
                 return storage
                     = ExpressionValue(std::move(op(r.getAtom())),
                                       r.getEffectiveTimestamp());
@@ -936,7 +936,7 @@ binaryPlusOnTimestamp(const CellValue & l, const CellValue & r)
     if (r.isInteger())
     {
         //when no interval is specified (integer), operation is done in days
-        return std::move(CellValue(l.toTimestamp().addDays(r.toInt())));
+        return CellValue(l.toTimestamp().addDays(r.toInt()));
     }
     else if (r.isTimeinterval())
     {
@@ -947,14 +947,14 @@ binaryPlusOnTimestamp(const CellValue & l, const CellValue & r)
         std::tie(months, days, seconds) = r.toMonthDaySecond();
 
         if (seconds < 0)
-            return std::move(CellValue(l.toTimestamp().minusMonthDaySecond(months, days, fabs(seconds))));
+            return CellValue(l.toTimestamp().minusMonthDaySecond(months, days, fabs(seconds)));
         else
-            return std::move(CellValue(l.toTimestamp().plusMonthDaySecond(months, days, seconds)));
+            return CellValue(l.toTimestamp().plusMonthDaySecond(months, days, seconds));
     }
 
     throw HttpReturnException(400, "Adding unsupported type to timetamp");
 
-    return std::move(CellValue(l.toTimestamp()));
+    return CellValue(l.toTimestamp());
 
 }
 
@@ -962,7 +962,7 @@ static CellValue binaryPlus(const CellValue & l, const CellValue & r)
 {
     if (l.isString() || r.isString())
     {
-       return std::move(CellValue(l.toUtf8String() + r.toUtf8String())); 
+       return CellValue(l.toUtf8String() + r.toUtf8String());
     }
     else if (l.isTimestamp())
     {
@@ -987,11 +987,11 @@ static CellValue binaryPlus(const CellValue & l, const CellValue & r)
 
         //no implicit quantization;
         
-        return std::move(CellValue::fromMonthDaySecond(lmonths, ldays, lseconds));
+        return CellValue::fromMonthDaySecond(lmonths, ldays, lseconds);
     }
     else
     {
-        return std::move(CellValue(l.toDouble() + r.toDouble()));
+        return CellValue(l.toDouble() + r.toDouble());
     }
 }
 
@@ -1002,7 +1002,7 @@ static CellValue binaryMinusOnTimestamp(const CellValue & l, const CellValue & r
     if (r.isInteger())
     {
         //when no interval is specified (integer), operation is done in days
-        return std::move(CellValue(l.toTimestamp().addDays(-r.toInt())));
+        return CellValue(l.toTimestamp().addDays(-r.toInt()));
     }
     else if (r.isTimeinterval())
     {
@@ -1014,9 +1014,9 @@ static CellValue binaryMinusOnTimestamp(const CellValue & l, const CellValue & r
         std::tie(months, days, seconds) = r.toMonthDaySecond();
 
         if (seconds >= 0)
-            return std::move(CellValue(l.toTimestamp().minusMonthDaySecond(months, days, fabs(seconds))));
+            return CellValue(l.toTimestamp().minusMonthDaySecond(months, days, fabs(seconds)));
         else
-            return std::move(CellValue(l.toTimestamp().plusMonthDaySecond(months, days, seconds)));
+            return CellValue(l.toTimestamp().plusMonthDaySecond(months, days, seconds));
     }
     else if (r.isTimestamp())
     {
@@ -1024,11 +1024,11 @@ static CellValue binaryMinusOnTimestamp(const CellValue & l, const CellValue & r
         int64_t days = 0;
         float seconds = 0;
         std::tie(days, seconds) = l.toTimestamp().getDaySecondInterval(r.toTimestamp());
-        return std::move(CellValue::fromMonthDaySecond(0, days, seconds));
+        return CellValue::fromMonthDaySecond(0, days, seconds);
     }
 
     throw HttpReturnException(400, "Substracting unsupported type to timetamp");
-    return std::move(CellValue(l.toTimestamp()));
+    return CellValue(l.toTimestamp());
 
 }
 
@@ -1052,10 +1052,10 @@ static CellValue binaryMinus(const CellValue & l, const CellValue & r)
 
         //no implicit quantization;
         
-        return std::move(CellValue::fromMonthDaySecond(lmonths, ldays, lseconds));
+        return CellValue::fromMonthDaySecond(lmonths, ldays, lseconds);
     }
 
-    return std::move(CellValue(l.toDouble() - r.toDouble()));
+    return CellValue(l.toDouble() - r.toDouble());
 }
 
 static CellValue unaryMinus(const CellValue & r)
@@ -1076,7 +1076,7 @@ static CellValue unaryMinus(const CellValue & r)
         else 
             seconds = -seconds;
 
-        return std::move(CellValue::fromMonthDaySecond(months, days, seconds));
+        return CellValue::fromMonthDaySecond(months, days, seconds);
     }
     else return -r.toDouble();
 }
@@ -1096,7 +1096,7 @@ static CellValue multiplyInterval(const CellValue & l, double rvalue)
     seconds *= rvalue;
     seconds += fractionalDays*24.0f*60*60;
 
-    return std::move(CellValue::fromMonthDaySecond(months, days, seconds));
+    return CellValue::fromMonthDaySecond(months, days, seconds);
 }
 
 static CellValue binaryMultiplication(const CellValue & l, const CellValue & r)
@@ -1131,7 +1131,7 @@ static CellValue binaryDivision(const CellValue & l, const CellValue & r)
         seconds /= rvalue;
         seconds += fractionalDays*24.0f*60*60;
 
-        return std::move(CellValue::fromMonthDaySecond(months, ddays, seconds));
+        return CellValue::fromMonthDaySecond(months, ddays, seconds);
     }
     else return l.toDouble() / r.toDouble();
 }
@@ -1371,8 +1371,8 @@ doBinaryBitwise(const SqlExpression * expr,
                 const ExpressionValue & r = boundRhs(row, rstorage, filter);
                 Date ts = calcTs(l, r);
                 if (l.empty() || r.empty())
-                    return storage = std::move(ExpressionValue::null(ts));
-                return storage = std::move(ExpressionValue(op(l.toInt(), r.toInt()), ts));
+                    return storage = ExpressionValue::null(ts);
+                return storage = ExpressionValue(op(l.toInt(), r.toInt()), ts);
             },
             expr,
             std::make_shared<IntegerValueInfo>()};
@@ -1392,8 +1392,8 @@ doUnaryBitwise(const SqlExpression * expr,
                 ExpressionValue rstorage;
                 const ExpressionValue & r = boundRhs(row, rstorage, filter);
                 if (r.empty())
-                    return storage = std::move(ExpressionValue::null(r.getEffectiveTimestamp()));
-                return storage = std::move(ExpressionValue(std::move(op(r.toInt())), r.getEffectiveTimestamp()));
+                    return storage = ExpressionValue::null(r.getEffectiveTimestamp());
+                return storage = ExpressionValue(std::move(op(r.toInt())), r.getEffectiveTimestamp());
             },
             expr,
             std::make_shared<IntegerValueInfo>()};
@@ -1764,7 +1764,7 @@ bind(SqlBindingScope & scope) const
     std::vector<std::shared_ptr<ExpressionValueInfo> > clauseInfo;
 
     for (auto & c: clauses) {
-        boundClauses.emplace_back(std::move(c->bind(scope)));
+        boundClauses.emplace_back(c->bind(scope));
         clauseInfo.push_back(boundClauses.back().info);
     }   
 
@@ -1936,26 +1936,26 @@ bind(SqlBindingScope & scope) const
                     if (l.isFalse() && r.isFalse()) {
                         Date ts = std::min(l.getEffectiveTimestamp(),
                                            r.getEffectiveTimestamp());
-                        return storage = std::move(ExpressionValue(false, ts));
+                        return storage = ExpressionValue(false, ts);
                     }
                     else if (l.isFalse()) {
-                        return storage = std::move(ExpressionValue(false, l.getEffectiveTimestamp()));
+                        return storage = ExpressionValue(false, l.getEffectiveTimestamp());
                     }
                     else if (r.isFalse()) {
-                        return storage = std::move(ExpressionValue(false, r.getEffectiveTimestamp()));
+                        return storage = ExpressionValue(false, r.getEffectiveTimestamp());
                     }
                     else if (l.empty() && r.empty()) {
                         Date ts = std::min(l.getEffectiveTimestamp(),
                                            r.getEffectiveTimestamp());
-                        return storage = std::move(ExpressionValue::null(ts));
+                        return storage = ExpressionValue::null(ts);
                     }
                     else if (l.empty())
-                        return storage = std::move(ExpressionValue::null(l.getEffectiveTimestamp()));
+                        return storage = ExpressionValue::null(l.getEffectiveTimestamp());
                     else if (r.empty())
-                        return storage = std::move(ExpressionValue::null(r.getEffectiveTimestamp()));
+                        return storage = ExpressionValue::null(r.getEffectiveTimestamp());
                     Date ts = std::max(l.getEffectiveTimestamp(),
                                        r.getEffectiveTimestamp());
-                    return storage = std::move(ExpressionValue(true, ts));
+                    return storage = ExpressionValue(true, ts);
                 },
                 this,
                 std::make_shared<BooleanValueInfo>()};
@@ -1974,26 +1974,26 @@ bind(SqlBindingScope & scope) const
                     if (l.isTrue() && r.isTrue()) {
                         Date ts = std::max(l.getEffectiveTimestamp(),
                                            r.getEffectiveTimestamp());
-                        return storage = std::move(ExpressionValue(true, ts));
+                        return storage = ExpressionValue(true, ts);
                     }
                     else if (l.isTrue()) {
-                        return storage = std::move(ExpressionValue(true, l.getEffectiveTimestamp()));
+                        return storage = ExpressionValue(true, l.getEffectiveTimestamp());
                     }
                     else if (r.isTrue()) {
-                        return storage = std::move(ExpressionValue(true, r.getEffectiveTimestamp()));
+                        return storage = ExpressionValue(true, r.getEffectiveTimestamp());
                     }
                     else if (l.empty() && r.empty()) {
                         Date ts = std::max(l.getEffectiveTimestamp(),
                                            r.getEffectiveTimestamp());
-                        return storage = std::move(ExpressionValue::null(ts));
+                        return storage = ExpressionValue::null(ts);
                     }
                     else if (l.empty())
-                        return storage = std::move(ExpressionValue::null(l.getEffectiveTimestamp()));
+                        return storage = ExpressionValue::null(l.getEffectiveTimestamp());
                     else if (r.empty())
-                        return storage = std::move(ExpressionValue::null(r.getEffectiveTimestamp()));
+                        return storage =ExpressionValue::null(r.getEffectiveTimestamp());
                     Date ts = std::min(l.getEffectiveTimestamp(),
                                        r.getEffectiveTimestamp());
-                    return storage = std::move(ExpressionValue(false, ts));
+                    return storage = ExpressionValue(false, ts);
                 },
                 this,
                 std::make_shared<BooleanValueInfo>()};
@@ -2008,7 +2008,7 @@ bind(SqlBindingScope & scope) const
                     const ExpressionValue & r = boundRhs(row, rstorage, filter);
                     if (r.empty())
                         return storage = std::move(r);
-                    return storage = std::move(ExpressionValue(!r.isTrue(), r.getEffectiveTimestamp()));
+                    return storage = ExpressionValue(!r.isTrue(), r.getEffectiveTimestamp());
                 },
                 this,
                 std::make_shared<BooleanValueInfo>()};
@@ -2127,8 +2127,8 @@ bind(SqlBindingScope & scope) const
             {
                 auto v = boundExpr(row, filter);
                 bool val = (v .* fn) ();
-                return storage = std::move(ExpressionValue(notType ? !val : val,
-                                                           v.getEffectiveTimestamp()));
+                return storage = ExpressionValue(notType ? !val : val,
+                                                 v.getEffectiveTimestamp());
             },
             this,
             std::make_shared<BooleanValueInfo>()};
@@ -2213,7 +2213,7 @@ bind(SqlBindingScope & scope) const
 
     std::vector<BoundSqlExpression> boundArgs;
     for (auto& arg : args) {
-        boundArgs.emplace_back(std::move(arg->bind(scope)));
+        boundArgs.emplace_back(arg->bind(scope));
     }
 
     BoundFunction fn = scope.doGetFunction(tableName, functionName,
@@ -2259,7 +2259,7 @@ bindBuiltinFunction(SqlBindingScope & scope,
                     // ??? BAD SMELL
                     //Don't evaluate the args for aggregator
                     evaluatedArgs.resize(boundArgs.size());
-                    return storage = std::move(fn(evaluatedArgs, row));
+                    return storage = fn(evaluatedArgs, row);
                 },
                 this,
                 fn.resultInfo};
@@ -2272,9 +2272,9 @@ bindBuiltinFunction(SqlBindingScope & scope,
                     std::vector<ExpressionValue> evaluatedArgs;
                     evaluatedArgs.reserve(boundArgs.size());
                     for (auto & a: boundArgs)
-                        evaluatedArgs.emplace_back(std::move(a(row, fn.filter)));
+                        evaluatedArgs.emplace_back(a(row, fn.filter));
 
-                    return storage = std::move(fn(evaluatedArgs, row));
+                    return storage = fn(evaluatedArgs, row);
                 },
                 this,
                 fn.resultInfo};
@@ -2546,11 +2546,11 @@ bind(SqlBindingScope & scope) const
                     if (boundWhen.size() > 0 && boundWhen[0].second.info->isRow()) {
                         // No else defined, first when returned a row,
                         // return an empty row as default else
-                        return storage = std::move(ExpressionValue(RowValue()));
+                        return storage = ExpressionValue(RowValue());
                     }
 
                     // default else returns an empty value
-                    return storage = std::move(ExpressionValue());
+                    return storage = ExpressionValue();
                 },
                 this,
                 // TODO: infer the type
@@ -2572,7 +2572,7 @@ bind(SqlBindingScope & scope) const
 
                     if (elseExpr)
                         return boundElse(row, storage, filter);
-                    else return storage = std::move(ExpressionValue());
+                    else return storage = ExpressionValue();
                 },
                 this,
                 std::make_shared<AnyValueInfo>()};
@@ -2694,21 +2694,21 @@ bind(SqlBindingScope & scope) const
                     return storage = l;
 
                 if (v < l)
-                    return storage = std::move(ExpressionValue(notBetween,
-                                                               std::max(v.getEffectiveTimestamp(),
-                                                                        l.getEffectiveTimestamp())));
+                    return storage = ExpressionValue(notBetween,
+                                                     std::max(v.getEffectiveTimestamp(),
+                                                              l.getEffectiveTimestamp()));
 
                 if (u.empty())
                     return storage = u;
                 if (v > u)
-                    return storage = std::move(ExpressionValue(notBetween,
-                                           std::max(v.getEffectiveTimestamp(),
-                                                    u.getEffectiveTimestamp())));
+                    return storage = ExpressionValue(notBetween,
+                                                     std::max(v.getEffectiveTimestamp(),
+                                                              u.getEffectiveTimestamp()));
 
-                return storage = std::move(ExpressionValue(!notBetween,
-                                                           std::max(std::max(v.getEffectiveTimestamp(),
-                                                                             u.getEffectiveTimestamp()),
-                                                                    l.getEffectiveTimestamp())));
+                return storage = ExpressionValue(!notBetween,
+                                                 std::max(std::max(v.getEffectiveTimestamp(),
+                                                                   u.getEffectiveTimestamp()),
+                                                          l.getEffectiveTimestamp()));
             },
             this,
             std::make_shared<BooleanValueInfo>()};
@@ -2889,8 +2889,8 @@ bind(SqlBindingScope & scope) const
                     bool found = valsPtr->count(v);
 
                     // 4.  Return our result
-                    return storage = std::move(ExpressionValue(isnegative ? !found : found,
-                                                               v.getEffectiveTimestamp()));
+                    return storage = ExpressionValue(isnegative ? !found : found,
+                                                     v.getEffectiveTimestamp());
                 };
             
             return { exec, this, std::make_shared<BooleanValueInfo>() };
@@ -2928,13 +2928,13 @@ bind(SqlBindingScope & scope) const
 
                 if ((v == itemValue))
                 {
-                    return storage = std::move(ExpressionValue(!isnegative,
-                                                           std::max(v.getEffectiveTimestamp(),
-                                                                    itemValue.getEffectiveTimestamp())));
+                    return storage = ExpressionValue(!isnegative,
+                                                     std::max(v.getEffectiveTimestamp(),
+                                                              itemValue.getEffectiveTimestamp()));
                 }
             }
 
-            return storage = std::move(ExpressionValue(isnegative, v.getEffectiveTimestamp()));
+            return storage = ExpressionValue(isnegative, v.getEffectiveTimestamp());
         },
         this,
         std::make_shared<BooleanValueInfo>()};
@@ -2958,12 +2958,12 @@ bind(SqlBindingScope & scope) const
             std::pair<bool, Date> found = s.hasKey(v.toUtf8String());
             
             if (found.first) {
-                return storage = std::move(ExpressionValue(!isnegative,
-                                                           std::max(v.getEffectiveTimestamp(),
-                                                                    found.second)));
+                return storage = ExpressionValue(!isnegative,
+                                                 std::max(v.getEffectiveTimestamp(),
+                                                          found.second));
             }
 
-            return storage = std::move(ExpressionValue(isnegative, v.getEffectiveTimestamp()));
+            return storage = ExpressionValue(isnegative, v.getEffectiveTimestamp());
         
         },
         this,
@@ -2988,12 +2988,12 @@ bind(SqlBindingScope & scope) const
             std::pair<bool, Date> found = s.hasValue(v);
             
             if (found.first) {
-                return storage = std::move(ExpressionValue(!isnegative,
-                                                           std::max(v.getEffectiveTimestamp(),
-                                                                    found.second)));
+                return storage = ExpressionValue(!isnegative,
+                                                 std::max(v.getEffectiveTimestamp(),
+                                                          found.second));
             }
 
-            return storage = std::move(ExpressionValue(isnegative, v.getEffectiveTimestamp()));
+            return storage = ExpressionValue(isnegative, v.getEffectiveTimestamp());
         },
         this,
         std::make_shared<BooleanValueInfo>()};
@@ -3127,7 +3127,7 @@ bind(SqlBindingScope & scope) const
 
             if (value.empty()) {
                 return storage =
-                    std::move(ExpressionValue::null(Date::negativeInfinity()));
+                    ExpressionValue::null(Date::negativeInfinity());
             }
             if (!value.isString())
                 throw HttpReturnException(400, "LIKE expression expected its left "
@@ -3144,9 +3144,9 @@ bind(SqlBindingScope & scope) const
 
             bool matched = matchSqlFilter(valueString, filterString);
 
-            return storage = std::move(ExpressionValue(matched != isnegative,
-                                        std::max(value.getEffectiveTimestamp(),
-                                                 filterEV.getEffectiveTimestamp())));
+            return storage = ExpressionValue(matched != isnegative,
+                                             std::max(value.getEffectiveTimestamp(),
+                                                      filterEV.getEffectiveTimestamp()));
         },
         this,
         std::make_shared<BooleanValueInfo>()};
@@ -3163,7 +3163,7 @@ print() const
         + right->print()
         + ")";
 
-    return std::move(result);
+    return result;
 }
 
 std::shared_ptr<SqlExpression>
@@ -3200,7 +3200,7 @@ getChildren() const
     children.emplace_back(std::move(left));
     children.emplace_back(std::move(right));
 
-    return std::move(children);
+    return children;
 
 }
 
@@ -3229,8 +3229,8 @@ bind(SqlBindingScope & scope) const
                 {
                     ExpressionValue valStorage;
                     const ExpressionValue & val = boundExpr(row, valStorage, filter);
-                    return storage = std::move(ExpressionValue(val.coerceToString(),
-                                                               val.getEffectiveTimestamp()));
+                    return storage = ExpressionValue(val.coerceToString(),
+                                                     val.getEffectiveTimestamp());
                 },
                 this,
                 std::make_shared<StringValueInfo>()};
@@ -3242,8 +3242,8 @@ bind(SqlBindingScope & scope) const
                 {
                     ExpressionValue valStorage;
                     const ExpressionValue & val = boundExpr(row, valStorage, filter);
-                    return storage = std::move(ExpressionValue(val.coerceToInteger(),
-                                                               val.getEffectiveTimestamp()));
+                    return storage = ExpressionValue(val.coerceToInteger(),
+                                                     val.getEffectiveTimestamp());
                 },
                 this,
                 std::make_shared<IntegerValueInfo>()};
@@ -3255,8 +3255,8 @@ bind(SqlBindingScope & scope) const
                 {
                     ExpressionValue valStorage;
                     const ExpressionValue & val = boundExpr(row, valStorage, filter);
-                    return storage = std::move(ExpressionValue(val.coerceToNumber(),
-                                                               val.getEffectiveTimestamp()));
+                    return storage = ExpressionValue(val.coerceToNumber(),
+                                                     val.getEffectiveTimestamp());
                 },
                 this,
                 std::make_shared<Float64ValueInfo>()};
@@ -3268,8 +3268,8 @@ bind(SqlBindingScope & scope) const
                 {
                     ExpressionValue valStorage;
                     const ExpressionValue & val = boundExpr(row, valStorage, filter);
-                    return storage = std::move(ExpressionValue(val.coerceToTimestamp(),
-                                                               val.getEffectiveTimestamp()));
+                    return storage = ExpressionValue(val.coerceToTimestamp(),
+                                                     val.getEffectiveTimestamp());
                 },
                 this,
                 std::make_shared<IntegerValueInfo>()};
@@ -3281,8 +3281,8 @@ bind(SqlBindingScope & scope) const
                 {
                     ExpressionValue valStorage;
                     const ExpressionValue & val = boundExpr(row, valStorage, filter);
-                    return storage = std::move(ExpressionValue(val.coerceToBoolean(),
-                                                               val.getEffectiveTimestamp()));
+                    return storage = ExpressionValue(val.coerceToBoolean(),
+                                                     val.getEffectiveTimestamp());
                 },
                 this,
                 std::make_shared<BooleanValueInfo>()};
@@ -3294,8 +3294,8 @@ bind(SqlBindingScope & scope) const
                 {
                     ExpressionValue valStorage;
                     const ExpressionValue & val = boundExpr(row, valStorage, filter);
-                    return storage = std::move(ExpressionValue(val.coerceToBlob(),
-                                                               val.getEffectiveTimestamp()));
+                    return storage = ExpressionValue(val.coerceToBlob(),
+                                                     val.getEffectiveTimestamp());
                 },
                 this,
                     std::make_shared<BlobValueInfo>()};
@@ -3307,8 +3307,8 @@ bind(SqlBindingScope & scope) const
                 {
                     ExpressionValue valStorage;
                     const ExpressionValue & val = boundExpr(row, valStorage, filter);
-                    return storage = std::move(ExpressionValue(CellValue(val.coerceToPath()),
-                                                               val.getEffectiveTimestamp()));
+                    return storage = ExpressionValue(CellValue(val.coerceToPath()),
+                                                     val.getEffectiveTimestamp());
                 },
                 this,
                 std::make_shared<PathValueInfo>()};
@@ -3895,7 +3895,7 @@ bind(SqlBindingScope & scope) const
                          const VariableFilter & filter)
             -> const ExpressionValue &
             {
-                return storage = std::move(outputColumns.exec(scope, filter));
+                return storage = outputColumns.exec(scope, filter);
             };
 
         BoundSqlExpression result(exec, this, outputColumns.info);

--- a/sql/tokenize.cc
+++ b/sql/tokenize.cc
@@ -268,7 +268,7 @@ tokenize_exec(std::function<bool (Utf8String&)> exec,
     bool another = false;
     while (another || (context && !context.eof())) {
 
-        Utf8String word = std::move(expect_token(context, another));
+        Utf8String word = expect_token(context, another);
 
         if(word.length() < minTokenLength)
             continue;

--- a/tensorflow/tensorflow_plugin.cc
+++ b/tensorflow/tensorflow_plugin.cc
@@ -1327,7 +1327,7 @@ struct TensorflowGraphBase: public Function {
 
         //cerr << "outputs " << outputs.size() << " tensors" << endl;
 
-        return std::move(outputs);
+        return outputs;
     }
 
     virtual ExpressionValue

--- a/testing/MLDB-1165-where-rowname-in-optim.py
+++ b/testing/MLDB-1165-where-rowname-in-optim.py
@@ -49,9 +49,14 @@ dataset.commit();
 
 result = mldb.query(
     "select * from example_small WHERE rowName() NOT IN "
-    "('u1', 'u3', 'u5', 'u7')")
+    "('u1', 'u3', 'u5', 'u7') order by rowPath()")
 
-expected = [["_rowName","x"],["u6","whatever"],["u8","whatever"],["u4","whatever"],["u2","whatever"],["u9","whatever"],["u0","whatever"]]
+expected = [["_rowName","x"],["u0","whatever"],["u2","whatever"],["u4","whatever"],["u6","whatever"],["u8","whatever"],["u9","whatever"]]
+
+mldb.log("result");
+mldb.log(result)
+mldb.log("expected");
+mldb.log(expected)
 
 assert result == expected
 

--- a/testing/MLDB-1559-transform-method.cc
+++ b/testing/MLDB-1559-transform-method.cc
@@ -52,7 +52,7 @@ void TestExpression(const T& expression, int expected)
                 a = a->transform(onChild);
             }
 
-            return std::move(args);
+            return args;
         };
 
     expression.transform(onChild);

--- a/testing/MLDB-1694-flatten-embeddings.py
+++ b/testing/MLDB-1694-flatten-embeddings.py
@@ -33,7 +33,7 @@ class Mldb1694(MldbUnitTest):
  
     def test_prediction_works(self):
         self.assertTableResultEquals(
-            mldb.query("""select * from transpose(
+            mldb.query("""select round(pred * 10000) as pred from transpose(
                             (
                                 SELECT inception({url: '%s'}) as *
                                 NAMED 'pred'
@@ -43,11 +43,11 @@ class Mldb1694(MldbUnitTest):
                 """ % self.amazingGrace),
             [
                 ["_rowName","pred"],
-                ["softmax.0.866", 0.8080089092254639],
-                ["softmax.0.794", 0.022845188155770302],
-                ["softmax.0.896", 0.009539488703012466],
-                ["softmax.0.849", 0.009413405321538448],
-                ["softmax.0.926", 0.007742532528936863]
+                ["softmax.0.866", 8080],
+                ["softmax.0.794",  228],
+                ["softmax.0.896",   95],
+                ["softmax.0.849",   94],
+                ["softmax.0.926",   77]
             ])
 
 
@@ -56,7 +56,7 @@ class Mldb1694(MldbUnitTest):
         # but accesses the output parameter softmax and flattens
         # the embedding
         self.assertTableResultEquals(
-            mldb.query("""select * from transpose(
+            mldb.query("""select round(pred * 10000) as pred from transpose(
                             (
                                 SELECT flatten(inception({url: '%s'})[softmax]) as *
                                 NAMED 'pred'
@@ -66,11 +66,11 @@ class Mldb1694(MldbUnitTest):
                 """ % self.amazingGrace),
             [
                 ["_rowName","pred"],
-                ["866", 0.8080089092254639],
-                ["794", 0.022845188155770302],
-                ["896", 0.009539488703012466],
-                ["849", 0.009413405321538448],
-                ["926", 0.007742532528936863]
+                ["866", 8080],
+                ["794",  228],
+                ["896",   95],
+                ["849",   94],
+                ["926",   77]
             ])
 
 

--- a/testing/MLDB-1841-distinct-on.py
+++ b/testing/MLDB-1841-distinct-on.py
@@ -201,12 +201,12 @@ class DistinctOnTest(MldbUnitTest):
             }
         })
 
-        res = mldb.query("SELECT * from transformed")
+        res = mldb.query("SELECT * from transformed order by rowPath()")
 
         expected = [["_rowName", "x", "z"],
                     ["row1", 1, 1],
-                    ["row3", 1, 2],
                     ["row2", 2, 1],
+                    ["row3", 1, 2],
                     ["row5", 2, 3]]
 
         self.assertEqual(res, expected)

--- a/testing/mldb_config_persistence_test.cc
+++ b/testing/mldb_config_persistence_test.cc
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE( test_plugin_loading )
         }
         
         BOOST_CHECK_EQUAL(proxy.get("/v1/plugins").jsonBody(),
-                          Json::Value({ "jsplugin" }));
+                          Json::Value({ Json::Value("jsplugin") }));
         server.shutdown();
     }
 
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE( test_plugin_loading )
         }
 
         BOOST_CHECK_EQUAL(proxy.get("/v1/plugins").jsonBody(),
-                          Json::Value({ "jsplugin" }));
+                          Json::Value({ Json::Value("jsplugin") }));
 
         auto res = proxy.perform("DELETE", "/v1/plugins/jsplugin");
         cerr << res << endl;

--- a/testing/mldb_determinism_test.cc
+++ b/testing/mldb_determinism_test.cc
@@ -47,7 +47,7 @@ struct TestRegisterAggregator {
                        SqlBindingScope & context)
             -> BoundAggregator
             {
-                return std::move(aggregator());
+                return aggregator();
             };
         handles.push_back(registerAggregator(Utf8String(name), fn));
         doRegister(aggregator, std::forward<Names>(names)...);

--- a/testing/summary_stats_proc_test.py
+++ b/testing/summary_stats_proc_test.py
@@ -39,7 +39,8 @@ class SummaryStatsProcTest(MldbUnitTest):  # noqa
                 }
             }
         })
-        res = mldb.query("SELECT * FROM output")
+        res = mldb.query("SELECT * FROM output order by rowPath()")
+        mldb.log(res)
         self.assertTableResultEquals(res, [
             ["_rowName", "value.data_type", "value.num_null",
              "value.num_unique", "value.max", "value.avg", "value.min",
@@ -50,17 +51,19 @@ class SummaryStatsProcTest(MldbUnitTest):  # noqa
              "value.most_frequent_items.10",
              "value.most_frequent_items.patate"],
 
-            ["colTxt", "categorical", 1, 2, None, None, None, None, None,
-             None, 1, None, None, None, None, None, 1],
-
-             ["colC", "number", 2, 1, 20, 20, 20, 20, 20, 20, None, 1, None,
-              None, "NaN", None, None],
+            ["colA", "number", 0, 2, 10, 4, 1, 1, 1, 10, None, None, None, 2,
+             5.196152422706632, 1, None],
 
             ["colB", "number", 2, 1, 2, 2, 2, 2, 2, 2, None, None, 1, None,
              "NaN", None, None],
 
-            ["colA", "number", 0, 2, 10, 4, 1, 1, 1, 10, None, None, None, 2,
-             5.196152422706632, 1, None]
+            ["colC", "number", 2, 1, 20, 20, 20, 20, 20, 20, None, 1, None,
+              None, "NaN", None, None],
+
+            ["colTxt", "categorical", 1, 2, None, None, None, None, None,
+             None, 1, None, None, None, None, None, 1]
+
+
         ])
 
     def test_dottest_col_names(self):

--- a/types/any.cc
+++ b/types/any.cc
@@ -134,7 +134,7 @@ jsonDecodeStrTyped(const std::string & json)
     Any ev;
     payloadDesc.parseJsonTyped(&ev, context);
 
-    return std::move(ev);
+    return ev;
 }
 
 Any
@@ -145,7 +145,7 @@ jsonDecodeTyped(const Json::Value & json)
     Any ev;
     payloadDesc.parseJsonTyped(&ev, context);
 
-    return std::move(ev);
+    return ev;
 }
 
 std::string
@@ -155,7 +155,7 @@ jsonEncodeStrTyped(const Any & val)
     std::ostringstream stream;
     StreamJsonPrintingContext context(stream);
     payloadDesc.printJson(&val, context);
-    return std::move(stream.str());
+    return stream.str();
 }
 
 Json::Value

--- a/types/any.h
+++ b/types/any.h
@@ -1,9 +1,9 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* any.h                                                           -*- C++ -*-
 
    Jeremy Barnes, July 4 2014
    Copyright (c) 2014 Datacratic Inc.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 */
 
 #pragma once

--- a/types/json_printing.cc
+++ b/types/json_printing.cc
@@ -131,7 +131,7 @@ jsonEscape(const std::string & str)
         else if (p == NO_ESCAPING)
             return str;
         heap_buf.resize(p - heap_buf.data());
-        return std::move(heap_buf);
+        return heap_buf;
     }
 }
 
@@ -206,7 +206,7 @@ void jsonEscape(const std::string & str, std::string & out)
     } else {
         // We need an allocation anyway, so use the simple solution
         if (out.empty())
-            out = std::move(jsonEscape(str));
+            out = jsonEscape(str);
         else out += jsonEscape(str);
     }
 }
@@ -232,7 +232,7 @@ void jsonEscape(const char * str, size_t len, std::string & out)
     } else {
         // We need an allocation anyway, so use the simple solution
         if (out.empty())
-            out = std::move(jsonEscape(string(str, str + len)));
+            out = jsonEscape(string(str, str + len));
         else out += jsonEscape(string(str, str + len));
     }
 }

--- a/types/meta_value_description.cc
+++ b/types/meta_value_description.cc
@@ -102,7 +102,7 @@ static Json::Value getDefaultValue(const ValueDescription & description)
     description.printJson(val, context);
     description.destroy(val);
 
-    return std::move(jval);
+    return jval;
 }
 
 static ValueDescriptionRepr

--- a/types/string.cc
+++ b/types/string.cc
@@ -587,14 +587,14 @@ Utf8String
 Utf8String::
 toLower() const
 {
-    return std::move(boost::locale::to_lower(data_));
+    return boost::locale::to_lower(data_);
 }
 
 Utf8String
 Utf8String::
 toUpper() const
 {
-    return std::move(boost::locale::to_upper(data_));
+    return boost::locale::to_upper(data_);
 }
 
 Utf8String::iterator

--- a/types/structure_description.h
+++ b/types/structure_description.h
@@ -184,7 +184,7 @@ struct StructureDescription
         const char * fieldName = fieldNames.back().get();
         
         auto it = fields.insert
-            (Fields::value_type(fieldName, std::move(FieldDescription())))
+            (Fields::value_type(fieldName, FieldDescription()))
             .first;
         
         FieldDescription & fd = it->second;
@@ -216,7 +216,7 @@ struct StructureDescription
         const char * fieldName = fieldNames.back().get();
         
         auto it = fields.insert
-            (Fields::value_type(fieldName, std::move(FieldDescription())))
+            (Fields::value_type(fieldName, FieldDescription()))
             .first;
         
         auto desc = std::make_shared<Desc>(defaultValue, baseDesc);
@@ -368,7 +368,7 @@ addParent(ValueDescriptionT<V> * description_)
         fieldNames.emplace_back(::strdup(name.c_str()));
         const char * fieldName = fieldNames.back().get();
 
-        auto it = fields.insert(Fields::value_type(fieldName, std::move(FieldDescription()))).first;
+        auto it = fields.insert(Fields::value_type(fieldName, FieldDescription())).first;
         FieldDescription & fd = it->second;
         fd.fieldName = fieldName;
         fd.comment = ofd.comment;

--- a/types/tuple_description.h
+++ b/types/tuple_description.h
@@ -11,6 +11,7 @@
 
 
 #include "mldb/types/value_description.h"
+#include <type_traits>
 
 namespace Datacratic {
 
@@ -26,9 +27,9 @@ template<typename Tuple, int n, typename First, typename... Rest>
 struct AddTupleTypes<Tuple, n, First, Rest...> {
     static void go(std::vector<TupleElementDescription> & elements)
     {
-        auto desc = getDefaultDescriptionShared((First *)0);
+        auto desc = getDefaultDescriptionShared((typename std::remove_reference<First>::type *)0);
         Tuple * tpl = 0;
-        void * el = &std::get<n>(*tpl);
+        const void * el = &std::get<n>(*tpl);
         int offset = (size_t)el;
 
         TupleElementDescription elDesc;

--- a/types/value_description.h
+++ b/types/value_description.h
@@ -583,7 +583,7 @@ std::string jsonEncodeStr(const T & obj)
     result.reserve(116);  /// try to force a 128 byte allocation
     StringJsonPrintingContext context(result);
     desc->printJson(&obj, context);
-    return std::move(result);
+    return result;
 }
 
 // jsonEncode implementation for any type which:

--- a/utils/json_diff.cc
+++ b/utils/json_diff.cc
@@ -186,7 +186,7 @@ jsonDiffObjects(const Json::Value & obj1,
         }
         else if (it1 != end1 && (it2 == end2 || *it1 < *it2)) {
             // Deleted field
-            result.fields[*it1] = std::move(JsonDiff(obj1[*it1], JsonDiff::deleted));
+            result.fields[*it1] = JsonDiff(obj1[*it1], JsonDiff::deleted);
             ++it1;
         }
         else {

--- a/utils/testing/watchdog.h
+++ b/utils/testing/watchdog.h
@@ -52,7 +52,7 @@ struct Watchdog {
              std::function<void ()> timeoutFunction = abortProcess)
         : finished(false), seconds(seconds), timeoutFunction(timeoutFunction)
     {
-        thread = std::move(std::thread(std::bind(&Watchdog::runThread, this)));
+        thread = std::thread(std::bind(&Watchdog::runThread, this));
     }
 
     ~Watchdog()

--- a/vfs/filter_streams.cc
+++ b/vfs/filter_streams.cc
@@ -792,7 +792,7 @@ fork(const std::map<std::string, std::string> & options) const
     filter_istream result;
     result.openFromHandler(handlerOptions.fork(rdbuf(), sink),
                            this->resource, options);
-    return std::move(result);
+    return result;
 }
 
 std::pair<const char *, size_t>

--- a/vfs/lz4_filter.h
+++ b/vfs/lz4_filter.h
@@ -136,7 +136,7 @@ struct JML_PACKED Header
         if (head.checkBits != head.checksumOptions())
             throw lz4_error("corrupted options");
 
-        return std::move(head);
+        return head;
     }
 
     template<typename Sink>

--- a/vfs_handlers/archive.cc
+++ b/vfs_handlers/archive.cc
@@ -301,7 +301,7 @@ struct RegisterArchiveHandler {
                 //cerr << "matching " << archiveMemberUri
                 //<< " against " << uri << endl;
                 if (uri.rawString() == archiveMemberUri) {
-                    result = std::move(open(options));
+                    result = open(options);
                     return false;
                 }
                 return true;

--- a/vfs_handlers/docker.cc
+++ b/vfs_handlers/docker.cc
@@ -442,7 +442,7 @@ struct RegisterDockerHandler {
                                     int depth)
             {
                 if (uri == uriToFind) {
-                    result = std::move(open(options));
+                    result = open(options);
                     return false;
                 }
                 return true;

--- a/vfs_handlers/s3_handlers.cc
+++ b/vfs_handlers/s3_handlers.cc
@@ -288,7 +288,7 @@ private:
             ExcAssertEqual(state, RESPONSE);
             string chunkData = std::move(data);
             setState(IDLE);
-            return std::move(chunkData);
+            return chunkData;
         }
 
         void setState(int newState)

--- a/watch/testing/watch_test.cc
+++ b/watch/testing/watch_test.cc
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE( test_move )
 {
     WatchesT<std::string> watches;
     std::vector<Watch> w;
-    w.emplace_back(std::move(watches.add()));
+    w.emplace_back(watches.add());
     BOOST_CHECK_EQUAL(watches.size(), 1);
     
     watches.trigger("hello");

--- a/watch/watch.cc
+++ b/watch/watch.cc
@@ -205,7 +205,7 @@ waitGeneric(double timeToWait)
     if (!found)
         throw ML::Exception("No event found before timeout");
         
-    return std::move(res);
+    return res;
 }
 
 std::shared_ptr<const ValueDescription>

--- a/watch/watch.h
+++ b/watch/watch.h
@@ -1,8 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* watch.h                                                       -*- C++ -*-
    Jeremy Barnes, 6 April 2014
    Copyright (c) 2014 Datacratic Inc.  All rights reserved.
+
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Class to deal with watchers.
 */
@@ -209,7 +209,7 @@ struct Watch {
         if (!found)
             throwException(WATCH_ERR_TIMEOUT, "No event found before timeout");
 
-        return std::move(res);
+        return res;
     }
 
     /** Pop an event, or throw an exception if the event was not found.
@@ -874,9 +874,9 @@ struct WatchAllData {
         // Once all are done, we bind them so that they can start
         // triggering
         for (unsigned i = 0;  i < elementWatches.size();  ++i) {
+            // clang doesn't like std::bind when used with g++6 headers
             elementWatches[i].bindGeneric
-                (std::bind(&WatchAllData::onElementTrigger, this,
-                           std::placeholders::_1, i));
+                ([this,i](const Any & val) { this->onElementTrigger(val, i); });
         }
     }
 
@@ -923,7 +923,7 @@ WatchT<AllOutput> all(Watches&&... watches)
     // Now activate it to send any existing results through
     data->activate();
 
-    return std::move(result);
+    return result;
 }
 
 


### PR DESCRIPTION
Switches the default version of clang to 3.8 and fixes the warning messages that it found (mostly around spurious std::move constructs).  This allows compilation and all tests to pass with toolchain=clang.

@jean it requires clang 3.8 to be installed on the build machines.
