### PR TITLE
Dynamic load Tensorflow kernels for CPU (MLDB-1939)

### DIFF
--- a/ext/tensorflow.mk
+++ b/ext/tensorflow.mk
@@ -338,18 +338,74 @@ TENSORFLOW_KERNEL_CC_FILES:=$(shell find $(CWD)/tensorflow/core/kernels -name "*
 
 TENSORFLOW_KERNEL_CC_BUILD:=$(sort $(TENSORFLOW_KERNEL_CC_FILES:$(CWD)/%=%))
 
-# For each target architecture we set the flags here
-TF_ARCH_FLAGS_x86_64:=-mavx
-
-$(eval $(call set_compile_option,$(TENSORFLOW_KERNEL_CC_BUILD) $(TENSORFLOW_PROTOBUF_BUILD),$(TENSORFLOW_COMPILE_FLAGS) $(TF_ARCH_FLAGS_$(ARCH))))
-
+# Dependencies for the kernel files... basically everything else needs to
+# be built first
 $(TENSORFLOW_KERNEL_CC_FILES):	$(TENSORFLOW_PROTOBUF_HEADERS) | $(TENSORFLOW_INCLUDES) $(INC)/external/re2 $(INC)/external/jpeg-9a $(INC)/external/eigen_archive/eigen-eigen-$(TENSORFLOW_EIGEN_MERCURIAL_HASH) $(HOSTBIN)/protoc  $(INC)/google/protobuf $(INC)/external/farmhash-$(TENSORFLOW_FARMHASH_HASH) $(INC)/external/libpng-1.2.53
-$(eval $(call library,tensorflow-kernels,$(TENSORFLOW_KERNEL_CC_BUILD) $(TENSORFLOW_CUDA_NVCC_BUILD),tensorflow-ops $(TENSORFLOW_CUDA_LINK),,,,,$(TENSORFLOW_CUDA_LINKER_FLAGS)))
 
+# This is a list of variants for each architecture
+# Note that this can cause long compile times as a big chunk of
+# TensorFlow is built multiple times, in that case you
+# might want to set TF_KERNEL_VARIANTS:=(whichever one applies) to
+# speed up compile times
+TF_KERNEL_VARIANTS_x86_64:=sse2 sse42 avx avx2
+TF_KERNEL_VARIANTS_aarch64:=generic
+TF_KERNEL_VARIANTS_arm:=generic
 
+# For each variant, this provides the optimization flags passed in
+# The correct kernels library is detected at runtime and loaded
+# dynamically on Tensorflow initialization
+TF_KERNEL_VARIANT_x86_64_sse2:=-msse2
+TF_KERNEL_VARIANT_x86_64_sse42:=-msse4.2
+TF_KERNEL_VARIANT_x86_64_avx:=-mavx
+TF_KERNEL_VARIANT_x86_64_avx2:=-mavx2 -mfma
+
+# ARM variants don't currently detect their CPU capabilities at
+# runtime, so only a generic variant is compiled
+TF_KERNEL_VARIANT_aarch64_generic:=-funsafe-math-optimizations -ftree-vectorize
+TF_KERNEL_VARIANT_arm_generic:=-funsafe-math-optimizations -ftree-vectorize
+
+# By default, we compile all kernel variants for our architecture
+# This can be overridden to speed up compile times
+TF_KERNEL_VARIANTS?=$(TF_KERNEL_VARIANTS_$(ARCH))
+
+# If no kernel variants are specified, we can't build kernels
+# and so we will fail at compile time
+$(if $(TF_KERNEL_VARIANTS),,$(error TF_KERNEL_VARIANTS_$(ARCH) is not set; when cross-compiling you need to set up architecture variants))
+
+# Macro to define a kernel variant for compilation
+# This will create a library tensorflow-kernels-(variant) that can be
+# loaded at runtime depending upon the detected architecture.
+#
+# To create this, we
+# a) copy the given files to a temporary directory so that they are seen
+#    as unique by the build system
+# b) compile them with the custom flags
+#
+# $(1) = variant name
+
+define tf_kernel_variant
+
+# Rule to copy the source files over
+mldb/ext/tensorflow/../../$(BUILD)/$(ARCH)/tmp/tensorflow-kernel-variants/$(1)/%:	$(CWD)/%
+	mkdir -p $$(dir $$@) && cp $$< $$@~ && mv $$@~ $$@
+
+TENSORFLOW_KERNEL_BUILD_VARIANT_$(1):=$(TENSORFLOW_KERNEL_CC_BUILD:%=../../$(BUILD)/$(ARCH)/tmp/tensorflow-kernel-variants/$(1)/%)
+
+$$(eval $$(call set_compile_option,$$(TENSORFLOW_KERNEL_BUILD_VARIANT_$(1)),$$(TENSORFLOW_COMPILE_FLAGS) $$(TF_KERNEL_VARIANT_$(ARCH)_$(1))))
+$$(eval $$(call library,tensorflow-kernels-$(1),$$(TENSORFLOW_KERNEL_BUILD_VARIANT_$(1)) $$(TENSORFLOW_CUDA_NVCC_BUILD),tensorflow-ops $$(TENSORFLOW_CUDA_LINK),,,,,$$(TENSORFLOW_CUDA_LINKER_FLAGS),$(BUILD)/$(ARCH)/tmp/tensorflow-kernel-variants))
+
+# Tensorflow depends upon having a variant
+$(LIB)/libtensorflow.so: $(LIB)/libtensorflow-kernels-$(1).so
+
+#$(w arning $(LIB)/libtensorflow.so: $(LIB)/libtensorflow-kernels-$(1).so)
+
+endef
+
+$(foreach variant,$(TF_KERNEL_VARIANTS),$(eval $(call tf_kernel_variant,$(variant))))
 
 # Overall library that wraps it all together
-$(eval $(call library,tensorflow,,tensorflow-ops tensorflow-kernels tensorflow-core))
+$(eval $(call library,tensorflow,../tf_load_kernels.cc,tensorflow-ops tensorflow-core))
+
 
 # And create a nice target name
 tensorflow_lib: $(LIB)/libtensorflow.so

--- a/ext/tf_load_kernels.cc
+++ b/ext/tf_load_kernels.cc
@@ -1,0 +1,94 @@
+/** tf_load_kernels.cc
+    Jeremy Barnes, 13 September 2016
+    Copyright (c) 2016 Datacratic Inc.  All rights reserved.
+
+    Detects what machine architecture Tensorflow is running on, and
+    loads the appropriate kernels library for the architecture.
+*/
+
+#include "mldb/arch/arch.h"
+#include <dlfcn.h>
+#include <mutex>
+#include <iostream>
+#if JML_INTEL_ISA
+#  include "mldb/arch/simd.h"
+#endif
+#include <cassert>
+
+using namespace std;
+using namespace ML;
+
+namespace Datacratic {
+namespace MLDB {
+
+// This is defined in the MLDB server
+static std::mutex dlopenMutex;
+
+namespace {
+struct AtInit {
+    AtInit()
+        : handle(nullptr)
+    {
+        // Also exclude anyone else from using dlopen, since it's not thread
+        // safe.
+        std::unique_lock<std::mutex> guard2(dlopenMutex);
+
+        const char * error = nullptr;
+
+#if JML_INTEL_ISA
+        // Try avx2 first
+        if (!handle && has_avx2()) {
+            error = load("avx2");
+        }
+        // Next is avx1
+        if (!handle && has_avx()) {
+            error = load("avx");
+        }
+        // Next SSE 4.2
+        if (!handle && has_sse42) {
+            error = load("sse42");
+        }
+        // Finally SSE2
+        if (!handle && has_sse2) {
+            error = load("sse2");
+        }
+#else
+        error = load("generic");
+#endif
+
+        if (!handle) {
+            cerr << "Couldn't load any TensorFlow kernels library: "
+                 << error << endl;
+            cerr << "Tensorflow operations will abort on launch" << endl;
+        }
+    }
+
+    ~AtInit()
+    {
+        if (handle)
+            dlclose(handle);
+    }
+
+    void * handle;  ///< Shared library handle
+
+    const char * load(const std::string & architecture)
+    {
+        string path = "libtensorflow-kernels-" + architecture + ".so";
+
+        dlerror();  // clear existing error
+
+        handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+        if (!handle) {
+            char * error = dlerror();
+            assert(error);
+            return error;
+        }
+
+        return nullptr;
+    }
+} atInit;
+
+} // file scope
+} // namespace MLDB
+} // namespace Datacratic
+

--- a/jml-build/sample.local.mk
+++ b/jml-build/sample.local.mk
@@ -1,4 +1,17 @@
 COMPILER_CACHE:=ccache
 
-# You should run ccache -M 12G or something similar to set the max cache size
+# If you are only doing local development, you don't need to build all
+# of the possible variants of Tensorflow.  In that case, you can set
+# one of the following depending upon the capability of your computer:
+#
+# If `cat /proc/cpuinfo | grep avx2` returns something
+# TF_KERNEL_VARIANTS:=avx2
+# Otherwise, if `cat /proc/cpuinfo | grep avx` returns something
+# TF_KERNEL_VARIANTS:=avx
+# Otherwise, any machine you're likely to have will do fine with this
+# TF_KERNEL_VARIANTS:=sse42
+# And if Tensorflow crashes with an illegal instruction, this is the fallback
+# TF_KERNEL_VARIANTS:=sse2
+
+# You should run ccache -M 20G or something similar to set the max cache size
 # to a value higher than the default 1G.


### PR DESCRIPTION
Our build for Tensorflow had a hard-coded option to use avx operations, which are not supported on older 64 bit CPUs.  By the same token, it was unable to make use of avx2 and FMA instructions available on new 64 bit CPUs.

This patch modifies the building of the Tensorflow kernels to build a separate library optimized for each processor architecture, and then select the appropriate one at runtime.

Note that it adds quite a long time to the build process, since there are four different options built.  Adding `TF_KERNEL_VARIANTS:=avx` or `TF_KERNEL_VARIANTS:=sse42` or `TF_KERNEL_VARIANTS:=avx2` to local.mk will cause only a single one to be built, improving compile times.