### PR TITLE
clang fixes

### DIFF
--- a/ml/jml/boosted_stumps_generator.h
+++ b/ml/jml/boosted_stumps_generator.h
@@ -41,15 +41,15 @@ public:
               std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
-    virtual void defaults();
+    virtual void defaults() override;
 
     /** Return possible configuration options. */
-    virtual Config_Options options() const;
+    virtual Config_Options options() const override;
 
     /** Initialize the generator, given the feature space to be used for
         generation. */
     virtual void init(std::shared_ptr<const Feature_Space> fs,
-                      Feature predicted);
+                      Feature predicted) override;
 
     using Weight_Updating_Generator::generate;
 
@@ -61,7 +61,7 @@ public:
              const distribution<float> & training_weights,
              const distribution<float> & validation_weights,
              const std::vector<Feature> & features,
-             int recursion) const;
+             int recursion) const override;
 
     Boosted_Stumps
     generate_stumps(Thread_Context & context,
@@ -76,7 +76,7 @@ public:
     generate_and_update(Thread_Context & context,
                         const Training_Data & training_data,
                         boost::multi_array<float, 2> & weights,
-                        const std::vector<Feature> & features) const;
+                        const std::vector<Feature> & features) const override;
 
     Stump_Generator weak_learner;
     

--- a/ml/jml/boosting_generator.h
+++ b/ml/jml/boosting_generator.h
@@ -39,15 +39,15 @@ public:
               std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
-    virtual void defaults();
+    virtual void defaults() override;
 
     /** Return possible configuration options. */
-    virtual Config_Options options() const;
+    virtual Config_Options options() const override;
 
     /** Initialize the generator, given the feature space to be used for
         generation. */
     virtual void init(std::shared_ptr<const Feature_Space> fs,
-                      Feature predicted);
+                      Feature predicted) override;
 
     using Weight_Updating_Generator::generate;
 
@@ -58,14 +58,14 @@ public:
              const Training_Data & validation_data,
              const distribution<float> & training_weights,
              const distribution<float> & validation_weights,
-             const std::vector<Feature> & features, int) const;
+             const std::vector<Feature> & features, int) const override;
 
     /** Generate a classifier, with a given weights array as input. */
     virtual std::shared_ptr<Classifier_Impl>
     generate_and_update(Thread_Context & context,
                         const Training_Data & training_data,
                         boost::multi_array<float, 2> & weights,
-                        const std::vector<Feature> & features) const;
+                        const std::vector<Feature> & features) const override;
 
     std::shared_ptr<Classifier_Generator> weak_learner;
 

--- a/ml/jml/decision_tree_generator.h
+++ b/ml/jml/decision_tree_generator.h
@@ -38,15 +38,15 @@ public:
               std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
-    virtual void defaults();
+    virtual void defaults() override;
 
     /** Return possible configuration options. */
-    virtual Config_Options options() const;
+    virtual Config_Options options() const override;
 
     /** Initialize the generator, given the feature space to be used for
         generation. */
     virtual void init(std::shared_ptr<const Feature_Space> fs,
-                      Feature predicted);
+                      Feature predicted) override;
 
     using Classifier_Generator::generate;
 
@@ -57,7 +57,7 @@ public:
              const Training_Data & validation_data,
              const distribution<float> & training_weights,
              const distribution<float> & validation_weights,
-             const std::vector<Feature> & features, int recursion) const;
+             const std::vector<Feature> & features, int recursion) const override;
 
     /** Generate a classifier for boosting. */
     virtual std::shared_ptr<Classifier_Impl>
@@ -66,7 +66,7 @@ public:
              const boost::multi_array<float, 2> & weights,
              const std::vector<Feature> & features,
              float & Z,
-             int recursion) const;
+             int recursion) const override;
 
     int max_depth;
     int trace;

--- a/ml/jml/early_stopping_generator.h
+++ b/ml/jml/early_stopping_generator.h
@@ -34,10 +34,10 @@ public:
               std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
