### PR TITLE
Mldb 1391 classifier proc err on bad cfg

### DIFF
--- a/jml/utils/configuration.cc
+++ b/jml/utils/configuration.cc
@@ -336,13 +336,13 @@ void
 Configuration::
 throwOnUnknwonKeys(
     vector<string> & keys,
-    const function<bool(const string & )> & removeIfFct) const
+    const function<bool(const string & )> & ignoreKeyFct) const
 {
     string prefixDot = prefix_ + ".";
     keys.erase(
         remove_if(keys.begin(), keys.end(),
                   [&] (const std::string & str) {
-                     return (removeIfFct && removeIfFct(str)) || str.find(prefixDot) != 0;
+                     return (ignoreKeyFct && ignoreKeyFct(str)) || str.find(prefixDot) != 0;
                   }),
         keys.end());
 

--- a/jml/utils/configuration.cc
+++ b/jml/utils/configuration.cc
@@ -342,7 +342,9 @@ throwOnUnknwonKeys(
     keys.erase(
         remove_if(keys.begin(), keys.end(),
                   [&] (const std::string & str) {
-                     return (ignoreKeyFct && ignoreKeyFct(str)) || str.find(prefixDot) != 0;
+                     return (ignoreKeyFct && ignoreKeyFct(str)) // fct says to ignore
+                        || str.find(prefixDot) != 0 // prefix not found
+                        || str.rfind(".") != prefixDot.size() - 1; // prefix found, but non terminal key
                   }),
         keys.end());
 

--- a/jml/utils/configuration.cc
+++ b/jml/utils/configuration.cc
@@ -6,6 +6,7 @@
 
    Configuration file parser.
 */
+#include <boost/algorithm/string/join.hpp>
 
 #include "configuration.h"
 #include "mldb/base/parse_context.h"
@@ -349,7 +350,7 @@ throwOnUnknwonKeys(
 
     if (!keys.empty()) {
         throw ML::Exception("Unknown key(s) encountered in config: %s",
-                            ML::join(keys).c_str());
+                            boost::algorithm::join(keys, " ").c_str());
     }
 }
 

--- a/jml/utils/configuration.cc
+++ b/jml/utils/configuration.cc
@@ -330,4 +330,26 @@ allKeys() const
     return result;
 }
 
+
+/** Call after all keys have been consumed with findAndRemove */
+void
+Configuration::
+throwOnUnknwonKeys(
+    vector<string> & keys,
+    const function<bool(const string & )> & removeIfFct) const
+{
+    string prefixDot = prefix_ + ".";
+    keys.erase(
+        remove_if(keys.begin(), keys.end(),
+                  [&] (const std::string & str) {
+                     return (removeIfFct && removeIfFct(str)) || str.find(prefixDot) != 0;
+                  }),
+        keys.end());
+
+    if (!keys.empty()) {
+        throw ML::Exception("Unknown key(s) encountered in config: %s",
+                            ML::join(keys).c_str());
+    }
+}
+
 } // namespace ML

--- a/jml/utils/configuration.cc
+++ b/jml/utils/configuration.cc
@@ -291,7 +291,6 @@ raw_set(const std::string & key, const std::string & value)
     if (!writeable_)
         throw Exception("Configuration::operator []: "
                         "object is not writeable");
-
     data_->entries[key] = value;
 }
 

--- a/jml/utils/configuration.h
+++ b/jml/utils/configuration.h
@@ -175,12 +175,23 @@ public:
     template<class X>
     bool find(X & val, const std::string & key) const
     {
-        //std::cerr << "find: key = " << key << std::endl;
         std::string full_key = find_key(key, true);
         if (!raw_count(full_key)) return false;
         std::string value = raw_get(full_key);
         parse_value(val, value, full_key);
         return true;
+    }
+
+    template<class X>
+    bool findAndRemove(X & val,
+                       const std::string & key,
+                       std::vector<std::string> & list) const
+    {
+        if (find(val, key)) {
+            list.erase(remove(list.begin(), list.end(), find_key(key, true)),
+                       list.end());
+        }
+        return false;
     }
 
     template<class X>

--- a/jml/utils/configuration.h
+++ b/jml/utils/configuration.h
@@ -208,6 +208,10 @@ public:
             throw Exception("required key " + key + " not found");
     }
 
+    void throwOnUnknwonKeys(
+        std::vector<std::string> & keys,
+        const std::function<bool(const std::string &)> & removeIfFct = nullptr) const;
+
 private:
     struct Data;
     std::shared_ptr<Data> data_;

--- a/jml/utils/configuration.h
+++ b/jml/utils/configuration.h
@@ -208,9 +208,12 @@ public:
             throw Exception("required key " + key + " not found");
     }
 
+    /** Empties the key vector from keys not starting with "prefix().".
+     *  If ignoreKeyFct is provided, also removes the key when the function returns true.
+     *  After that cleaning, throws if any key is left in the vector. */
     void throwOnUnknwonKeys(
         std::vector<std::string> & keys,
-        const std::function<bool(const std::string &)> & removeIfFct = nullptr) const;
+        const std::function<bool(const std::string &)> & ignoreKeyFct = nullptr) const;
 
 private:
     struct Data;

--- a/jml/utils/string_functions.cc
+++ b/jml/utils/string_functions.cc
@@ -240,21 +240,4 @@ trim(const string & other)
     return result;
 }
 
-std::string
-join(const std::vector<std::string> strings)
-{
-    stringstream ss;
-    bool first = true;
-    for (const auto & s: strings) {
-        if (JML_UNLIKELY(first)) {
-            first = false;
-        }
-        else {
-            ss << " ";
-        }
-        ss << s;
-    }
-    return ss.str();
-}
-
 } // namespace ML

