### PR TITLE
[MLDB-1928] rename f to f1Score

### DIFF
--- a/container_files/public_html/doc/builtin/procedures/Accuracy.md
+++ b/container_files/public_html/doc/builtin/procedures/Accuracy.md
@@ -25,7 +25,7 @@ The `status` field will contain statistics relevant to the model's mode.
 The `status` field will contain the [Area
 Under the Curve](http://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve) under the key `auc`, along with the performance statistics (e.g. [precision, recall](http://en.wikipedia.org/wiki/Precision_and_recall)) for the classifier using
 the thresholds which give the best [MCC](http://en.wikipedia.org/wiki/Matthews_correlation_coefficient) and the best [F-score](http://en.wikipedia.org/wiki/F1_score), under the keys `bestMcc` and
-`bestF`, respectively.
+`bestF1Score`, respectively.
 
 Here is a sample output:
 
@@ -36,7 +36,7 @@ Here is a sample output:
       "pr": {
         "recall": 0.6712328767123288, 
         "precision": 0.8448275862068966, 
-        "f": 0.7480916030534351,
+        "f1Score": 0.7480916030534351,
         "accuracy": 0.8196721311
       }, 
       "mcc": 0.6203113512927362, 
@@ -54,11 +54,11 @@ Here is a sample output:
       }
     }, 
     "auc": 0.8176836861768365, 
