### PR TITLE
protobuf dependency fixes

### DIFF
--- a/ext/protobuf.mk
+++ b/ext/protobuf.mk
@@ -11,7 +11,7 @@ ifneq ($(PREMAKE),1)
 #
 # $(1) = arch to build for (either $HOSTARCH or $ARCH)
 # $(2) = place to install libraries
-# $(3) = place to install headers
+# $(3) = place to install headers (unused)
 # $(4) = place to install binaries
 
 define build_protobuf_for_arch
@@ -30,6 +30,9 @@ $(4)/protoc: $(if $(call sne,$(1),$(HOSTARCH)),$(HOSTBIN)/protoc)
 	&& ./autogen.sh > configure-log.txt 2>&1 \
 	&& TMP=$(PWD)/$(TMP) ./configure \
 		--prefix $(PWD)/$(BUILD)/$(1) \
+		--libdir=$(PWD)/$(2) \
+		--includedir=$(PWD)/$(3) \
+		--bindir=$(PWD)/$(4) \
 		--program-suffix="" \
 		$$(PROTOC_EXTRA_ARGS_$(1)) >> configure-log.txt 2>&1) \
 	|| (echo $(COLOR_RED)Protobuf configure failed for $(1)$(COLOR_RESET) && cat $(BUILD)/$(1)/tmp/protobuf-build/configure-log.txt && false)

--- a/ext/protobuf.mk
+++ b/ext/protobuf.mk
@@ -11,7 +11,7 @@ ifneq ($(PREMAKE),1)
 #
 # $(1) = arch to build for (either $HOSTARCH or $ARCH)
 # $(2) = place to install libraries
-# $(3) = place to install headers (unused)
+# $(3) = place to install headers
 # $(4) = place to install binaries
 
 define build_protobuf_for_arch

--- a/ext/tensorflow.mk
+++ b/ext/tensorflow.mk
@@ -119,7 +119,7 @@ $(INC)/external/eigen_archive/eigen-eigen-$(TENSORFLOW_EIGEN_MERCURIAL_HASH):
 
 # To create a protobuf file, we compile the input file.  Same for the .h
 # file.
-$(CWD)/%.pb.cc $(CWD)/%.pb.h:		$(CWD)/%.proto $(HOSTBIN)/protoc
+$(CWD)/%.pb.cc $(CWD)/%.pb.h:		$(CWD)/%.proto $(HOSTBIN)/protoc $(INC)/google/protobuf
 	@echo "         $(COLOR_CYAN)[PROTO]$(COLOR_RESET)			$(basename $<)"
 	@$(HOSTBIN)/protoc $< -Imldb/ext/tensorflow --cpp_out=$(TF_CWD)
 
@@ -328,7 +328,7 @@ $(foreach op,$(TENSORFLOW_OPS), \
 # Put them all into one convenient library, along with the no_op.  The no_op
 # has to be here, and not in the core library, as otherwise the interface is
 # generated for each of the ops and we have multiple definitions.
-$(CWD)/tensorflow/core/ops/no_op.cc: | $(TENSORFLOW_PROTOBUF_FILES:%.proto=%.pb.h)
+$(CWD)/tensorflow/core/ops/no_op.cc: | $(INC)/google/protobuf $(TENSORFLOW_PROTOBUF_FILES:%.proto=%.pb.h)
 $(eval $(call set_compile_option,tensorflow/core/ops/no_op.cc,$(TENSORFLOW_COMPILE_FLAGS)))
 $(eval $(call library,tensorflow-ops,tensorflow/core/ops/no_op.cc,$(foreach op,$(TENSORFLOW_OPS),tensorflow_$(op)_ops) tensorflow-core,,,,,$(TENSORFLOW_CUDA_LINKER_FLAGS)))
 

--- a/ext/tensorflow.mk
+++ b/ext/tensorflow.mk
@@ -119,7 +119,7 @@ $(INC)/external/eigen_archive/eigen-eigen-$(TENSORFLOW_EIGEN_MERCURIAL_HASH):
 
 # To create a protobuf file, we compile the input file.  Same for the .h
 # file.
-$(CWD)/%.pb.cc $(CWD)/%.pb.h:		$(CWD)/%.proto $(HOSTBIN)/protoc $(INC)/google/protobuf
+$(CWD)/%.pb.cc $(CWD)/%.pb.h:		$(CWD)/%.proto $(HOSTBIN)/protoc | $(INC)/google/protobuf
 	@echo "         $(COLOR_CYAN)[PROTO]$(COLOR_RESET)			$(basename $<)"
 	@$(HOSTBIN)/protoc $< -Imldb/ext/tensorflow --cpp_out=$(TF_CWD)
 


### PR DESCRIPTION
 - Add dependency on protobuf headers for pb.h and pb.cc files
 - install protobuf in proper directory when $BIN $LIB and INC are changed
   (docker builds)