--- a/jml/utils/string_functions.cc
+++ b/jml/utils/string_functions.cc
@@ -240,5 +240,21 @@ trim(const string & other)
     return result;
 }
 
+std::string
+join(const std::vector<std::string> strings)
+{
+    stringstream ss;
+    bool first = true;
+    for (const auto & s: strings) {
+        if (JML_UNLIKELY(first)) {
+            first = false;
+        }
+        else {
+            ss << " ";
+        }
+        ss << s;
+    }
+    return ss.str();
+}
 
 } // namespace ML

--- a/jml/utils/string_functions.h
+++ b/jml/utils/string_functions.h
@@ -69,6 +69,8 @@ unsigned replace_all(std::string & haystack, const std::string & search,
  * string. */
 std::string trim(const std::string & other);
 
+std::string join(const std::vector<std::string> strings);
+
 } // namespace ML
 
 

--- a/jml/utils/string_functions.h
+++ b/jml/utils/string_functions.h
@@ -69,8 +69,6 @@ unsigned replace_all(std::string & haystack, const std::string & search,
  * string. */
 std::string trim(const std::string & other);
 
-std::string join(const std::vector<std::string> strings);
-
 } // namespace ML
 
 

--- a/ml/jml/bagging_generator.cc
+++ b/ml/jml/bagging_generator.cc
@@ -45,12 +45,14 @@ Bagging_Generator::~Bagging_Generator()
 
 void
 Bagging_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    config.find(num_bags,         "num_bags");
-    config.find(validation_split, "validation_split");
+    Classifier_Generator::configure(config, unparsedKeys);
+    config.findAndRemove(num_bags, "num_bags", unparsedKeys);
+    config.findAndRemove(validation_split, "validation_split", unparsedKeys);
 
     weak_learner = get_trainer("weak_learner", config);
+
 }
 
 void

--- a/ml/jml/bagging_generator.h
+++ b/ml/jml/bagging_generator.h
@@ -34,7 +34,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config);
+    configure(const Configuration & config,
+              std::vector<std::string> & unparsedKeys);
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/boosted_stumps_generator.cc
+++ b/ml/jml/boosted_stumps_generator.cc
@@ -67,18 +67,18 @@ Boosted_Stumps_Generator::~Boosted_Stumps_Generator()
 
 void
 Boosted_Stumps_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    Early_Stopping_Generator::configure(config);
+    Early_Stopping_Generator::configure(config, unparsedKeys);
     
-    config.find(max_iter,             "max_iter");
-    config.find(min_iter,             "min_iter");
-    config.find(true_only,            "true_only");
-    config.find(fair,                 "fair");
-    config.find(cost_function,        "cost_function");
-    config.find(output_function,      "output_function");
-    config.find(short_circuit_window, "short_circuit_window");
-    config.find(trace_training_acc,   "trace_training_acc");
+    config.findAndRemove(max_iter, "max_iter", unparsedKeys);
+    config.findAndRemove(min_iter, "min_iter", unparsedKeys);
+    config.findAndRemove(true_only, "true_only", unparsedKeys);
+    config.findAndRemove(fair, "fair", unparsedKeys);
+    config.findAndRemove(cost_function, "cost_function", unparsedKeys);
+    config.findAndRemove(output_function, "output_function", unparsedKeys);
+    config.findAndRemove(short_circuit_window, "short_circuit_window", unparsedKeys);
+    config.findAndRemove(trace_training_acc, "trace_training_acc", unparsedKeys);
 }
 
 void

--- a/ml/jml/boosted_stumps_generator.h
+++ b/ml/jml/boosted_stumps_generator.h
@@ -37,7 +37,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config);
+    configure(const Configuration & config,
+              std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/boosting_generator.cc
+++ b/ml/jml/boosting_generator.cc
@@ -48,15 +48,15 @@ Boosting_Generator::~Boosting_Generator()
 
 void
 Boosting_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    Early_Stopping_Generator::configure(config);
+    Early_Stopping_Generator::configure(config, unparsedKeys);
 
-    config.find(max_iter,             "max_iter");
-    config.find(min_iter,             "min_iter");
-    config.find(cost_function,        "cost_function");
-    config.find(short_circuit_window, "short_circuit_window");
-    config.find(trace_training_acc,   "trace_training_acc");
+    config.findAndRemove(max_iter, "max_iter", unparsedKeys);
+    config.findAndRemove(min_iter, "min_iter", unparsedKeys);
+    config.findAndRemove(cost_function, "cost_function", unparsedKeys);
+    config.findAndRemove(short_circuit_window, "short_circuit_window", unparsedKeys);
+    config.findAndRemove(trace_training_acc, "trace_training_acc", unparsedKeys);
 
     weak_learner = get_trainer("weak_learner", config);
 }

--- a/ml/jml/boosting_generator.h
+++ b/ml/jml/boosting_generator.h
@@ -35,7 +35,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config);
+    configure(const Configuration & config,
+              std::vector<std::string> & unparsedKeys);
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/boosting_generator.h
+++ b/ml/jml/boosting_generator.h
@@ -36,7 +36,7 @@ public:
     /** Configure the generator with its parameters. */
     virtual void
     configure(const Configuration & config,
-              std::vector<std::string> & unparsedKeys);
+              std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/classifier_generator.cc
+++ b/ml/jml/classifier_generator.cc
@@ -213,6 +213,19 @@ type() const
     return demangle(typeid(*this).name());
 }
 
+void
+Classifier_Generator::
+assertNoRemainingKeys(std::vector<std::string> remainingKeys,
+                      const Configuration & config)
+{
+    string typeKey = config.prefix() + ".type";
+    string allowPrefix = config.prefix() + "._";
+    auto allowKeyFct = [&] (const string & str) {
+        return str == typeKey || str.find(allowPrefix) == 0;
+    };
+    config.throwOnUnknwonKeys(remainingKeys, allowKeyFct);
+}
+
 
 /*****************************************************************************/
 /* FACTORIES                                                                 */
