### PR TITLE
Wait for jconfig.h before building the lib

### DIFF
--- a/ext/jpeg.mk
+++ b/ext/jpeg.mk
@@ -16,7 +16,7 @@ $(CWD)/jconfig.h:
 	cd mldb/ext/jpeg && ./configure
 endif
 
-$(JPEG_SOURCE):	$(CWD)/jconfig.h
+$(LIB)/libjpeg.so:	$(CWD)/jconfig.h
 
 JPEG_INCLUDE_FILES:=$(CWD)/jconfig.h
 

--- a/ext/jpeg.mk
+++ b/ext/jpeg.mk
@@ -16,8 +16,13 @@ $(CWD)/jconfig.h:
 	cd mldb/ext/jpeg && ./configure
 endif
 
-$(LIB)/libjpeg.so:	$(CWD)/jconfig.h
-
 JPEG_INCLUDE_FILES:=$(CWD)/jconfig.h
+
+define jpeg_add_dep
+$(CWD)/$(1):	$(2)
+endef
+
+$(foreach source,$(JPEG_SOURCE),$(eval $(call jpeg_add_dep,$(source),$(JPEG_INCLUDE_FILES))))
+
 
 $(eval $(call library,jpeg,$(JPEG_SOURCE)))


### PR DESCRIPTION
Should fix :

```
 In file included from ./mldb/ext/jpeg/jaricom.c:17:0:
 ./mldb/ext/jpeg/jinclude.h:20:55: fatal error: jconfig.h: No such file or directory
```

The original code didn't seem to add a dependency, but it might be magic beyond my gmake powers.
Replaced with an obvious construct.

@jeremybarnes  can you double check please?