### PR TITLE
Pass $HOSTBIN to build_protobuf_for_arch

### DIFF
--- a/ext/protobuf.mk
+++ b/ext/protobuf.mk
@@ -59,5 +59,5 @@ endef
 ifneq ($(ARCH),$(HOSTARCH))
 $(eval $(call build_protobuf_for_arch,$(HOSTARCH),$(BUILD)/$(HOSTARCH)/lib,$(BUILD)/$(HOSTARCH)/include,$(BUILD)/$(HOSTARCH)/bin))
 endif
-$(eval $(call build_protobuf_for_arch,$(ARCH),$(LIB),$(INC),$(BIN)))
+$(eval $(call build_protobuf_for_arch,$(ARCH),$(LIB),$(INC),$(HOSTBIN)))
 endif


### PR DESCRIPTION
Fixes inconditional rebuilds of protobuf when using a modified $(BIN)
(docker builds)