@@ -266,6 +279,5 @@ get_trainer(const std::string & name, const Configuration & config)
 
     return result;
 }
-
 } // namespace ML
 

--- a/ml/jml/classifier_generator.cc
+++ b/ml/jml/classifier_generator.cc
@@ -38,11 +38,11 @@ init(std::shared_ptr<const Feature_Space> fs, Feature predicted)
 
 void
 Classifier_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    config.find(verbosity, "verbosity");
-    config.find(profile, "profile");
-    config.find(validate, "validate");
+    config.findAndRemove(verbosity, "verbosity", unparsedKeys);
+    config.findAndRemove(profile, "profile", unparsedKeys);
+    config.findAndRemove(validate, "validate", unparsedKeys);
 }
 
 void
@@ -213,20 +213,6 @@ type() const
     return demangle(typeid(*this).name());
 }
 
-void
-Classifier_Generator::
-assertNoRemainingKeys(std::vector<std::string> remainingKeys,
-                      const Configuration & config)
-{
-    string typeKey = config.prefix() + ".type";
-    string allowPrefix = config.prefix() + "._";
-    auto allowKeyFct = [&] (const string & str) {
-        return str == typeKey || str.find(allowPrefix) == 0;
-    };
-    config.throwOnUnknwonKeys(remainingKeys, allowKeyFct);
-}
-
-
 /*****************************************************************************/
 /* FACTORIES                                                                 */
 /*****************************************************************************/
@@ -275,7 +261,15 @@ get_trainer(const std::string & name, const Configuration & config)
         = Registry<Classifier_Generator>::singleton().create(type);
 
     Configuration config2(config, name, Configuration::PREFIX_APPEND);
-    result->configure(config2);
+    auto unparsedKeys = config2.allKeys();
+    result->configure(config2, unparsedKeys);
+
+    string typeKey = config2.prefix() + ".type";
+    string allowPrefix = config2.prefix() + "._";
+    auto allowKeyFct = [&] (const string & str) {
+        return str == typeKey || str.find(allowPrefix) == 0;
+    };
+    config2.throwOnUnknwonKeys(remainingKeys, allowKeyFct);
 
     return result;
 }

--- a/ml/jml/classifier_generator.cc
+++ b/ml/jml/classifier_generator.cc
@@ -269,7 +269,7 @@ get_trainer(const std::string & name, const Configuration & config)
     auto allowKeyFct = [&] (const string & str) {
         return str == typeKey || str.find(allowPrefix) == 0;
     };
-    config2.throwOnUnknwonKeys(remainingKeys, allowKeyFct);
+    config2.throwOnUnknwonKeys(unparsedKeys, allowKeyFct);
 
     return result;
 }

--- a/ml/jml/classifier_generator.h
+++ b/ml/jml/classifier_generator.h
@@ -106,6 +106,11 @@ public:
     /** Log a message for the given module at the given debug level. */
     std::ostream & log(const std::string & module, int level) const;
 
+    /** Checks if any key of the current config.prefix() is left EXCEPT for
+     *  prefix().type and keys starting with prefix()._ */
+    static void assertNoRemainingKeys(std::vector<std::string> remainingKeys,
+                                      const Configuration & config);
+
     /** Current verbosity level. */
     int verbosity;
 

--- a/ml/jml/classifier_generator.h
+++ b/ml/jml/classifier_generator.h
@@ -34,7 +34,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config);
+    configure(const Configuration & config,
+              std::vector<std::string> & unparsedKeys);
     
     /** Return to the default configuration. */
     virtual void defaults();
@@ -105,11 +106,6 @@ public:
 
     /** Log a message for the given module at the given debug level. */
     std::ostream & log(const std::string & module, int level) const;
-
-    /** Checks if any key of the current config.prefix() is left EXCEPT for
-     *  prefix().type and keys starting with prefix()._ */
-    static void assertNoRemainingKeys(std::vector<std::string> remainingKeys,
-                                      const Configuration & config);
 
     /** Current verbosity level. */
     int verbosity;

--- a/ml/jml/decision_tree_generator.cc
+++ b/ml/jml/decision_tree_generator.cc
@@ -127,10 +127,16 @@ configure(const Configuration & config)
 {
     Classifier_Generator::configure(config);
 
-    config.find(trace, "trace");
-    config.find(max_depth, "max_depth");
-    config.find(update_alg, "update_alg");
-    config.find(random_feature_propn, "random_feature_propn");
+    auto keys = config.allKeys();
+    config.findAndRemove(trace, "trace", keys);
+    config.findAndRemove(max_depth, "max_depth", keys);
+    config.findAndRemove(update_alg, "update_alg", keys);
+    config.findAndRemove(random_feature_propn, "random_feature_propn", keys);
+    config.findAndRemove(verbosity, "verbosity", keys);
+
+    string typeKey = config.find_key("type", true);
+    config.throwOnUnknwonKeys(
+        keys, [&] (const string & str) { return str == typeKey; });
 }
 
 void

--- a/ml/jml/decision_tree_generator.cc
+++ b/ml/jml/decision_tree_generator.cc
@@ -123,18 +123,15 @@ Decision_Tree_Generator::~Decision_Tree_Generator()
 
 void
 Decision_Tree_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    Classifier_Generator::configure(config);
+    Classifier_Generator::configure(config, unparsedKeys);
 
