### PR TITLE
Use internal gmock for protobuf (MLDB-1926)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "ext/v8-cross-build-output"]
 	path = ext/v8-cross-build-output
 	url = https://github.com/mldbai/v8-cross-build-output.git
+[submodule "ext/gmock"]
+	path = ext/gmock
+	url = https://github.com/mldbai/gmock-1.7.0.git

--- a/ext/protobuf.mk
+++ b/ext/protobuf.mk
@@ -23,6 +23,7 @@ $(4)/protoc: $(if $(call sne,$(1),$(HOSTARCH)),$(HOSTBIN)/protoc)
 	@echo "   $(COLOR_BLUE)[COPY EXTERN]$(COLOR_RESET)                      	protobuf3 $(1)"
 	@mkdir -p $(BUILD)/$(1)/tmp/protobuf-build
 	@cp -rf mldb/ext/protobuf/* $(BUILD)/$(1)/tmp/protobuf-build
+	@ln -sf $(PWD)/mldb/ext/gmock $(BUILD)/$(1)/tmp/protobuf-build/
 	@echo " $(COLOR_BLUE)[CONFIG EXTERN]$(COLOR_RESET)                      	protobuf3 $(1)"
 	@(cd $(BUILD)/$(1)/tmp/protobuf-build \
 	&& ./autogen.sh > configure-log.txt 2>&1 \


### PR DESCRIPTION
We should never need to download gmock again...