-    "bestF": {
+    "bestF1Score": {
       "pr": {
         "recall": 0.6712328767123288, 
         "precision": 0.8448275862068966, 
-        "f": 0.7480916030534351,
+        "f1Score": 0.7480916030534351,
         "accuracy": 0.8196721311
       }, 
       "mcc": 0.6203113512927362, 
@@ -112,21 +112,21 @@ Here is a sample output:
     "status": {
         "labelStatistics": {
             "0": {
-                "f": 0.8000000143051146,
+                "f1Score": 0.8000000143051146,
                 "recall": 1.0,
                 "support": 2,
                 "precision": 0.6666666865348816,
                 "accuracy": 1.0
             },
             "1": {
-                "f": 0.0,
+                "f1Score": 0.0,
                 "recall": 0.0,
                 "support": 1,
                 "precision": 0.0,
                 "accuracy": 0.0
             },
             "2": {
-                "f": 1.0,
+                "f1Score": 1.0,
                 "recall": 1.0,
                 "support": 2,
                 "precision": 1.0,
@@ -134,7 +134,7 @@ Here is a sample output:
             }
         },
         "weightedStatistics": {
-            "f": 0.7200000057220459,
+            "f1Score": 0.7200000057220459,
             "recall": 0.8,
             "support": 5,
             "precision": 0.6666666746139527,

--- a/ml/separation_stats.cc
+++ b/ml/separation_stats.cc
@@ -69,7 +69,7 @@ toJson() const
     result["pr"]["accuracy"] = accuracy();
     result["pr"]["precision"] = precision();
     result["pr"]["recall"] = recall();
-    result["pr"]["f"] = f();
+    result["pr"]["f1Score"] = f();
     result["mcc"] = mcc();
     result["gain"] = gain();
     result["counts"]["truePositives"] = truePositives();
@@ -354,7 +354,7 @@ getRocCurveJson() const
     Json::Value js;
     js["aroc"] = auc;
     js["model"] = modelJs;
-    js["bestF"] = bestF.toJson();
+    js["bestF1Score"] = bestF.toJson();
     js["bestMcc"] = bestMcc.toJson();
 
     return js;
@@ -374,7 +374,7 @@ toJson() const
 {
     Json::Value result;
     result["auc"] = auc;
-    result["bestF"] = bestF.toJson();
+    result["bestF1Score"] = bestF.toJson();
     result["bestMcc"] = bestMcc.toJson();
     return result;
 }

--- a/plugins/accuracy.cc
+++ b/plugins/accuracy.cc
@@ -236,7 +236,6 @@ runBoolean(AccuracyConfig & runAccuracyConf,
     // cerr << stats.atPercentile(0.01).toJson();
 
     return Any(stats.toJson());
-
 }
 
 RunOutput
@@ -391,7 +390,7 @@ runCategorical(AccuracyConfig & runAccuracyConf,
         class_stats["accuracy"] = accuracy;
         class_stats["precision"] = precision;
         class_stats["recall"] = recall;
-        class_stats["f"] = 2 * ML::xdiv(precision * recall,
+        class_stats["f1Score"] = 2 * ML::xdiv(precision * recall,
                                         precision + recall);
         class_stats["support"] = support;
         results["labelStatistics"][actual_it.first.toString()] = class_stats;
@@ -399,7 +398,7 @@ runCategorical(AccuracyConfig & runAccuracyConf,
         total_accuracy += accuracy * support;
         total_precision += precision * support;
         total_recall += recall * support;
-        total_f1 += class_stats["f"].asDouble() * support;
+        total_f1 += class_stats["f1Score"].asDouble() * support;
         total_support += support;
     }
 
@@ -408,7 +407,7 @@ runCategorical(AccuracyConfig & runAccuracyConf,
     weighted_stats["accuracy"] = total_accuracy / total_support;
     weighted_stats["precision"] = total_precision / total_support;
     weighted_stats["recall"] = total_recall / total_support;
-    weighted_stats["f"] = total_f1 / total_support;
+    weighted_stats["f1Score"] = total_f1 / total_support;
     weighted_stats["support"] = total_support;
     results["weightedStatistics"] = weighted_stats;
 

--- a/testing/MLDB-256_accuracy_accepts_all_cls_modes.py
+++ b/testing/MLDB-256_accuracy_accepts_all_cls_modes.py
@@ -184,7 +184,7 @@ class Mldb256Test(MldbUnitTest):
         jsRez = rez.json()
         self.assertGreater(jsRez["status"]["folds"][0]["resultsTest"]["auc"], 0.65)
 
-        bestF = jsRez["status"]["folds"][0]["resultsTest"]["bestF"]
+        bestF = jsRez["status"]["folds"][0]["resultsTest"]["bestF1Score"]
         accuracy = (bestF["counts"]["truePositives"] + bestF["counts"]["trueNegatives"]) / \
                         (bestF["population"]["included"] + bestF["population"]["excluded"])
         self.assertEqual(bestF["pr"]["accuracy"], accuracy)
@@ -213,21 +213,21 @@ class Mldb256Test(MldbUnitTest):
 
         goodLabelStatistics = {
                     "0": {
-                        "f": 0.8,
+                        "f1Score": 0.8,
                         "recall": 1.0,
                         "support": 2,
                         "precision": 2./3,
                         "accuracy": 0.8
                     },
                     "1": {
-                        "f": 0.0,
+                        "f1Score": 0.0,
                         "recall": 0.0,
                         "support": 1,
                         "precision": 0.0,
                         "accuracy": 0.8
                     },
                     "2": {
-                        "f": 1.0,
+                        "f1Score": 1.0,
                         "recall": 1.0,
                         "support": 2,
                         "precision": 1.0,
@@ -245,7 +245,7 @@ class Mldb256Test(MldbUnitTest):
         total_support = 0
         total_precision = 0
         for val in goodLabelStatistics.itervalues():
-            total_f1 += val["f"] * val["support"]
+            total_f1 += val["f1Score"] * val["support"]
             total_accuracy += val["accuracy"] * val["support"]
             total_recall += val["recall"] * val["support"]
             total_precision += val["precision"] * val["support"]
@@ -253,7 +253,7 @@ class Mldb256Test(MldbUnitTest):
 
         self.assertEqual(jsRez["status"]["firstRun"]["status"]["weightedStatistics"],
                 {
-                    "f": total_f1 / total_support,
+                    "f1Score": total_f1 / total_support,
                     "recall": total_recall / total_support,
                     "accuracy": total_accuracy / total_support,
                     "support": total_support,

--- a/testing/test_classifier_test_proc.py
+++ b/testing/test_classifier_test_proc.py
@@ -6,8 +6,6 @@
 # This tests the `classifier.test` procedure.
 #
 from __future__ import division
-from pprint import pformat
-import unittest
 
 mldb = mldb_wrapper.wrap(mldb)  # noqa
 
@@ -207,21 +205,21 @@ class TestClassifierTestProc(MldbUnitTest):  # noqa
         truth = {
             'labelStatistics': {
                 '0': {
-                    "f": 2/3,
+                    "f1Score": 2/3,
                     "recall": 1,
                     "support": 1,
                     "precision": .5,
                     "accuracy": 0.75,
                 },
                 '1': {
-                    "f": 1,
+                    "f1Score": 1,
                     "recall": 1,
                     "support": 1,
                     "precision": 1,
                     "accuracy": 1,
                 },
                 '2': {
-                    "f": 2. * .5  / 1.5,
+                    "f1Score": 2. * .5  / 1.5,
                     "recall": 0.5,
                     "support": 2,
                     "precision": 1,
@@ -229,7 +227,7 @@ class TestClassifierTestProc(MldbUnitTest):  # noqa
                 },
             },
             'weightedStatistics': {
-                'f': (2/3 + 1 + 2/3*2)/4,
+                'f1Score': (2/3 + 1 + 2/3*2)/4,
                 'recall': (1+1+.5*2)/4,
                 'support': 4,
                 'precision': (.5+1+1*2)/4,
@@ -264,21 +262,21 @@ class TestClassifierTestProc(MldbUnitTest):  # noqa
         truth = {
             'labelStatistics': {
                 '0': {
-                    "f": 2/5,
+                    "f1Score": 2/5,
                     "recall": 1,
                     "support": 1,
                     "precision": .25,
                     "accuracy": 5/8,
                 },
                 '1': {
-                    "f": 1,
+                    "f1Score": 1,
                     "recall": 1,
                     "support": 3,
                     "precision": 1,
                     "accuracy": 1,
                 },
                 '2': {
-                    "f": 2/5,
+                    "f1Score": 2/5,
                     "recall": 0.25,
                     "support": 4,
                     "precision": 1,
@@ -286,7 +284,7 @@ class TestClassifierTestProc(MldbUnitTest):  # noqa
                 },
             },
             'weightedStatistics': {
-                'f': (2/5 + 3 + 2/5*4) / 8,
+                'f1Score': (2/5 + 3 + 2/5*4) / 8,
                 'recall': (1 + 3 + .25*4)/8,
                 'support': 8,
                 'precision': (.25 + 3 + 4) / 8,


### PR DESCRIPTION
Simply rename the confusing "f" to "f1Score" (and "bestF" to "bestF1Score") in the classifier.test output.