-    auto keys = config.allKeys();
-    config.findAndRemove(trace, "trace", keys);
-    config.findAndRemove(max_depth, "max_depth", keys);
-    config.findAndRemove(update_alg, "update_alg", keys);
-    config.findAndRemove(random_feature_propn, "random_feature_propn", keys);
-    config.findAndRemove(verbosity, "verbosity", keys);
-
-    Classifier_Generator::assertNoRemainingKeys(keys, config);
+    config.findAndRemove(trace, "trace", unparsedKeys);
+    config.findAndRemove(max_depth, "max_depth", unparsedKeys);
+    config.findAndRemove(update_alg, "update_alg", unparsedKeys);
+    config.findAndRemove(random_feature_propn, "random_feature_propn", unparsedKeys);
+    config.findAndRemove(verbosity, "verbosity", unparsedKeys);
 }
 
 void

--- a/ml/jml/decision_tree_generator.cc
+++ b/ml/jml/decision_tree_generator.cc
@@ -134,9 +134,7 @@ configure(const Configuration & config)
     config.findAndRemove(random_feature_propn, "random_feature_propn", keys);
     config.findAndRemove(verbosity, "verbosity", keys);
 
-    string typeKey = config.find_key("type", true);
-    config.throwOnUnknwonKeys(
-        keys, [&] (const string & str) { return str == typeKey; });
+    Classifier_Generator::assertNoRemainingKeys(keys, config);
 }
 
 void

--- a/ml/jml/decision_tree_generator.h
+++ b/ml/jml/decision_tree_generator.h
@@ -34,7 +34,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config);
+    configure(const Configuration & config,
+              std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/early_stopping_generator.cc
+++ b/ml/jml/early_stopping_generator.cc
@@ -30,10 +30,10 @@ Early_Stopping_Generator::
 
 void
 Early_Stopping_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    Classifier_Generator::configure(config);
-    config.find(validate_split, "validate_split");
+    Classifier_Generator::configure(config, unparsedKeys);
+    config.findAndRemove(validate_split, "validate_split", unparsedKeys);
 }
 
 void

--- a/ml/jml/early_stopping_generator.h
+++ b/ml/jml/early_stopping_generator.h
@@ -30,7 +30,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config);
+    configure(const Configuration & config,
+              std::vector<std::string> & unparsedKeys);
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/early_stopping_generator.h
+++ b/ml/jml/early_stopping_generator.h
@@ -31,7 +31,7 @@ public:
     /** Configure the generator with its parameters. */
     virtual void
     configure(const Configuration & config,
-              std::vector<std::string> & unparsedKeys);
+              std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/glz_classifier_generator.cc
+++ b/ml/jml/glz_classifier_generator.cc
@@ -60,9 +60,7 @@ configure(const Configuration & config)
     config.findAndRemove(feature_proportion, "feature_proportion", keys);
     config.findAndRemove(verbosity, "verbosity", keys);
 
-    string typeKey = config.find_key("type", true);
-    config.throwOnUnknwonKeys(
-        keys, [&] (const string & str) { return str == typeKey; });
+    Classifier_Generator::assertNoRemainingKeys(keys, config);
 }
 
 void

--- a/ml/jml/glz_classifier_generator.cc
+++ b/ml/jml/glz_classifier_generator.cc
@@ -43,24 +43,19 @@ GLZ_Classifier_Generator::~GLZ_Classifier_Generator()
 
 void
 GLZ_Classifier_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    Classifier_Generator::configure(config);
-
-    auto keys = config.allKeys();
-    config.findAndRemove(add_bias, "add_bias", keys);
-    config.findAndRemove(do_decode, "decode", keys);
-    config.findAndRemove(link_function, "link_function", keys);
-    config.findAndRemove(normalize, "normalize", keys);
-    config.findAndRemove(condition, "condition", keys);
-    config.findAndRemove(regularization, "regularization", keys);
-    config.findAndRemove(regularization_factor, "regularization_factor", keys);
-    config.findAndRemove(max_regularization_iteration, "max_regularization_iteration", keys);
-    config.findAndRemove(regularization_epsilon, "regularization_epsilon", keys);
-    config.findAndRemove(feature_proportion, "feature_proportion", keys);
-    config.findAndRemove(verbosity, "verbosity", keys);
-
-    Classifier_Generator::assertNoRemainingKeys(keys, config);
+    Classifier_Generator::configure(config, unparsedKeys);
+    config.findAndRemove(add_bias, "add_bias", unparsedKeys);
+    config.findAndRemove(do_decode, "decode", unparsedKeys);
+    config.findAndRemove(link_function, "link_function", unparsedKeys);
+    config.findAndRemove(normalize, "normalize", unparsedKeys);
+    config.findAndRemove(condition, "condition", unparsedKeys);
+    config.findAndRemove(regularization, "regularization", unparsedKeys);
+    config.findAndRemove(regularization_factor, "regularization_factor", unparsedKeys);
+    config.findAndRemove(max_regularization_iteration, "max_regularization_iteration", unparsedKeys);
+    config.findAndRemove(regularization_epsilon, "regularization_epsilon", unparsedKeys);
+    config.findAndRemove(feature_proportion, "feature_proportion", unparsedKeys);
 }
 
 void

--- a/ml/jml/glz_classifier_generator.cc
+++ b/ml/jml/glz_classifier_generator.cc
@@ -64,7 +64,7 @@ configure(const Configuration & config)
     string prefix = config.prefix() + ".";
     keys.erase(remove_if(keys.begin(), keys.end(),
                          [&] (const string & str) {
-                            return str == fullKey || str.find(prefix) == string::npos;
+                            return str == fullKey || str.find(prefix) != 0;
                          }),
                 keys.end());
 

--- a/ml/jml/glz_classifier_generator.cc
+++ b/ml/jml/glz_classifier_generator.cc
@@ -60,18 +60,9 @@ configure(const Configuration & config)
     config.findAndRemove(feature_proportion, "feature_proportion", keys);
     config.findAndRemove(verbosity, "verbosity", keys);
 