-    virtual void defaults();
+    virtual void defaults() override;
 
     /** Return possible configuration options. */
-    virtual Config_Options options() const;
+    virtual Config_Options options() const override;
 
     using Classifier_Generator::generate;
 
@@ -52,7 +52,7 @@ public:
              const Training_Data & training_data,
              const distribution<float> & ex_weights,
              const std::vector<Feature> & features,
-             int recursion = 0) const;
+             int recursion = 0) const override;
     
     float validate_split;
 };

--- a/ml/jml/glz_classifier_generator.h
+++ b/ml/jml/glz_classifier_generator.h
@@ -39,15 +39,15 @@ public:
               std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
-    virtual void defaults();
+    virtual void defaults() override;
 
     /** Return possible configuration options. */
-    virtual Config_Options options() const;
+    virtual Config_Options options() const override;
 
     /** Initialize the generator, given the feature space to be used for
         generation. */
     virtual void init(std::shared_ptr<const Feature_Space> fs,
-                      Feature predicted);
+                      Feature predicted) override;
 
     using Classifier_Generator::generate;
 
@@ -58,7 +58,7 @@ public:
              const boost::multi_array<float, 2> & weights,
              const std::vector<Feature> & features,
              float & Z,
-             int) const;
+             int) const override;
 
     bool add_bias;          ///< Do we add and learn a bias term?
     bool do_decode;         ///< Do we run a decoder at all?

--- a/ml/jml/null_classifier_generator.h
+++ b/ml/jml/null_classifier_generator.h
@@ -39,15 +39,15 @@ public:
               std::vector<std::string> & unparsedKeys) override;
     
     /** Return to the default configuration. */
-    virtual void defaults();
+    virtual void defaults() override;
 
     /** Return possible configuration options. */
-    virtual Config_Options options() const;
+    virtual Config_Options options() const override;
 
     /** Initialize the generator, given the feature space to be used for
         generation. */
     virtual void init(std::shared_ptr<const Feature_Space> fs,
-                      Feature predicted);
+                      Feature predicted) override;
 
     using Classifier_Generator::generate;
 
@@ -59,7 +59,7 @@ public:
              const distribution<float> & training_weights,
              const distribution<float> & validation_weights,
              const std::vector<Feature> & features,
-             int recursion) const;
+             int recursion) const override;
 
     /* Once init has been called, we clone our potential models from this
        one. */

--- a/ml/neural/perceptron_generator.h
+++ b/ml/neural/perceptron_generator.h
@@ -39,15 +39,15 @@ public:
               std::vector<std::string> & unusedKeys) override;
     
     /** Return to the default configuration. */
-    virtual void defaults();
+    virtual void defaults() override;
 
     /** Return possible configuration options. */
-    virtual Config_Options options() const;
+    virtual Config_Options options() const override;
 
     /** Initialize the generator, given the feature space to be used for
         generation. */
     virtual void init(std::shared_ptr<const Feature_Space> fs,
-                      Feature predicted);
+                      Feature predicted) override;
 
     using Early_Stopping_Generator::generate;
 
@@ -58,7 +58,7 @@ public:
              const Training_Data & validation_data,
              const distribution<float> & training_weights,
              const distribution<float> & validation_weights,
-             const std::vector<Feature> & features, int = 0) const;
+             const std::vector<Feature> & features, int = 0) const override;
 
     unsigned max_iter;
     unsigned min_iter;


### PR DESCRIPTION
Almost fixes clang build. There is a problem with tf.
```
./mldb/ext/tensorflow/tensorflow/cc/framework/scope.cc:25:8: error: constructor for 'tensorflow::Scope' must explicitly initialize the const member 'colocation_constraints_'
Scope::Scope(Graph* graph, Status* status, Scope::NameMap* name_map)
       ^
mldb/ext/tensorflow/tensorflow/cc/framework/scope.h:245:36: note: 'colocation_constraints_' declared here
  const std::unordered_set<string> colocation_constraints_;
```

Any ideas?