-    string fullKey = config.find_key("type", true);
-    string prefix = config.prefix() + ".";
-    keys.erase(remove_if(keys.begin(), keys.end(),
-                         [&] (const string & str) {
-                            return str == fullKey || str.find(prefix) != 0;
-                         }),
-                keys.end());
-
-    if (!keys.empty()) {
-        throw ML::Exception("Unknown key(s) encountered in config: %s",
-                            ML::join(keys).c_str());
-    }
+    string typeKey = config.find_key("type", true);
+    config.throwOnUnknwonKeys(
+        keys, [&] (const string & str) { return str == typeKey; });
 }
 
 void

--- a/ml/jml/glz_classifier_generator.cc
+++ b/ml/jml/glz_classifier_generator.cc
@@ -19,6 +19,7 @@
 #include "mldb/ml/algebra/least_squares.h"
 #include "mldb/arch/timers.h"
 #include "mldb/base/parallel.h"
+#include "mldb/jml/utils/string_functions.h"
 
 using namespace std;
 
@@ -46,16 +47,31 @@ configure(const Configuration & config)
 {
     Classifier_Generator::configure(config);
 
-    config.find(add_bias, "add_bias");
-    config.find(do_decode, "decode");
-    config.find(link_function, "link_function");
-    config.find(normalize, "normalize");
-    config.find(condition, "condition");
-    config.find(regularization, "regularization");
-    config.find(regularization_factor, "regularization_factor");
-    config.find(max_regularization_iteration, "max_regularization_iteration");
-    config.find(regularization_epsilon, "regularization_epsilon");
-    config.find(feature_proportion, "feature_proportion");
+    auto keys = config.allKeys();
+    config.findAndRemove(add_bias, "add_bias", keys);
+    config.findAndRemove(do_decode, "decode", keys);
+    config.findAndRemove(link_function, "link_function", keys);
+    config.findAndRemove(normalize, "normalize", keys);
+    config.findAndRemove(condition, "condition", keys);
+    config.findAndRemove(regularization, "regularization", keys);
+    config.findAndRemove(regularization_factor, "regularization_factor", keys);
+    config.findAndRemove(max_regularization_iteration, "max_regularization_iteration", keys);
+    config.findAndRemove(regularization_epsilon, "regularization_epsilon", keys);
+    config.findAndRemove(feature_proportion, "feature_proportion", keys);
+    config.findAndRemove(verbosity, "verbosity", keys);
+
+    string fullKey = config.find_key("type", true);
+    string prefix = config.prefix() + ".";
+    keys.erase(remove_if(keys.begin(), keys.end(),
+                         [&] (const string & str) {
+                            return str == fullKey || str.find(prefix) == string::npos;
+                         }),
+                keys.end());
+
+    if (!keys.empty()) {
+        throw ML::Exception("Unknown key(s) encountered in config: %s",
+                            ML::join(keys).c_str());
+    }
 }
 
 void

--- a/ml/jml/glz_classifier_generator.h
+++ b/ml/jml/glz_classifier_generator.h
@@ -35,7 +35,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config);
+    configure(const Configuration & config,
+              std::vector<std::string> & unparsedKeys);
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/glz_classifier_generator.h
+++ b/ml/jml/glz_classifier_generator.h
@@ -36,7 +36,7 @@ public:
     /** Configure the generator with its parameters. */
     virtual void
     configure(const Configuration & config,
-              std::vector<std::string> & unparsedKeys);
+              std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/naive_bayes_generator.cc
+++ b/ml/jml/naive_bayes_generator.cc
@@ -42,12 +42,11 @@ Naive_Bayes_Generator::~Naive_Bayes_Generator()
 
 void
 Naive_Bayes_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    Classifier_Generator::configure(config);
-    
-    config.find(trace,        "trace");
-    config.find(feature_prop, "feature_prop");
+    Classifier_Generator::configure(config, unparsedKeys);
+    config.findAndRemove(trace, "trace", unparsedKeys);
+    config.findAndRemove(feature_prop, "feature_prop", unparsedKeys);
 }
 
 void

--- a/ml/jml/naive_bayes_generator.h
+++ b/ml/jml/naive_bayes_generator.h
@@ -32,7 +32,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config) override;
+    configure(const Configuration & config,
+              std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
     virtual void defaults() override;

--- a/ml/jml/null_classifier_generator.cc
+++ b/ml/jml/null_classifier_generator.cc
@@ -34,9 +34,9 @@ Null_Classifier_Generator::~Null_Classifier_Generator()
 
 void
 Null_Classifier_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    Classifier_Generator::configure(config);
+    Classifier_Generator::configure(config, unparsedKeys);
 }
 
 void

--- a/ml/jml/null_classifier_generator.h
+++ b/ml/jml/null_classifier_generator.h
@@ -35,7 +35,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config);
+    configure(const Configuration & config,
+              std::vector<std::string> & unparsedKeys);
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/null_classifier_generator.h
+++ b/ml/jml/null_classifier_generator.h
@@ -36,7 +36,7 @@ public:
     /** Configure the generator with its parameters. */
     virtual void
     configure(const Configuration & config,
-              std::vector<std::string> & unparsedKeys);
+              std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/stump_generator.cc
+++ b/ml/jml/stump_generator.cc
@@ -70,15 +70,15 @@ Stump_Generator::~Stump_Generator()
 
 void
 Stump_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    Classifier_Generator::configure(config);
+    Classifier_Generator::configure(config, unparsedKeys);
     
-    config.find(committee_size,       "committee_size");
-    config.find(feature_prop,         "feature_prop");
-    config.find(trace,                "trace");
-    config.find(update_alg,           "update_alg");
-    config.find(ignore_highest,       "ignore_highest");
+    config.findAndRemove(committee_size, "committee_size", unparsedKeys);
+    config.findAndRemove(feature_prop, "feature_prop", unparsedKeys);
+    config.findAndRemove(trace, "trace", unparsedKeys);
+    config.findAndRemove(update_alg, "update_alg", unparsedKeys);
+    config.findAndRemove(ignore_highest, "ignore_highest", unparsedKeys);
 }
 
 void

--- a/ml/jml/stump_generator.h
+++ b/ml/jml/stump_generator.h
@@ -35,7 +35,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config);
+    configure(const Configuration & config,
+              std::vector<std::string> & unparsedKeys);
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/ml/jml/testing/decision_tree_multithreaded_test.cc
+++ b/ml/jml/testing/decision_tree_multithreaded_test.cc
@@ -71,7 +71,8 @@ BOOST_AUTO_TEST_CASE( test_decision_tree_multithreaded1 )
     config.parse_string(config_options, "inbuilt config file");
 
     Decision_Tree_Generator generator;
-    generator.configure(config);
+    vector<string> unparsedKeys; // should be used to validade invalid keys
+    generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 
     distribution<float> training_weights(nfv, 1);

--- a/ml/jml/testing/decision_tree_unlimited_depth_test.cc
+++ b/ml/jml/testing/decision_tree_unlimited_depth_test.cc
@@ -72,7 +72,8 @@ BOOST_AUTO_TEST_CASE( test_decision_tree_multithreaded_binary )
     config.parse_string(config_options, "inbuilt config file");
 
     Decision_Tree_Generator generator;
-    generator.configure(config);
+    vector<string> unparsedKeys; // should be used to validade invalid keys
+    generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 
     distribution<float> training_weights(nfv, 1);
@@ -123,7 +124,8 @@ BOOST_AUTO_TEST_CASE( test_decision_tree_multithreaded_regression )
     config.parse_string(config_options, "inbuilt config file");
 
     Decision_Tree_Generator generator;
-    generator.configure(config);
+    vector<string> unparsedKeys; // should be used to validade invalid keys
+    generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 
     distribution<float> training_weights(nfv, 1);

--- a/ml/jml/testing/decision_tree_unlimited_depth_test.cc
+++ b/ml/jml/testing/decision_tree_unlimited_depth_test.cc
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE( test_decision_tree_multithreaded_binary )
     config.parse_string(config_options, "inbuilt config file");
 
     Decision_Tree_Generator generator;
-    vector<string> unparsedKeys; // should be used to validade invalid keys
+    vector<string> unparsedKeys; // should be used to root out invalid keys
     generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE( test_decision_tree_multithreaded_regression )
     config.parse_string(config_options, "inbuilt config file");
 
     Decision_Tree_Generator generator;
-    vector<string> unparsedKeys; // should be used to validade invalid keys
+    vector<string> unparsedKeys; // should be used to root out invalid keys
     generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 

--- a/ml/jml/testing/decision_tree_xor_test.cc
+++ b/ml/jml/testing/decision_tree_xor_test.cc
@@ -68,7 +68,8 @@ BOOST_AUTO_TEST_CASE( test_xor_function )
     config.parse_string(config_options, "inbuilt config file");
 
     Decision_Tree_Generator generator;
-    generator.configure(config);
+    vector<string> unparsedKeys; // should be used to validade invalid keys
+    generator.configure(config, unparsedKeys);
     generator.init(data.feature_space(),
                    fs.features()[0]);
 

--- a/ml/jml/testing/decision_tree_xor_test.cc
+++ b/ml/jml/testing/decision_tree_xor_test.cc
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE( test_xor_function )
     config.parse_string(config_options, "inbuilt config file");
 
     Decision_Tree_Generator generator;
-    vector<string> unparsedKeys; // should be used to validade invalid keys
+    vector<string> unparsedKeys; // should be used to root out invalid keys
     generator.configure(config, unparsedKeys);
     generator.init(data.feature_space(),
                    fs.features()[0]);

--- a/ml/jml/testing/glz_classifier_test.cc
+++ b/ml/jml/testing/glz_classifier_test.cc
@@ -74,7 +74,8 @@ BOOST_AUTO_TEST_CASE( test_glz_classifier_test )
     config.parse_string(config_options, "inbuilt config file");
 
     GLZ_Classifier_Generator generator;
-    generator.configure(config);
+    vector<string> unparsedKeys; // should be used to validade invalid keys
+    generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 
     distribution<float> training_weights(nfv, 1);
@@ -140,7 +141,8 @@ BOOST_AUTO_TEST_CASE( test_glz_classifier_missing )
     config.parse_string(config_options, "inbuilt config file");
 
     GLZ_Classifier_Generator generator;
-    generator.configure(config);
+    vector<string> unparsedKeys; // should be used to validade invalid keys
+    generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 
     distribution<float> training_weights(nfv, 1);
@@ -212,7 +214,8 @@ BOOST_AUTO_TEST_CASE( test_glz_classifier_missing2 )
     config.parse_string(config_options, "inbuilt config file");
 
     GLZ_Classifier_Generator generator;
-    generator.configure(config);
+    vector<string> unparsedKeys; // should be used to validade invalid keys
+    generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 
     distribution<float> training_weights(nfv, 1);

--- a/ml/jml/testing/glz_classifier_test.cc
+++ b/ml/jml/testing/glz_classifier_test.cc
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE( test_glz_classifier_test )
     config.parse_string(config_options, "inbuilt config file");
 
     GLZ_Classifier_Generator generator;
-    vector<string> unparsedKeys; // should be used to validade invalid keys
+    vector<string> unparsedKeys; // should be used to root out invalid keys
     generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE( test_glz_classifier_missing )
     config.parse_string(config_options, "inbuilt config file");
 
     GLZ_Classifier_Generator generator;
-    vector<string> unparsedKeys; // should be used to validade invalid keys
+    vector<string> unparsedKeys; // should be used to root out invalid keys
     generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE( test_glz_classifier_missing2 )
     config.parse_string(config_options, "inbuilt config file");
 
     GLZ_Classifier_Generator generator;
-    vector<string> unparsedKeys; // should be used to validade invalid keys
+    vector<string> unparsedKeys; // should be used to root out invalid keys
     generator.configure(config, unparsedKeys);
     generator.init(fsp, fs.features()[0]);
 

--- a/ml/neural/perceptron_generator.cc
+++ b/ml/neural/perceptron_generator.cc
@@ -85,20 +85,20 @@ Perceptron_Generator::~Perceptron_Generator()
 
 void
 Perceptron_Generator::
-configure(const Configuration & config)
+configure(const Configuration & config, vector<string> & unparsedKeys)
 {
-    Early_Stopping_Generator::configure(config);
+    Early_Stopping_Generator::configure(config, unparsedKeys);
     
-    config.find(max_iter, "max_iter");
-    config.find(min_iter, "min_iter");
-    config.find(learning_rate, "learning_rate");
-    config.find(arch_str, "arch");
-    config.find(batch_size, "batch_size");
-    config.find(activation, "activation");
-    config.find(output_activation, "output_activation");
-    config.find(do_decorrelate, "decorrelate");
-    config.find(do_normalize, "normalize");
-    config.find(target_value, "target_value");
+    config.findAndRemove(max_iter, "max_iter", unparsedKeys);
+    config.findAndRemove(min_iter, "min_iter", unparsedKeys);
+    config.findAndRemove(learning_rate, "learning_rate", unparsedKeys);
+    config.findAndRemove(arch_str, "arch", unparsedKeys);
+    config.findAndRemove(batch_size, "batch_size", unparsedKeys);
+    config.findAndRemove(activation, "activation", unparsedKeys);
+    config.findAndRemove(output_activation, "output_activation", unparsedKeys);
+    config.findAndRemove(do_decorrelate, "decorrelate", unparsedKeys);
+    config.findAndRemove(do_normalize, "normalize", unparsedKeys);
+    config.findAndRemove(target_value, "target_value", unparsedKeys);
 }
 
 void

--- a/ml/neural/perceptron_generator.h
+++ b/ml/neural/perceptron_generator.h
@@ -35,7 +35,8 @@ public:
 
     /** Configure the generator with its parameters. */
     virtual void
-    configure(const Configuration & config);
+    configure(const Configuration & config,
+              std::vector<std::string> & unusedKeys) override;
     
     /** Return to the default configuration. */
     virtual void defaults();

--- a/testing/MLDB-429-classifier-empty-label.js
+++ b/testing/MLDB-429-classifier-empty-label.js
@@ -48,7 +48,6 @@ var trainClassifierProcedureConfig = {
                 type: "glz",
                 verbosity: 3,
                 normalize: false,
-                link: 'linear',
                 "regularization": 'l2'
             }
         },

--- a/testing/MLDB-529-duplicate-pin.js
+++ b/testing/MLDB-529-duplicate-pin.js
@@ -90,7 +90,6 @@ var trainClassifierProcedureConfig = {
                 type: "glz",
                 verbosity: 3,
                 normalize: false,
-                link: 'linear',
                 "regularization": 'l2'
             }
         },

--- a/testing/MLDB-779_cant_test_bs_cls.py
+++ b/testing/MLDB-779_cant_test_bs_cls.py
@@ -62,7 +62,6 @@ for cls in ["bdt", "glz", "bs"]:
                         "type": "boosted_stumps",
                         "min_iter": 10,
                         "max_iter": 200,
-                        "update_alg": "gentle",
                         "verbosity": 3
                     },
                     "bdt": {

--- a/testing/MLDB-785-decision-tree-missing.js
+++ b/testing/MLDB-785-decision-tree-missing.js
@@ -161,7 +161,7 @@ function trainClassifier(algorithm)
                     type: "boosted_stumps",
                     min_iter: 1,
                     max_iter: 1,
-                    verbisity: 5
+                    verbosity: 5
                 }
             },
             algorithm: algorithm,

--- a/testing/MLDB-878_experiment_proc.py
+++ b/testing/MLDB-878_experiment_proc.py
@@ -55,7 +55,6 @@ class Mldb878Test(MldbUnitTest):  # noqa
                         "type": "glz",
                         "verbosity": 3,
                         "normalize": False,
-                        "link": "linear",
                         "regularization": 'l2'
                     }
                 },
@@ -258,7 +257,6 @@ class Mldb878Test(MldbUnitTest):  # noqa
                         "type": "glz",
                         "verbosity": 3,
                         "normalize": False,
-                        "link": "linear",
                         "regularization": 'l2'
                     }
                 },
@@ -304,7 +302,6 @@ class Mldb878Test(MldbUnitTest):  # noqa
                         "type": "glz",
                         "verbosity": 3,
                         "normalize": False,
-                        "link": "linear",
                         "regularization": 'l2'
                     }
                 },
@@ -434,7 +431,6 @@ class Mldb878Test(MldbUnitTest):  # noqa
                             "type": "glz",
                             "verbosity": 3,
                             "normalize": False,
-                            "link": "linear",
                             "regularization": 'l2'
                         }
                     },
@@ -464,7 +460,6 @@ class Mldb878Test(MldbUnitTest):  # noqa
                             "type": "glz",
                             "verbosity": 3,
                             "normalize": False,
-                            "link": "linear",
                             "regularization": 'l2'
                         }
                     },
@@ -492,7 +487,6 @@ class Mldb878Test(MldbUnitTest):  # noqa
                             "type": "glz",
                             "verbosity": 3,
                             "normalize": False,
-                            "link": "linear",
                             "regularization": 'l2'
                         }
                     },
@@ -522,7 +516,6 @@ class Mldb878Test(MldbUnitTest):  # noqa
                             "type": "glz",
                             "verbosity": 3,
                             "normalize": False,
-                            "link": "linear",
                             "regularization": 'l2'
                         }
                     },
@@ -604,7 +597,6 @@ class Mldb878Test(MldbUnitTest):  # noqa
                             "type": "glz",
                             "verbosity": 3,
                             "normalize": False,
-                            "link": "linear",
                             "regularization": 'l2'
                         }
                     },
@@ -634,7 +626,6 @@ class Mldb878Test(MldbUnitTest):  # noqa
                             "type": "glz",
                             "verbosity": 3,
                             "normalize": False,
-                            "link": "linear",
                             "regularization": 'l2'
                         }
                     },

--- a/testing/MLDB-926_auto_functions_for_procs.py
+++ b/testing/MLDB-926_auto_functions_for_procs.py
@@ -55,7 +55,6 @@ conf = {
                 "type": "glz",
                 "verbosity": 3,
                 "normalize": False,
-                "link": "linear",
                "regularization": 'l2'
             }
         },

--- a/testing/MLDB-991_permuter_procedure.py
+++ b/testing/MLDB-991_permuter_procedure.py
@@ -49,7 +49,6 @@ procedure_conf = {
                 "type": "glz",
                 "verbosity": 3,
                 "normalize": False,
-                "link": "linear",
                 "regularization": 'l2'
             },
             "bglz": {

--- a/testing/classifier_test_err_on_empty_sets.py
+++ b/testing/classifier_test_err_on_empty_sets.py
@@ -28,7 +28,6 @@ class ClassifierTestErrorWhenNoDataTest(MldbUnitTest):  # noqa
                         "type": "glz",
                         "verbosity": 3,
                         "normalize": False,
-                        "link": "linear",
                         "regularization": 'l2'
                     }
                 },

--- a/testing/test_classifier_test_proc.py
+++ b/testing/test_classifier_test_proc.py
@@ -398,5 +398,39 @@ class TestClassifierTestProc(MldbUnitTest):  # noqa
                 }
             })
 
+    @unittest.expectedFailure
+    def test_classifier_allows_underscored_key_param(self):
+        msg = "No feature vectors were produced as all"
+        with self.assertRaisesRegexp(mldb_wrapper.ResponseException, msg):
+            mldb.put("/v1/procedures/regression_cls", {
+                "type": "classifier.experiment",
+                "params": {
+                    "inputData": "SELECT {*} AS features, label AS label FROM foo",
+                    "experimentName": "reg_exp",
+                    "keepArtifacts": True,
+                    "modelFileUrlPattern": "file://temp/mldb-256_reg.cls",
+                    "algorithm": "glz_linear",
+                    "configuration": {
+                        "glz_linear": {
+                            "type": "glz",
+                            "normalize": True,
+                            "link_function": 'linear',
+                            "regularization": 'l1',
+                            "regularization_factor": 0.001,
+                            "_ignored" : "this key is ignored"
+                        },
+
+                        # The key is clearly different, no problem
+                        "FOO": {
+                            "FOO": "linear"
+                        }
+                    },
+                    "kfold": 2,
+                    "mode": "regression",
+                    "outputAccuracyDataset": True
+                }
+            })
+
+
 if __name__ == '__main__':
     mldb.run_tests()

--- a/testing/test_classifier_test_proc.py
+++ b/testing/test_classifier_test_proc.py
@@ -336,6 +336,8 @@ class TestClassifierTestProc(MldbUnitTest):  # noqa
 
     @unittest.expectedFailure
     def test_classifier_doesnt_rejects_dotted_neighbor_param(self):
+
+        # This assertion works
         msg = "No feature vectors were produced as all"
         with self.assertRaisesRegexp(mldb_wrapper.ResponseException, msg):
             mldb.put("/v1/procedures/regression_cls", {
@@ -366,6 +368,7 @@ class TestClassifierTestProc(MldbUnitTest):  # noqa
                 }
             })
 
+        # This assertion fails, see below
         msg = "No feature vectors were produced as all"
         with self.assertRaisesRegexp(mldb_wrapper.ResponseException, msg):
             mldb.put("/v1/procedures/regression_cls", {
@@ -387,7 +390,9 @@ class TestClassifierTestProc(MldbUnitTest):  # noqa
 
                         # It should be the same error as the previous one, but
                         # the key is too similar and confuses the error
-                        # detector
+                        # detector (because it contains a dot) Should the
+                        # Configure class stop accepting dotted key it would
+                        # solve this.
                         "glz_linear.BAR": {
                             "FOO": "linear"
                         }
@@ -398,7 +403,6 @@ class TestClassifierTestProc(MldbUnitTest):  # noqa
                 }
             })
 
-    @unittest.expectedFailure
     def test_classifier_allows_underscored_key_param(self):
         msg = "No feature vectors were produced as all"
         with self.assertRaisesRegexp(mldb_wrapper.ResponseException, msg):


### PR DESCRIPTION
Validates the classifier configuration payloads.
* The validation can be wrong if dotted keys are used. The problem lies with the `Configuration` class which allows them, making validation "impossible" in its current state. We could either refuse dotted keys or use a Path system. (A test cases demonstrates the situation.)
* End values starting with an underscore are ignored, which allows commenting. (This pattern is used in `classifiers.json`.)