### PR TITLE
Removed ML namespace from APIS (MLDB-1980)

### DIFF
--- a/arch/abort.cc
+++ b/arch/abort.cc
@@ -16,7 +16,7 @@
 using namespace std;
 
 
-namespace ML {
+namespace MLDB {
 
 namespace {
 
@@ -74,4 +74,4 @@ void set_abort_state(bool b)
 
 
 
-} // namepsace ML
+} // namepsace MLDB

--- a/arch/abort.h
+++ b/arch/abort.h
@@ -1,10 +1,11 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+// 
 
 /** abort.h                                 -*- C++ -*-
     Rémi Attab, 13 Nov 2012
     Copyright (c) 2012 Datacratic.  All rights reserved.
 
     Utilities related to the abort() function.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     These functions are meant to be used as debugging helpers so that the
     program can be stopped as soon as an error is detected. This is mainly
@@ -14,10 +15,9 @@
 
 */
 
-#ifndef __jml__utils__abort_h__
-#define __jml__utils__abort_h__
+#pragma once
 
-namespace ML {
+namespace MLDB {
 
 /** Calls abort() if one of the following criterias are met:
 
@@ -39,6 +39,4 @@ bool get_abort_state();
 void set_abort_state(bool b);
 
 
-} // ML
-
-#endif // __jml__utils__abort_h__
+} // MLDB

--- a/arch/backtrace.cc
+++ b/arch/backtrace.cc
@@ -24,7 +24,7 @@
 
 using namespace std;
 
-namespace ML {
+namespace MLDB {
 
 size_t backtrace(char * buffer, size_t bufferSize, int num_to_skip)
 {
@@ -172,4 +172,4 @@ backtrace(const BacktraceInfo & info,
     return result;
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/backtrace.h
+++ b/arch/backtrace.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* backtrace.h                                                      -*- C++ -*-
    Jeremy Barnes, 26 February 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Interface to a bactrace function.
 */
@@ -10,10 +9,9 @@
 #include <iostream>
 #include <vector>
 
-#ifndef __jml__arch__backtrace_h__
-#define __jml__arch__backtrace_h__
+#pragma once
 
-namespace ML {
+namespace MLDB {
 
 /** Basic backtrace information */
 struct BacktraceInfo {
@@ -71,6 +69,4 @@ std::vector<BacktraceFrame> backtrace(int num_to_skip);
 std::vector<BacktraceFrame>
 backtrace(const BacktraceInfo & info, int num_to_skip);
 
-} // namespace ML
-
-#endif /* __jml__arch__backtrace_h__ */
+} // namespace MLDB

--- a/arch/cache.h
+++ b/arch/cache.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* cache.h                                                         -*- C++ -*-
    Jeremy Barnes, 21 January 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Cache control functions.
 */
@@ -17,6 +16,8 @@
 #include "mldb/compiler/compiler.h"
 
 namespace ML {
+
+using namespace MLDB;
 
 static const size_t l1_cache_size = 32 * 1024;
 

--- a/arch/cal.cc
+++ b/arch/cal.cc
@@ -22,7 +22,7 @@ namespace ML {
 
 namespace {
 
-Env_Option<bool> debug("DEBUG_CAL_INIT", false);
+EnvOption<bool> debug("DEBUG_CAL_INIT", false);
 
 } // file scope
 

--- a/arch/cpu_info.cc
+++ b/arch/cpu_info.cc
@@ -15,7 +15,7 @@
 using namespace std;
 
 
-namespace ML {
+namespace MLDB {
 
 int num_cpus_result = 0;
 
@@ -46,5 +46,5 @@ void init_num_cpus()
     //cerr << "num_cpus_result = " << num_cpus_result << endl;
 }
 
-} // namespace ML
+} // namespace MLDB
 

--- a/arch/cpu_info.h
+++ b/arch/cpu_info.h
@@ -1,18 +1,16 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* cpu_info.h                                                      -*- C++ -*-
    Jeremy Barnes, 22 January 2010
    Copyright (c) 2010 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Information about CPUs.
 */
 
-#ifndef __jml__arch__cpu_info_h__
-#define __jml__arch__cpu_info_h__
+#pragma once
 
 #include "mldb/compiler/compiler.h"
 
-namespace ML {
+namespace MLDB {
 
 /** Returns the number of CPU cores installed in the system. */
 
@@ -26,6 +24,4 @@ JML_ALWAYS_INLINE int num_cpus()
     return num_cpus_result;
 }
 
-} // namespace ML
-
-#endif /* __jml__arch__cpu_info_h__ */
+} // namespace MLDB

--- a/arch/cpuid.cc
+++ b/arch/cpuid.cc
@@ -16,7 +16,7 @@
 using namespace std;
 
 
-namespace ML {
+namespace MLDB {
 
 #if defined __i686__ || defined __amd64__
 
@@ -237,4 +237,4 @@ CPU_Info * static_cpu_info = 0;
 
 #endif // __i686__
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/cpuid.h
+++ b/arch/cpuid.h
@@ -12,7 +12,7 @@
 #include <string>
 #include "mldb/compiler/compiler.h"
 
-namespace ML {
+namespace MLDB {
 
 #if defined __i686__ || defined __amd64__ || defined __i586__ || defined __i386__
 
@@ -183,4 +183,4 @@ Regs cpuid(uint32_t request, uint32_t ecx = 0);
 
 #endif // __i686__
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/cuda.cc
+++ b/arch/cuda.cc
@@ -22,7 +22,7 @@ namespace ML {
 
 namespace {
 
-Env_Option<bool> debug("DEBUG_CUDA_INIT", false);
+EnvOption<bool> debug("DEBUG_CUDA_INIT", false);
 
 } // file scope
 

--- a/arch/demangle.cc
+++ b/arch/demangle.cc
@@ -21,7 +21,7 @@
 
 using namespace std;
 
-namespace ML {
+namespace MLDB {
 
 char * char_demangle(const char * name)
 {
@@ -55,5 +55,5 @@ std::string demangle(const std::type_info & type)
     return demangle(type.name());
 }
 
-} // namespace ML
+} // namespace MLDB
 

--- a/arch/demangle.h
+++ b/arch/demangle.h
@@ -1,21 +1,18 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* demangle.h                                                      -*- C++ -*-
    Jeremy Barnes, 27 January 2005
    Copyright (c) 2005 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
-
-   Interface to a demangler.
+   Interface to the C++ demangler.
 */
 
-#ifndef __arch__demangle_h__
-#define __arch__demangle_h__
+#pragma once
 
 
 #include <string>
 #include <typeinfo>
 
-namespace ML {
+namespace MLDB {
 
 /* returns a null-terminated string allocated on the heap */
 char * char_demangle(const char * name);
@@ -35,7 +32,5 @@ std::string type_name()
     return demangle(typeid(T));
 }
 
-} // namespace ML
-
-#endif /* __arch__demangle_h__ */
+} // namespace MLDB
 

--- a/arch/environment_static.cc
+++ b/arch/environment_static.cc
@@ -16,7 +16,7 @@ using namespace std;
 
 extern char ** environ;
 
-namespace ML {
+namespace MLDB {
 
 Environment::Environment()
 {
@@ -48,4 +48,4 @@ Environment::instance()
     return result;
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/exception.cc
+++ b/arch/exception.cc
@@ -18,7 +18,7 @@
 using namespace std;
 
 
-namespace ML {
+namespace MLDB {
 
 Exception::Exception(const std::string & msg)
     : message(msg)
@@ -97,20 +97,20 @@ std::string getExceptionString()
 /* ASSERTION FAILURE                                                         */
 /*****************************************************************************/
 
-Assertion_Failure::
-Assertion_Failure(const std::string & msg)
+AssertionFailure::
+AssertionFailure(const std::string & msg)
     : Exception(msg)
 {
 }
 
-Assertion_Failure::
-Assertion_Failure(const char * msg, ...)
+AssertionFailure::
+AssertionFailure(const char * msg, ...)
     : Exception(msg)
 {
 }
 
-Assertion_Failure::
-Assertion_Failure(const char * assertion,
+AssertionFailure::
+AssertionFailure(const char * assertion,
                   const char * function,
                   const char * file,
                   int line)
@@ -121,4 +121,4 @@ Assertion_Failure(const char * assertion,
 
 
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/exception.h
+++ b/arch/exception.h
@@ -14,7 +14,7 @@
 #include "stdarg.h"
 #include "exception_handler.h"
 
-namespace ML {
+namespace MLDB {
 
 class Exception : public std::exception {
 public:
@@ -47,14 +47,14 @@ std::string getExceptionString();
 
 /** Exception thrown when an exception assert is made and fails. */
 
-struct Assertion_Failure: public Exception {
-    Assertion_Failure(const std::string & msg);
-    Assertion_Failure(const char * msg, ...);
-    Assertion_Failure(const char * assertion,
+struct AssertionFailure: public Exception {
+    AssertionFailure(const std::string & msg);
+    AssertionFailure(const char * msg, ...);
+    AssertionFailure(const char * assertion,
                       const char * function,
                       const char * file,
                       int line);
 };
 
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/exception_handler.cc
+++ b/arch/exception_handler.cc
@@ -24,9 +24,9 @@
 using namespace std;
 
 
-namespace ML {
+namespace MLDB {
 
-Env_Option<bool> TRACE_EXCEPTIONS("JML_TRACE_EXCEPTIONS", true);
+EnvOption<bool> TRACE_EXCEPTIONS("JML_TRACE_EXCEPTIONS", true);
 
 __thread bool trace_exceptions = false;
 __thread bool trace_exceptions_initialized = false;
@@ -111,7 +111,7 @@ void default_exception_tracer(void * object, const std::type_info * tinfo)
     const std::exception * exc = to_std_exception(object, tinfo);
 
     // We don't want these exceptions to be printed out.
-    if (dynamic_cast<const ML::SilentException *>(exc)) return;
+    if (dynamic_cast<const MLDB::SilentException *>(exc)) return;
 
     /* avoid allocations when std::bad_alloc is thrown */
     bool noAlloc = dynamic_cast<const std::bad_alloc *>(exc);
@@ -194,7 +194,7 @@ end:
 
     char const * reports = getenv("ENABLE_EXCEPTION_REPORTS");
     if (!noAlloc && reports) {
-        std::string path = ML::format("%s/exception-report-%s-%d-%d.log",
+        std::string path = MLDB::format("%s/exception-report-%s-%d-%d.log",
                                       reports, datetime, pid, tid);
 
         std::ofstream file(path, std::ios_base::app);
@@ -206,4 +206,4 @@ end:
     }
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/exception_handler.h
+++ b/arch/exception_handler.h
@@ -1,16 +1,14 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* exception_handler.h                                             -*- C++ -*-
    Jeremy Barnes, 2 December 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Interface for the exception handler.
 */
 
-#ifndef __jml__arch__exception_handler_h__
-#define __jml__arch__exception_handler_h__
+#pragma once
 
-namespace ML {
+namespace MLDB {
 
 /// Set the default value of tracing exceptions.  New threads will be
 /// initialized to this value.
@@ -39,9 +37,7 @@ struct Set_Trace_Exceptions {
 
 void default_exception_tracer(void * object, const std::type_info * tinfo);
 
-} // namespace ML
+} // namespace MLDB
 
 #define JML_TRACE_EXCEPTIONS(value) \
-ML::Set_Trace_Exceptions trace_exc__(value);
-
-#endif /* __jml__arch__exception_handler_h__ */
+MLDB::Set_Trace_Exceptions trace_exc__(value);

--- a/arch/exception_hook.cc
+++ b/arch/exception_hook.cc
@@ -21,7 +21,7 @@
 
 using namespace std;
 
-namespace ML {
+namespace MLDB {
 
 /** Hook for the function to call when we throw an exception.  The first
     argument is a pointer to the object thrown; the second is the type
@@ -79,7 +79,7 @@ struct Init {
 
 } // file scope
 
-} // namespace ML
+} // namespace MLDB
 
 /** Our overridden version of __cxa_throw.  The first argument is the
     object that was thrown.  The second is the type info block for the
@@ -92,23 +92,23 @@ void
 __cxa_throw (void *thrown_object, std::type_info *tinfo,
              void (*destructor) (void *) )
 {
-    using namespace ML;
+    using namespace MLDB;
 
     //cerr << "exception was thrown" << endl;
     //cerr << "exception_tracer = " << exception_tracer << endl;
     
     /** If we have installed an exception tracing hook, we follow it here. */
     if (!exception_tracer || !exception_tracer(thrown_object, tinfo)) {
-        default_exception_tracer(thrown_object, tinfo);
+        MLDB::default_exception_tracer(thrown_object, tinfo);
     }
 
-    if (!done_init) {
-        Init();
+    if (!MLDB::done_init) {
+        MLDB::Init();
     }
 
     /** Now we finish by calling the old handler which will propegate the
         exception as usual. */
-    old_handler(thrown_object, tinfo, destructor);
+    MLDB::old_handler(thrown_object, tinfo, destructor);
 
     /** This should never happen, as __cxa_throw is a noreturn() function.
         If for some reason it returns, we abort out. */

--- a/arch/exception_hook.h
+++ b/arch/exception_hook.h
@@ -1,16 +1,14 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* exception_hook.cc
    Jeremy Barnes, 7 February 2005
    Copyright (c) 2005 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Object file to install the exception tracer.
 */
 
-#ifndef __arch__exception_hook_h__
-#define __arch__exception_hook_h__
+#pragma once
 
-namespace ML {
+namespace MLDB {
 
 /** Hook for the function to call when we throw an exception.  The first
     argument is a pointer to the object thrown; the second is the type
@@ -20,6 +18,4 @@ namespace ML {
 */
 extern bool (*exception_tracer) (void *, const std::type_info *);
 
-} // namespace ML
-
-#endif /* __arch__exception_hook_h__ */
+} // namespace MLDB

--- a/arch/exception_internals.h
+++ b/arch/exception_internals.h
@@ -9,8 +9,7 @@
    definitions.
 */
 
-#ifndef __jml__arch__exception_internals_h__
-#define __jml__arch__exception_internals_h__
+#pragma once
 
 #include <typeinfo>
 #include <exception>
@@ -62,6 +61,3 @@ struct __cxa_eh_globals
 extern "C" __cxa_eh_globals *__cxa_get_globals () throw();
 
 } // __cxxabiv1
-
-
-#endif /* __jml__arch__exception_internals_h__ */

--- a/arch/format.cc
+++ b/arch/format.cc
@@ -16,7 +16,7 @@
 
 using namespace std;
 
-namespace ML {
+namespace MLDB {
 
 struct va_ender {
     va_ender(va_list & ap)
@@ -66,4 +66,4 @@ std::string vformat(const char * fmt, va_list ap)
     }
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/format.h
+++ b/arch/format.h
@@ -1,22 +1,18 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* format.h                                                        -*- C++ -*-
    Jeremy Barnes, 26 February 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
-   
-
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Functions for the manipulation of strings.
 */
 
-#ifndef __arch__format_h__
-#define __arch__format_h__
+#pragma once
 
 #include <string>
 #include "stdarg.h"
 #include "mldb/compiler/compiler.h"
 
-namespace ML {
+namespace MLDB {
 
 // This machinery allows us to use a std::string with %s via c++11
 template<typename T>
@@ -45,6 +41,5 @@ inline std::string format(const char * fmt)
 
 std::string vformat(const char * fmt, va_list ap) JML_FORMAT_STRING(1, 0);
 
-} // namespace ML
+} // namespace MLDB
 
-#endif /* __arch__format_h__ */

--- a/arch/fslock.cc
+++ b/arch/fslock.cc
@@ -93,7 +93,7 @@ lock()
             recoverMutex();
         }
         else {
-            throw ML::Exception(error, "pthread_mutex_lock");
+            throw MLDB::Exception(error, "pthread_mutex_lock");
         }
     }
 }
@@ -117,7 +117,7 @@ tryLock()
             goto recovered;
         }
         else if (error != EBUSY) {
-            throw ML::Exception(error, "pthread_mutex_trylock");
+            throw MLDB::Exception(error, "pthread_mutex_trylock");
         }
     }
 
@@ -150,7 +150,7 @@ initMutex()
         if (!mutex_) {
             loadMutexFile();
             if (!mutex_) {
-                throw ML::Exception("mutex could not be loaded nor"
+                throw MLDB::Exception("mutex could not be loaded nor"
                                     " created");
             }
         }
@@ -171,7 +171,7 @@ createMutexFile()
     string tmpLock(lockname + "-" + to_string(gettid()));
     int fd = ::open(tmpLock.c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
     if (fd == -1) {
-        throw ML::Exception(errno, "open");
+        throw MLDB::Exception(errno, "open");
     }
 
     Call_Guard fdGuard([&] () {
@@ -183,14 +183,14 @@ createMutexFile()
 
     /* mmap the file */
     if (::ftruncate(fd, sizeof(pthread_mutex_t)) == -1) {
-        throw ML::Exception(errno, "ftruncate");
+        throw MLDB::Exception(errno, "ftruncate");
     }
     pthread_mutex_t * newMutex
         = (pthread_mutex_t *) ::mmap(nullptr, sizeof(pthread_mutex_t),
                                      PROT_READ | PROT_WRITE, MAP_SHARED,
                                      fd, 0);
     if (newMutex == MAP_FAILED) {
-        throw ML::Exception(errno, "mmap");
+        throw MLDB::Exception(errno, "mmap");
     }
 
     Call_Guard mmapGuard([&] () {
@@ -205,24 +205,24 @@ createMutexFile()
 
     error = ::pthread_mutexattr_init(&mutexattr);
     if (error != 0) {
-        throw ML::Exception(error, "pthread_mutexattr_init");
+        throw MLDB::Exception(error, "pthread_mutexattr_init");
     }
     error = ::pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_DEFAULT);
     if (error != 0) {
-        throw ML::Exception(error, "pthread_mutexattr_settype");
+        throw MLDB::Exception(error, "pthread_mutexattr_settype");
     }
     error = ::pthread_mutexattr_setpshared(&mutexattr, 1);
     if (error != 0) {
-        throw ML::Exception(error, "pthread_mutexattr_setpshared");
+        throw MLDB::Exception(error, "pthread_mutexattr_setpshared");
     }
     error = ::pthread_mutexattr_setrobust(&mutexattr, PTHREAD_MUTEX_ROBUST);
     if (error != 0) {
-        throw ML::Exception(error, "pthread_mutexattr_setrobust");
+        throw MLDB::Exception(error, "pthread_mutexattr_setrobust");
     }
 
     error = ::pthread_mutex_init(newMutex, &mutexattr);
     if (error != 0) {
-        throw ML::Exception(error, "pthread_mutexattr_init");
+        throw MLDB::Exception(error, "pthread_mutexattr_init");
     }
 
     Call_Guard mtxGuard([&] () {
@@ -246,7 +246,7 @@ loadMutexFile()
     int fd = ::open(lockname.c_str(), O_RDWR, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
     if (fd == -1) {
         if (errno != ENOENT) {
-            throw ML::Exception(errno, "open");
+            throw MLDB::Exception(errno, "open");
         }
     }
     else {
@@ -254,7 +254,7 @@ loadMutexFile()
                              PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
         if (mutex == MAP_FAILED) {
             ::close(fd);
-            throw ML::Exception(errno, "mmap");
+            throw MLDB::Exception(errno, "mmap");
         }
         fd_ = fd;
         mutex_ = (pthread_mutex_t *) mutex;
@@ -268,10 +268,10 @@ recoverMutex()
 {
     int error = ::pthread_mutex_consistent(mutex_);
     if (error != 0) {
-        throw ML::Exception(error, "pthread_mutex_consistent");
+        throw MLDB::Exception(error, "pthread_mutex_consistent");
     }
     error = ::pthread_mutex_unlock(mutex_);
     if (error != 0 && error != EPERM) {
-        throw ML::Exception(error, "pthread_mutex_unlock");
+        throw MLDB::Exception(error, "pthread_mutex_unlock");
     }
 }

--- a/arch/gc_lock.h
+++ b/arch/gc_lock.h
@@ -90,7 +90,7 @@ public:
         std::string print() const;
     };
 
-    typedef ML::ThreadSpecificInstanceInfo<ThreadGcInfoEntry, GcLockBase>
+    typedef ThreadSpecificInstanceInfo<ThreadGcInfoEntry, GcLockBase>
         GcInfo;
     typedef typename GcInfo::PerThreadInfo ThreadGcInfo;
 

--- a/arch/gc_lock_impl.h
+++ b/arch/gc_lock_impl.h
@@ -51,7 +51,7 @@ GcLockBase::ThreadGcInfoEntry::
 unlockShared(RunDefer runDefer)
 {
     if (readLocked <= 0)
-        throw ML::Exception("Bad read lock nesting");
+        throw MLDB::Exception("Bad read lock nesting");
 
     --readLocked;
     if (!readLocked && !writeLocked) 
@@ -80,7 +80,7 @@ GcLockBase::ThreadGcInfoEntry::
 unlockExclusive()
 {
     if (writeLocked <= 0)
-        throw ML::Exception("Bad write lock nesting");
+        throw MLDB::Exception("Bad write lock nesting");
 
     --writeLocked;
     if (!writeLocked)
@@ -102,7 +102,7 @@ GcLockBase::ThreadGcInfoEntry::
 unlockSpeculative(RunDefer runDefer)
 {
     if (!specLocked) 
-        throw ML::Exception("Bad speculative lock nesting");
+        throw MLDB::Exception("Bad speculative lock nesting");
 
     --specLocked;
     if (!specLocked) {

--- a/arch/gpgpu.cc
+++ b/arch/gpgpu.cc
@@ -1,14 +1,10 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* gpgpu.cc                                                         -*- C++ -*-
    Jeremy Barnes, 10 March 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Delayed initialization of GPGPU runtimes.
 */
-
-#ifndef __arch__gpgpu_h__
-#define __arch__gpgpu_h__
 
 #include <dlfcn.h>
 #include <iostream>
@@ -16,10 +12,10 @@
 
 using namespace std;
 
-namespace ML {
+namespace MLDB {
 
-Env_Option<bool> use_cuda("USE_CUDA", false);
-Env_Option<bool> use_cal("USE_CAL", false);
+EnvOption<bool> use_cuda("USE_CUDA", false);
+EnvOption<bool> use_cal("USE_CAL", false);
 
 struct Load_CUDA {
     void * handle;
@@ -71,6 +67,4 @@ struct Load_CAL {
 
 } load_cal;
 
-} // namespace ML
-
-#endif /* __arch__cuda_h__ */
+} // namespace MLDB

--- a/arch/info.cc
+++ b/arch/info.cc
@@ -21,7 +21,7 @@
 #include <sys/time.h>
 #include <time.h>
 #include "mldb/arch/cpu_info.h"
-#include "mldb/jml/utils/guard.h"
+#include "mldb/base/scope.h"
 #include <dirent.h>
 #include "mldb/arch/format.h"
 #include <string.h>
@@ -29,7 +29,7 @@
 
 using namespace std;
 
-namespace ML {
+namespace MLDB {
 
 int userid()
 {
@@ -121,7 +121,7 @@ size_t num_open_files()
         throw Exception("num_open_files(): opendir(): "
                         + string(strerror(errno)));
 
-    Call_Guard closedir_dfd(std::bind(closedir, dfd));
+    Scope_Exit(closedir(dfd));
 
     size_t result = 0;
     
@@ -165,4 +165,4 @@ std::string fd_to_filename(int fd)
     }
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/info.h
+++ b/arch/info.h
@@ -1,21 +1,18 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* info.h                                                          -*- C++ -*-
    Jeremy Barnes, 3 April 2006
    Copyright (c) 2006 Jeremy Barnes.  All rights reserved.
-
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Generic information about the current machine.
 */
 
-#ifndef __utils__info_h__
-#define __utils__info_h__
+#pragma once
 
 #include <string>
 #include "mldb/compiler/compiler.h"
 #include "mldb/arch/cpu_info.h"
 
-namespace ML {
+namespace MLDB {
 
 /** A compact string giving context about the current program. */
 
@@ -39,6 +36,4 @@ size_t num_open_files();
 /** Turn an fd into a filename */
 std::string fd_to_filename(int fd);
 
-} // namespace ML
-
-#endif /* __utils__info_h__ */
+} // namespace MLDB

--- a/arch/node_exception_tracing.cc
+++ b/arch/node_exception_tracing.cc
@@ -10,7 +10,7 @@
 #include "mldb/arch/exception_hook.h"
 
 
-namespace ML {
+namespace MLDB {
 
 __thread BacktraceInfo * current_backtrace = nullptr;
 
@@ -93,4 +93,4 @@ struct Install_Handler {
 
 } // file scope
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/rcu_protected.h
+++ b/arch/rcu_protected.h
@@ -97,14 +97,14 @@ struct RcuLocked {
     T * operator -> () const
     {
         if (!ptr)
-            throw ML::Exception("dereferencing null RCUResult");
+            throw MLDB::Exception("dereferencing null RCUResult");
         return ptr;
     }
 
     T & operator * () const
     {
         if (!ptr)
-            throw ML::Exception("dereferencing null RCUResult");
+            throw MLDB::Exception("dereferencing null RCUResult");
         return *ptr;
     }
 };

--- a/arch/rwlock.h
+++ b/arch/rwlock.h
@@ -70,7 +70,7 @@ struct RWLock {
     void check_err(int res)
     {
         if (res == -1)
-            throw ML::Exception("couldn't perform rwlock operation");
+            throw MLDB::Exception("couldn't perform rwlock operation");
     }
 
     pthread_rwlock_t rwlock;

--- a/arch/semaphore.h
+++ b/arch/semaphore.h
@@ -23,13 +23,13 @@ struct Semaphore {
     Semaphore(int initialVal = 1)
     {
         if (sem_init(&val, 0, initialVal))
-            throw ML::Exception(errno, "sem_init");
+            throw MLDB::Exception(errno, "sem_init");
     }
 
     ~Semaphore()
     {
         if (sem_destroy(&val))
-            throw ML::Exception(errno, "sem_destroy");
+            throw MLDB::Exception(errno, "sem_destroy");
     }
 
     void acquire()
@@ -37,7 +37,7 @@ struct Semaphore {
         int res;
         while ((res = sem_wait(&val)) && errno == EINTR) ;
         if (res)
-            throw ML::Exception(errno, "sem_wait");
+            throw MLDB::Exception(errno, "sem_wait");
     }
 
     int acquire(double secondsToWait)
@@ -48,7 +48,7 @@ struct Semaphore {
         struct timespec ts = { seconds, nanoseconds };
         while ((res = sem_timedwait(&val, &ts)) && errno == EINTR) ;
         if (res && errno != ETIMEDOUT)
-            throw ML::Exception(errno, "sem_timedwait");
+            throw MLDB::Exception(errno, "sem_timedwait");
         return res;
     }
 
@@ -60,7 +60,7 @@ struct Semaphore {
         if (res && (errno == EAGAIN))
             return -1;
         if (res)
-            throw ML::Exception(errno, "sem_trywait");
+            throw MLDB::Exception(errno, "sem_trywait");
 
         return 0;
     }
@@ -70,7 +70,7 @@ struct Semaphore {
         int res;
         while ((res = sem_post(&val)) && errno == EINTR) ;
         if (res)
-            throw ML::Exception(errno, "sem_post");
+            throw MLDB::Exception(errno, "sem_post");
     }
 };
 

--- a/arch/shared_gc_lock.cc
+++ b/arch/shared_gc_lock.cc
@@ -15,7 +15,6 @@
 #include <boost/interprocess/sync/scoped_lock.hpp>
 
 using namespace std;
-using namespace ML;
 namespace ipc = boost::interprocess;
 
 

--- a/arch/simd.h
+++ b/arch/simd.h
@@ -12,7 +12,7 @@
 #include "cpuid.h"
 #include "mldb/arch/arch.h"
 
-namespace ML {
+namespace MLDB {
 
 #ifdef JML_INTEL_ISA
 # ifndef JML_USE_SSE1
@@ -55,4 +55,4 @@ JML_ALWAYS_INLINE bool has_avx2()
 
 #endif // __i686__
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/simd_vector.cc
+++ b/arch/simd_vector.cc
@@ -22,7 +22,7 @@
 using namespace std;
 
 
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 namespace Generic {
 
@@ -1843,4 +1843,4 @@ void vec_min_max_el(const float * x, float * mins, float * maxs, size_t n)
 
 } // namespace Generic
 } // namespace SIMD
-} // namespace ML
+} // namespace MLDB

--- a/arch/simd_vector.h
+++ b/arch/simd_vector.h
@@ -11,8 +11,7 @@
 #include "simd.h"
 #include "mldb/arch/arch.h"
 
-namespace ML {
-
+namespace MLDB {
 namespace SIMD {
 namespace Generic {
 
@@ -189,4 +188,4 @@ namespace SSE3 {
 using namespace Generic;
 
 } // namespace SIMD
-} // namespace ML
+} // namespace MLDB

--- a/arch/simd_vector_avx.cc
+++ b/arch/simd_vector_avx.cc
@@ -15,7 +15,7 @@
 
 using namespace std;
 
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 
 namespace Generic {
@@ -305,4 +305,4 @@ double vec_dotprod_dp(const float * x, const float * y, size_t n)
 
 } // namespace Avx
 } // namespace SIMD
-} // namespace ML
+} // namespace MLDB

--- a/arch/simd_vector_avx.h
+++ b/arch/simd_vector_avx.h
@@ -9,7 +9,7 @@
 
 #include <cstddef>
 
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 namespace Avx {
 
@@ -31,4 +31,4 @@ double vec_euclid(const float * x, const float * y, size_t n);
 
 } // namespace Avx
 } // namespace SIMD
-} // namespace ML
+} // namespace MLDB

--- a/arch/spinlock.cc
+++ b/arch/spinlock.cc
@@ -10,13 +10,14 @@
 #include "spinlock.h"
 #include <thread>
 
-namespace ML {
+namespace MLDB {
 
 void
 Spinlock::
 yield()
 {
+    // This is here so we don't need to #include <thread> in the .h file
     std::this_thread::yield();
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/spinlock.h
+++ b/arch/spinlock.h
@@ -9,7 +9,7 @@
 
 #include <atomic>
 
-namespace ML {
+namespace MLDB {
 
 
 /*****************************************************************************/
@@ -72,4 +72,4 @@ struct Spinlock {
     int yieldAfter;
 };
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/sse2.h
+++ b/arch/sse2.h
@@ -15,7 +15,7 @@
 
 #define USE_SIMD_SSE2 1
 
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 
 typedef float v4sf __attribute__((__vector_size__(16)));
@@ -125,4 +125,4 @@ inline v4si pack(int * where)
 }
 
 } // namespace SIMD
-} // namespace ML
+} // namespace MLDB

--- a/arch/sse2_exp.h
+++ b/arch/sse2_exp.h
@@ -43,7 +43,7 @@
 #include "sse2_poly.h"
 #include <cmath>
 
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 
 
@@ -313,4 +313,4 @@ inline v2df sse2_exp(v2df x)
 }
 
 } // namespace SIMD
-} // namespace ML
+} // namespace MLDB

--- a/arch/sse2_log.h
+++ b/arch/sse2_log.h
@@ -1,21 +1,19 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* sse2_log.h                                                      -*- C++ -*-
    Jeremy Barnes, 23 January 2010
    Copyright (c) 2010 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    SSE2 logarithm functions.
 */
 
-#ifndef __jml__arch__sse2_log_h__
-#define __jml__arch__sse2_log_h__
+#pragma once
 
 #include "sse2.h"
 #include "sse2_poly.h"
 #include "sse2_math.h"
 #include "sse2_misc.h"
 
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 
 /*****************************************************************************/
@@ -164,6 +162,3 @@ v2df sse2_log(v2df val)
 
 } // namespace SIMD
 } // namespace ML
-
-
-#endif /* __jml__arch__sse2_log_h__ */

--- a/arch/sse2_math.h
+++ b/arch/sse2_math.h
@@ -12,7 +12,7 @@
 #include "sse2.h"
 #include "sse2_misc.h"
 
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 
 inline v4sf pow2f_unsafe(v4si n)
@@ -143,4 +143,4 @@ inline v4sf sse2_trunc(v4sf x)
 }
 
 } // namespace SIMD
-} // namespace ML
+} // namespace MLDB

--- a/arch/sse2_misc.h
+++ b/arch/sse2_misc.h
@@ -12,7 +12,7 @@
 #include "sse2.h"
 #include <cmath>
 
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 
 inline v2df pass_nan(v2df input, v2df result)
@@ -130,4 +130,4 @@ inline v4sf pass_nan_inf_zero(v4sf input, v4sf result)
 }
 
 } // namespace SIMD
-} // namespace ML
+} // namespace MLDB

--- a/arch/sse2_poly.h
+++ b/arch/sse2_poly.h
@@ -1,16 +1,14 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* sse2_poly.h                                                     -*- C++ -*-
    Jeremy Barnes, 23 January 2010
    Copyright (c) 2010 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    SSE2 polynomial evalution functions.
 */
 
-#ifndef __jml__arch__sse2_poly_h__
-#define __jml__arch__sse2_poly_h__
+#pragma once
 
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 
 inline v4sf polevl( v4sf x, float * coef, int N )
@@ -76,7 +74,5 @@ inline double polevl( double x, double * coef, int N )
 
 
 } // namespace SIMD
-} // namespace ML
-
-#endif /* __jml__arch__sse2_poly_h__ */
+} // namespace MLDB
 

--- a/arch/testing/backtrace_test.cc
+++ b/arch/testing/backtrace_test.cc
@@ -20,7 +20,7 @@
 #include <iostream>
 
 
-using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE (exception_backtrace)
 {
     cerr << "\n\nan exception with a backtrace:\n";
     try {
-        throw ML::Exception("this exception produces a backtrace");
+        throw MLDB::Exception("this exception produces a backtrace");
     }
     catch (...) {
     }

--- a/arch/testing/bit_range_ops_test.cc
+++ b/arch/testing/bit_range_ops_test.cc
@@ -22,6 +22,7 @@
 
 
 using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;

--- a/arch/testing/bitops_test.cc
+++ b/arch/testing/bitops_test.cc
@@ -23,6 +23,7 @@
 
 
 using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;

--- a/arch/testing/cpuid_test.cc
+++ b/arch/testing/cpuid_test.cc
@@ -18,7 +18,7 @@
 #include <iostream>
 
 
-using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;

--- a/arch/testing/fslock_test.cc
+++ b/arch/testing/fslock_test.cc
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE( test_stale_and_trylock )
 
     pid_t childPid = ::fork();
     if (childPid == -1) {
-        throw ML::Exception(errno, "fork");
+        throw MLDB::Exception(errno, "fork");
     }
     else if (childPid == 0) {
         GuardedFsLock lock(lockedFile);
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE( test_stale_and_lock )
 
     pid_t childPid = ::fork();
     if (childPid == -1) {
-        throw ML::Exception(errno, "fork");
+        throw MLDB::Exception(errno, "fork");
     }
     else if (childPid == 0) {
         GuardedFsLock lock(lockedFile);

--- a/arch/testing/info_test.cc
+++ b/arch/testing/info_test.cc
@@ -22,7 +22,7 @@
 #include <fcntl.h>
 
 
-using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;
@@ -64,8 +64,8 @@ BOOST_AUTO_TEST_CASE( test_fd_to_filename )
     int fd = open("/dev/null", O_RDONLY);
     BOOST_CHECK_EQUAL(fd_to_filename(fd), "/dev/null");
 
-    BOOST_CHECK_THROW(fd_to_filename(500), ML::Exception);
-    BOOST_CHECK_THROW(fd_to_filename(-1), ML::Exception);
+    BOOST_CHECK_THROW(fd_to_filename(500), MLDB::Exception);
+    BOOST_CHECK_THROW(fd_to_filename(-1), MLDB::Exception);
 }
 
 BOOST_AUTO_TEST_CASE( test_fqdn_hostname )

--- a/arch/testing/simd_test.cc
+++ b/arch/testing/simd_test.cc
@@ -18,7 +18,7 @@
 #include <iostream>
 
 
-using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;

--- a/arch/testing/simd_vector_benchmark.cc
+++ b/arch/testing/simd_vector_benchmark.cc
@@ -23,13 +23,13 @@
 #include <cmath>
 
 
-using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;
 
 #if JML_INTEL_ISA
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 namespace Generic {
 double vec_dotprod_sse2(const double * x, const double * y, size_t n);
@@ -39,7 +39,7 @@ namespace Avx {
 double vec_dotprod(const double * x, const double * y, size_t n);
 } // namespace Avx
 } // namespace SIMD
-} // namespace ML
+} // namespace MLDB
 #endif // JML_INTEL_ISA
 
 double vec_dotprod_generic(const double * x, const double * y, size_t n)

--- a/arch/testing/simd_vector_test.cc
+++ b/arch/testing/simd_vector_test.cc
@@ -23,7 +23,7 @@
 #include <cmath>
 
 
-using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;
@@ -303,13 +303,13 @@ void vec_dotprod_test_case(int nvals)
     if (error >= eps) {
         cerr << "r = " << r << " r2 = " << r2 << endl;
         cerr << "error = " << error << " eps = " << eps << endl;
-        cerr << "type " << ML::type_name<T>() << endl;
+        cerr << "type " << MLDB::type_name<T>() << endl;
     }
     BOOST_CHECK(error < eps);
 }
 
 #if JML_INTEL_ISA
-namespace ML {
+namespace MLDB {
 namespace SIMD {
 namespace Generic {
 double vec_dotprod_sse2(const float * x, const float * y, size_t n);
@@ -322,7 +322,7 @@ double vec_dotprod_dp(const float * x, const float * y, size_t n);
 double vec_dotprod(const double * x, const double * y, size_t n);
 } // namespace Avx
 } // namespace SIMD
-} // namespace ML
+} // namespace MLDB
 
 template<typename T>
 void vec_dotprod_dp_test_case(int nvals)
@@ -338,7 +338,7 @@ void vec_dotprod_dp_test_case(int nvals)
     
     double r2 = SIMD::vec_dotprod_dp_sse2(x, y, nvals);
     // this will be trivially true if the CPU does not support AVX
-    double r2a = ML::has_avx() ? SIMD::Avx::vec_dotprod_dp(x, y, nvals) :
+    double r2a = MLDB::has_avx() ? SIMD::Avx::vec_dotprod_dp(x, y, nvals) :
         SIMD::vec_dotprod_dp_sse2(x, y, nvals);
 
     if (r2 != r2a)
@@ -347,7 +347,7 @@ void vec_dotprod_dp_test_case(int nvals)
     BOOST_CHECK_EQUAL(r2, r2a);
 
     // this will be trivially true if the CPU does not support AVX
-    double r3 = ML::has_avx() ? SIMD::Avx::vec_dotprod(x, y, nvals) :
+    double r3 = MLDB::has_avx() ? SIMD::Avx::vec_dotprod(x, y, nvals) :
          SIMD::vec_dotprod_sse2(x, y, nvals);
     double r4 = SIMD::vec_dotprod_sse2(x, y, nvals);
 

--- a/arch/testing/sse2_math_test.cc
+++ b/arch/testing/sse2_math_test.cc
@@ -27,8 +27,9 @@
 #include "mldb/jml/utils/floating_point.h"
 
 using namespace ML;
+using namespace MLDB;
 using namespace std;
-using namespace ML::SIMD;
+using namespace MLDB::SIMD;
 
 using boost::unit_test::test_suite;
 

--- a/arch/testing/thread_specific_test.cc
+++ b/arch/testing/thread_specific_test.cc
@@ -20,7 +20,7 @@
 #include <array>
 
 using namespace std;
-using namespace ML;
+using namespace MLDB;
 
 struct Data
 {
@@ -53,13 +53,13 @@ struct Data
 size_t Data::constructed = 0;
 size_t Data::destructed = 0;
 
-typedef ML::ThreadSpecificInstanceInfo<Data, Data> Tls;
+typedef ThreadSpecificInstanceInfo<Data, Data> Tls;
 
 
 BOOST_AUTO_TEST_CASE(sanityTest)
 {
     {
-        ML::ThreadSpecificInstanceInfo<Data, Data> data;
+        ThreadSpecificInstanceInfo<Data, Data> data;
         data.get();
     }
 

--- a/arch/testing/tick_counter_test.cc
+++ b/arch/testing/tick_counter_test.cc
@@ -16,7 +16,7 @@
 #include <iostream>
 
 
-using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;

--- a/arch/testing/vm_test.cc
+++ b/arch/testing/vm_test.cc
@@ -14,6 +14,7 @@
 #include "mldb/arch/exception.h"
 #include "mldb/jml/utils/vector_utils.h"
 #include "mldb/arch/exception_handler.h"
+#include "mldb/base/scope.h"
 
 #include <boost/test/unit_test.hpp>
 #include <iostream>
@@ -24,7 +25,7 @@
 
 
 
-using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;
@@ -37,7 +38,7 @@ size_t num_open_files()
         throw Exception("num_open_files(): opendir(): "
                         + string(strerror(errno)));
 
-    Call_Guard closedir_dfd(std::bind(closedir, dfd));
+    Scope_Exit(closedir(dfd));
 
     size_t result = 0;
     
@@ -103,9 +104,9 @@ BOOST_AUTO_TEST_CASE( test_pagemap_reader )
         
         {
             JML_TRACE_EXCEPTIONS(false);
-            BOOST_CHECK_THROW(reader[10], ML::Exception);
-            BOOST_CHECK_THROW(reader[memory - 1], ML::Exception);
-            BOOST_CHECK_THROW(reader[memory + npages * page_size], ML::Exception);
+            BOOST_CHECK_THROW(reader[10], MLDB::Exception);
+            BOOST_CHECK_THROW(reader[memory - 1], MLDB::Exception);
+            BOOST_CHECK_THROW(reader[memory + npages * page_size], MLDB::Exception);
         }
         
         BOOST_CHECK_EQUAL(reader[memory].present, false);

--- a/arch/thread_specific.h
+++ b/arch/thread_specific.h
@@ -23,7 +23,7 @@
 #include <unordered_set>
 #include <mutex>
 
-namespace ML {
+namespace MLDB {
 
 /*****************************************************************************/
 /* THREAD SPECIFIC INSTANCE INFO                                             */
@@ -41,7 +41,7 @@ namespace ML {
 template<typename T, typename Tag>
 struct ThreadSpecificInstanceInfo
 {
-    typedef ML::Spinlock Lock;
+    typedef Spinlock Lock;
 
     struct Value
     {
@@ -176,12 +176,12 @@ private:
 
     static thread_local std::unique_ptr<PerThreadInfo> staticInfo;
 
-    static ML::Spinlock freeIndexLock;
+    static Spinlock freeIndexLock;
     static std::deque<size_t> freeIndexes;
     static unsigned nextIndex;
     int index;
 
-    mutable ML::Spinlock freeSetLock;
+    mutable Spinlock freeSetLock;
     mutable std::unordered_set<Value*> freeSet;
 };
 
@@ -190,7 +190,7 @@ thread_local std::unique_ptr<typename ThreadSpecificInstanceInfo<T, Tag>::PerThr
 ThreadSpecificInstanceInfo<T, Tag>::staticInfo(new typename ThreadSpecificInstanceInfo<T, Tag>::PerThreadInfo());
 
 template<typename T, typename Tag>
-ML::Spinlock
+Spinlock
 ThreadSpecificInstanceInfo<T, Tag>::freeIndexLock;
 
 template<typename T, typename Tag>
@@ -201,4 +201,4 @@ template<typename T, typename Tag>
 unsigned
 ThreadSpecificInstanceInfo<T, Tag>::nextIndex = 0;
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/tick_counter.cc
+++ b/arch/tick_counter.cc
@@ -15,7 +15,7 @@
 using namespace std;
 
 
-namespace ML {
+namespace MLDB {
 
 /** The average number of ticks of overhead for the tick counter. */
 double ticks_overhead = -1.0;
@@ -59,7 +59,7 @@ double calc_ticks_overhead()
 
     uint64_t overhead = nt1 - nt2;
 
-    double result = xdiv<double>(overhead, ITERATIONS);
+    double result = (double)overhead / (double)ITERATIONS;
 
     //cerr << "nt1 = " << nt1 << " nt2 = " << nt2 << " overhead = "
     //     << overhead << " result = " << result << endl;
@@ -115,5 +115,5 @@ struct Init {
 
 } // file scope
 
-} // namespace ML
+} // namespace MLDB
 

--- a/arch/tick_counter.h
+++ b/arch/tick_counter.h
@@ -1,21 +1,18 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* tick_counter.h                                                  -*- C++ -*-
    Jeremy Barnes, 15 February 2007
    Copyright (c) 2007 Jeremy Barnes.  All rights reserved.
-   
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+
    Code to access the hardware tick counter.
 */
 
-#ifndef __arch__tick_counter_h__
-#define __arch__tick_counter_h__
+#pragma once
 
 #include "mldb/compiler/compiler.h"
 #include <stdint.h>
 #include "mldb/arch/arch.h"
-//#include <iostream>
 
-namespace ML {
+namespace MLDB {
 
 /** Return the number of CPU clock ticks since some epoch. */
 JML_ALWAYS_INLINE uint64_t ticks()
@@ -53,6 +50,4 @@ extern double seconds_per_tick;
 double calc_ticks_overhead();
 double calc_ticks_per_second(double seconds_to_measure = 0.01);
 
-} // namespace ML
-
-#endif /* __arch__tick_counter_h__ */
+} // namespace MLDB

--- a/arch/timers.h
+++ b/arch/timers.h
@@ -16,11 +16,10 @@
 #include <string.h>
 #include "exception.h"
 #include <sys/select.h>
-#include "mldb/jml/math/xdiv.h"
 #include <atomic>
 
 
-namespace ML {
+namespace MLDB {
 
 inline double cpu_time()
 {
@@ -101,7 +100,7 @@ struct Duty_Cycle_Timer {
 
         double duty_cycle() const
         {
-            return xdiv<double>(usAwake, usAsleep + usAwake);
+            return (double)usAwake / (double)(usAsleep + usAwake);
         }
     };
 
@@ -169,4 +168,4 @@ struct Duty_Cycle_Timer {
     double beforeSleep, afterSleep;
 };
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/vm.h
+++ b/arch/vm.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* vm.h                                                            -*- C++ -*-
    Jeremy Barnes, 22 February 2010
    Copyright (c) 2010 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Virtual memory functions.
 */
@@ -14,7 +13,7 @@
 #include <vector>
 #include "mldb/arch/exception.h"
 
-namespace ML {
+namespace MLDB {
 
 
 enum {
@@ -257,4 +256,4 @@ operator << (std::ostream & stream, const Pagemap_Reader & reader)
     return stream;
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/arch/wakeup_fd.h
+++ b/arch/wakeup_fd.h
@@ -22,7 +22,7 @@ struct Wakeup_Fd {
     {
         fd_ = ::eventfd(0, flags);
         if (fd_ == -1)
-            throw ML::Exception(errno, "eventfd");
+            throw MLDB::Exception(errno, "eventfd");
     }
 
     Wakeup_Fd(const Wakeup_Fd & other) = delete;
@@ -47,7 +47,7 @@ struct Wakeup_Fd {
         eventfd_t val = 1;
         int res = eventfd_write(fd_, val);
         if (res == -1)
-            throw ML::Exception(errno, "eventfd write()");
+            throw MLDB::Exception(errno, "eventfd write()");
     }
 
     eventfd_t read()
@@ -55,7 +55,7 @@ struct Wakeup_Fd {
         eventfd_t val = 0;
         int res = eventfd_read(fd_, &val); 
         if (res == -1)
-            throw ML::Exception(errno, "eventfd read()");
+            throw MLDB::Exception(errno, "eventfd read()");
         return val;
     }
 
@@ -66,9 +66,9 @@ struct Wakeup_Fd {
         if (res == -1 && errno == EWOULDBLOCK)
             return false;
         if (res == -1)
-            throw ML::Exception(errno, "eventfd read()");
+            throw MLDB::Exception(errno, "eventfd read()");
         if (res != sizeof(eventfd_t))
-            throw ML::Exception("eventfd read() returned wrong num bytes");
+            throw MLDB::Exception("eventfd read() returned wrong num bytes");
         return true;
     }
 

--- a/base/exc_assert.h
+++ b/base/exc_assert.h
@@ -1,9 +1,8 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* exc_assert.h                                                    -*- C++ -*-
    Jeremy Barnes, 15 July 2010
    Copyright (c) 2010 Datacratic.  All rights reserved.
    Copyright (c) 2010 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Simple functionality to include asserts that throw exceptions rather than
    abort the program.
@@ -14,20 +13,16 @@
 #include "mldb/arch/exception.h"
 #include "mldb/base/exc_check.h"
 
-namespace ML {
-
-} // namespace ML
-
 /// Simple forwarders with the right exception type.
 /// These will eventually be disable-able using a compiler switch.
 #define ExcAssert(condition)                    \
-    ExcCheckImpl(condition, "Assert failure", ML::Assertion_Failure)
+    ExcCheckImpl(condition, "Assert failure", ::MLDB::AssertionFailure)
 
 #define ExcAssertOp(op, value1, value2)         \
-    ExcCheckOpImpl(op, value1, value2, "Assert failure", ML::Assertion_Failure)
+    ExcCheckOpImpl(op, value1, value2, "Assert failure", ::MLDB::AssertionFailure)
 
 #define ExcAssertErrno(condition)               \
-    ExcCheckErrnoImpl(condition, "Assert failure", ML::Assertion_Failure)
+    ExcCheckErrnoImpl(condition, "Assert failure", ::MLDB::AssertionFailure)
 
 /// see ExcCheckOpImpl for more details
 #define ExcAssertEqual(value1, value2)          \

--- a/base/exc_check.h
+++ b/base/exc_check.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* exc_check.h                                                    -*- C++ -*-
    Rémi Attab, 24 Febuary 2012
    Copyright (c) 2012 Datacratic.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Quick and easy way to throw an exception on a failed condition.
 
@@ -25,8 +24,8 @@
     do {                                                                \
         if (!(condition)) {                                             \
             std::string msg__ =                                         \
-                ML::format("%s: %s", message, #condition);              \
-            ML::do_abort();                                             \
+                MLDB::format("%s: %s", message, #condition);              \
+            MLDB::do_abort();                                             \
             throw exc_type(msg__.c_str(), __PRETTY_FUNCTION__,          \
                     __FILE__, __LINE__);                                \
         }                                                               \
@@ -41,11 +40,11 @@
             stream1__ << value1;  stream2__ << value2;                  \
             std::string v1__ = stream1__.str();                         \
             std::string v2__ = stream2__.str();                         \
-            std::string msg__ = ML::format(                             \
+            std::string msg__ = MLDB::format(                             \
                     "%s: !(%s " #op " %s) [!(%s " #op " %s)]",          \
                     message, #value1, #value2, v1__.c_str(),            \
                     v2__.c_str());                                      \
-            ML::do_abort();                                             \
+            MLDB::do_abort();                                             \
             throw exc_type(msg__.c_str(), __PRETTY_FUNCTION__,          \
                                         __FILE__, __LINE__);            \
         }                                                               \
@@ -55,9 +54,9 @@
 #define ExcCheckErrnoImpl(condition, message, exc_type)                 \
     do {                                                                \
         if (!(condition)) {                                             \
-            std::string msg__ = ML::format("%s: %s(%d)",                \
+            std::string msg__ = MLDB::format("%s: %s(%d)",                \
                     message, strerror(errno), errno);                   \
-            ML::do_abort();                                             \
+            MLDB::do_abort();                                             \
             throw exc_type(msg__.c_str(), __PRETTY_FUNCTION__,          \
                     __FILE__, __LINE__);                                \
         }                                                               \
@@ -66,13 +65,13 @@
 
 /// Simple forwarders with the right exception type.
 #define ExcCheck(condition, message)                    \
-    ExcCheckImpl(condition, message, ML::Assertion_Failure)
+        ExcCheckImpl(condition, message, ::MLDB::AssertionFailure)
 
 #define ExcCheckOp(op, value1, value2, message)                         \
-    ExcCheckOpImpl(op, value1, value2, message, ML::Assertion_Failure)
+        ExcCheckOpImpl(op, value1, value2, message, ::MLDB::AssertionFailure)
 
 #define ExcCheckErrno(condition, message)       \
-    ExcCheckErrnoImpl(condition, message, ML::Assertion_Failure)
+        ExcCheckErrnoImpl(condition, message, ::MLDB::AssertionFailure)
 
 
 /// see ExcCheckOpImpl for more details

--- a/base/fast_float_parsing.h
+++ b/base/fast_float_parsing.h
@@ -1,21 +1,18 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* fast_float_parsing.h                                            -*- C++ -*-
    Jeremy Barnes, 25 February 2005
    Copyright (c) 2005 Jeremy Barnes.  All rights reserved.
-   
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.   
+
    Fast inline float parsing routines.
 */
 
-#ifndef __utils__fast_float_parsing_h__
-#define __utils__fast_float_parsing_h__
-
+#pragma once
 
 #include "mldb/base/parse_context.h"
 #include <limits>
 #include <errno.h>
 
-namespace ML {
+namespace MLDB {
 
 double binary_exp10 [10] = {
     10,
@@ -86,11 +83,11 @@ exp10_int(int val)
 */
 
 template<typename Float>
-inline bool match_float(Float & result, Parse_Context & c, bool lenient = true)
+inline bool match_float(Float & result, ParseContext & c, bool lenient = true)
 {
     if (c.eof()) return false;
 
-    Parse_Context::Revert_Token tok(c);
+    ParseContext::Revert_Token tok(c);
     // perfect decimal representation of double precision floats
     // should fit in 256 chars.
     char buf[256];
@@ -157,7 +154,7 @@ inline bool match_float(Float & result, Parse_Context & c, bool lenient = true)
         // exponential marker
         if (!c.eof() && (*c == 'e' || *c == 'E')) {
             // allow backtracking in case this is not part of the float
-            Parse_Context::Revert_Token token(c);
+            ParseContext::Revert_Token token(c);
             buf[c.get_offset() - from] = 'e';
             ++c;
         
@@ -197,7 +194,7 @@ inline bool match_float(Float & result, Parse_Context & c, bool lenient = true)
 }
 
 template<typename Float>
-inline Float expect_float(Parse_Context & c,
+inline Float expect_float(ParseContext & c,
                           const char * error = "expected real number")
 {
     Float result;
@@ -207,7 +204,4 @@ inline Float expect_float(Parse_Context & c,
 }
 
 
-} // namespace ML
-
-
-#endif /* __utils__fast_float_parsing_h__ */
+} // namespace MLDB

--- a/base/fast_int_parsing.h
+++ b/base/fast_int_parsing.h
@@ -1,27 +1,25 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* fast_int_parsing.h                                              -*- C++ -*-
    Jeremy Barnes, 24 March 2005
    Copyright (c) 2005 Jeremy Barnes.  All rights reserved.
-   
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Routines to quickly parse a base 10 integer.
 */
 
-#ifndef __utils__fast_int_parsing_h__
-#define __utils__fast_int_parsing_h__
+#pragma once
 
 #include "mldb/base/parse_context.h"
 #include <iostream>
 
+
 using namespace std;
 
 
-namespace ML {
+namespace MLDB {
 
-inline bool match_unsigned(unsigned long & val, Parse_Context & c)
+inline bool match_unsigned(unsigned long & val, ParseContext & c)
 {
-    Parse_Context::Revert_Token tok(c);
+    ParseContext::Revert_Token tok(c);
 
     val = 0;
     unsigned digits = 0;
@@ -44,9 +42,9 @@ inline bool match_unsigned(unsigned long & val, Parse_Context & c)
     return true;
 }
 
-inline bool match_int(long int & result, Parse_Context & c)
+inline bool match_int(long int & result, ParseContext & c)
 {
-    Parse_Context::Revert_Token tok(c);
+    ParseContext::Revert_Token tok(c);
 
     int sign = 1;
     if (c.match_literal('+')) ;
@@ -61,9 +59,9 @@ inline bool match_int(long int & result, Parse_Context & c)
     return true;
 }
 
-inline bool match_hex4(long int & result, Parse_Context & c)
+inline bool match_hex4(long int & result, ParseContext & c)
 {
-    Parse_Context::Revert_Token tok(c);
+    ParseContext::Revert_Token tok(c);
 
     int code = 0;
     unsigned digits = 0;
@@ -100,9 +98,9 @@ inline bool match_hex4(long int & result, Parse_Context & c)
 }
 
 inline bool match_unsigned_long(unsigned long & val,
-                                Parse_Context & c)
+                                ParseContext & c)
 {
-    Parse_Context::Revert_Token tok(c);
+    ParseContext::Revert_Token tok(c);
 
     val = 0;
     int digits = 0;
@@ -125,9 +123,9 @@ inline bool match_unsigned_long(unsigned long & val,
     return true;
 }
 
-inline bool match_long(long int & result, Parse_Context & c)
+inline bool match_long(long int & result, ParseContext & c)
 {
-    Parse_Context::Revert_Token tok(c);
+    ParseContext::Revert_Token tok(c);
 
     long sign = 1;
     if (c.match_literal('+')) ;
@@ -145,9 +143,9 @@ inline bool match_long(long int & result, Parse_Context & c)
 
 
 inline bool match_unsigned_long_long(unsigned long long & val,
-                                     Parse_Context & c)
+                                     ParseContext & c)
 {
-    Parse_Context::Revert_Token tok(c);
+    ParseContext::Revert_Token tok(c);
 
     val = 0;
     int digits = 0;
@@ -170,9 +168,9 @@ inline bool match_unsigned_long_long(unsigned long long & val,
     return true;
 }
 
-inline bool match_long_long(long long int & result, Parse_Context & c)
+inline bool match_long_long(long long int & result, ParseContext & c)
 {
-    Parse_Context::Revert_Token tok(c);
+    ParseContext::Revert_Token tok(c);
 
     long long sign = 1;
     if (c.match_literal('+')) ;
@@ -188,6 +186,5 @@ inline bool match_long_long(long long int & result, Parse_Context & c)
     return true;
 }
 
-} // namespace ML
+} // namespace MLDB
 
-#endif /* __utils__fast_int_parsing_h__ */

--- a/base/hash.cc
+++ b/base/hash.cc
@@ -72,7 +72,7 @@ std::string md5HashToHex(const char * buf, size_t nBytes)
 
     string md5;
     for (unsigned i = 0;  i < digestLen;  ++i) {
-        md5 += ML::format("%02x", digest[i]);
+        md5 += MLDB::format("%02x", digest[i]);
     }
 
     return md5;

--- a/base/optimized_path.cc
+++ b/base/optimized_path.cc
@@ -37,7 +37,7 @@ struct OptimizedPath::Itl {
 };
 
 /// Allow the default level to be controlled by the environment
-static ML::Env_Option<std::string>
+static EnvOption<std::string>
 DEFAULT_PATH_OPTIMIZATION_LEVEL("MLDB_DEFAULT_PATH_OPTIMIZATION_LEVEL", "ALWAYS");
 
 namespace {
@@ -54,7 +54,7 @@ int getDefaultLevel()
     else if (level == "never")
         return OptimizedPath::NEVER;
     else {
-        throw ML::Exception("Couldn't parse default path optimization level '"
+        throw MLDB::Exception("Couldn't parse default path optimization level '"
                             + std::string(DEFAULT_PATH_OPTIMIZATION_LEVEL)
                             + "'.  Options "
                             "are 'always', 'sometimes', 'never'.");
@@ -108,7 +108,7 @@ setOptimization(const std::string & pathName, int frequency)
     std::unique_lock<std::mutex> guard(pathRegistryMutex);
     auto it = pathRegistry.find(pathName);
     if (it == pathRegistry.end())
-        throw ML::Exception("Couldn't find path name '"
+        throw MLDB::Exception("Couldn't find path name '"
                             + pathName + "' setting optimization level");
     setOptimization(it->second, frequency);
 }
@@ -142,7 +142,7 @@ OptimizedPath(const std::string & name)
         defaultLevel = getDefaultLevel();
     setOptimization(this, defaultLevel);
     if (!pathRegistry.insert({name, this}).second) {
-        throw ML::Exception("Optimized path '" + name + "' was registered twice");
+        throw MLDB::Exception("Optimized path '" + name + "' was registered twice");
     }
 }
 

--- a/base/parse_context.cc
+++ b/base/parse_context.cc
@@ -21,25 +21,25 @@
 using namespace std;
 
 
-namespace ML {
+namespace MLDB {
 
 
 /*****************************************************************************/
 /* PARSE_CONTEXT                                                             */
 /*****************************************************************************/
 
-const std::string Parse_Context::CONSOLE("-");
+const std::string ParseContext::CONSOLE("-");
 
-Parse_Context::
-Parse_Context()
+ParseContext::
+ParseContext()
     : stream_(0), chunk_size_(0), first_token_(0), last_token_(0),
       cur_(0), ebuf_(0),
       line_(0), col_(0), ofs_(0)
 {
 }
 
-Parse_Context::
-Parse_Context(const std::string & filename, const char * start,
+ParseContext::
+ParseContext(const std::string & filename, const char * start,
               const char * end, unsigned line, unsigned col)
     : stream_(0), chunk_size_(0), first_token_(0), last_token_(0),
       filename_(filename), cur_(start), ebuf_(end),
@@ -49,8 +49,8 @@ Parse_Context(const std::string & filename, const char * start,
                                Buffer(0, start, end - start, false));
 }
 
-Parse_Context::
-Parse_Context(const std::string & filename, const char * start,
+ParseContext::
+ParseContext(const std::string & filename, const char * start,
               size_t length, unsigned line, unsigned col)
     : stream_(0), chunk_size_(0), first_token_(0), last_token_(0),
       filename_(filename), cur_(start), ebuf_(start + length),
@@ -62,8 +62,8 @@ Parse_Context(const std::string & filename, const char * start,
     //cerr << "current buffer has " << current_->size << " chars" << endl;
 }
 
-Parse_Context::
-Parse_Context(const std::string & filename)
+ParseContext::
+ParseContext(const std::string & filename)
     : stream_(0), chunk_size_(0), first_token_(0), last_token_(0),
       cur_(0), ebuf_(0),
       line_(0), col_(0), ofs_(0)
@@ -71,8 +71,8 @@ Parse_Context(const std::string & filename)
     init(filename);
 }
 
-Parse_Context::
-Parse_Context(const std::string & filename, std::istream & stream,
+ParseContext::
+ParseContext(const std::string & filename, std::istream & stream,
               unsigned line, unsigned col, size_t chunk_size)
     : stream_(&stream), chunk_size_(chunk_size), first_token_(0), last_token_(0),
       filename_(filename), cur_(0), ebuf_(0),
@@ -86,13 +86,13 @@ Parse_Context(const std::string & filename, std::istream & stream,
     }
 }
 
-Parse_Context::
-~Parse_Context()
+ParseContext::
+~ParseContext()
 {
 }
 
 void
-Parse_Context::
+ParseContext::
 init(const std::string & filename)
 {
     stream_ = 0;
@@ -162,20 +162,20 @@ struct MatchAnyCharLots {
 } // file scope
 
 bool
-Parse_Context::
+ParseContext::
 match_text(std::string & text, const char * delimiters)
 {
     int nd = strlen(delimiters);
 
     if (nd == 0)
-        throw ML::Exception("Parse_Context::match_text(): no characters");
+        throw MLDB::Exception("ParseContext::match_text(): no characters");
 
     if (nd <= 4) return match_text(text, MatchAnyChar(delimiters, nd));
     else return match_text(text, MatchAnyCharLots(delimiters, nd));
 }
 
 bool 
-Parse_Context::
+ParseContext::
 match_test_icase(const char* word)
 {
     Revert_Token token(*this);
@@ -200,7 +200,7 @@ match_test_icase(const char* word)
 }
 
 std::string
-Parse_Context::
+ParseContext::
 expect_text(char delimiter, bool allow_empty, const char * error)
 {
     string result;
@@ -210,7 +210,7 @@ expect_text(char delimiter, bool allow_empty, const char * error)
 }
     
 std::string
-Parse_Context::
+ParseContext::
 expect_text(const char * delimiters, bool allow_empty, const char * error)
 {
     string result;
@@ -220,12 +220,12 @@ expect_text(const char * delimiters, bool allow_empty, const char * error)
 }
 
 bool
-Parse_Context::
+ParseContext::
 match_int(int & val_, int min, int max)
 {
     Revert_Token tok(*this);
     long val = 0;
-    if (!ML::match_int(val, *this)) return false;
+    if (!MLDB::match_int(val, *this)) return false;
     if (val < min || val > max) return false;
     val_ = val;
     tok.ignore();
@@ -233,7 +233,7 @@ match_int(int & val_, int min, int max)
 }
     
 int
-Parse_Context::
+ParseContext::
 expect_int(int min, int max, const char * error)
 {
     int result;
@@ -242,12 +242,12 @@ expect_int(int min, int max, const char * error)
 }
 
 bool
-Parse_Context::
+ParseContext::
 match_hex4(int & val_, int min, int max)
 {
     Revert_Token tok(*this);
     long val = 0;
-    if (!ML::match_hex4(val, *this)) return false;
+    if (!MLDB::match_hex4(val, *this)) return false;
     if (val < min || val > max) return false;
     val_ = val;
     tok.ignore();
@@ -255,7 +255,7 @@ match_hex4(int & val_, int min, int max)
 }
 
 int
-Parse_Context::
+ParseContext::
 expect_hex4(int min, int max, const char * error)
 {
     int result;
@@ -264,12 +264,12 @@ expect_hex4(int min, int max, const char * error)
 }
 
 bool
-Parse_Context::
+ParseContext::
 match_unsigned(unsigned & val_, unsigned min, unsigned max)
 {
     Revert_Token tok(*this);
     unsigned long val;
-    if (!ML::match_unsigned(val, *this)) return false;
+    if (!MLDB::match_unsigned(val, *this)) return false;
     if (val < min || val > max) return false;
     val_ = val;
     tok.ignore();
@@ -277,7 +277,7 @@ match_unsigned(unsigned & val_, unsigned min, unsigned max)
 }
 
 unsigned
-Parse_Context::
+ParseContext::
 expect_unsigned(unsigned min, unsigned max, const char * error)
 {
     unsigned result = 1;
@@ -286,12 +286,12 @@ expect_unsigned(unsigned min, unsigned max, const char * error)
 }
 
 bool
-Parse_Context::
+ParseContext::
 match_long(long & val_, long min, long max)
 {
     Revert_Token tok(*this);
     long val = 0;
-    if (!ML::match_long(val, *this)) return false;
+    if (!MLDB::match_long(val, *this)) return false;
     if (val < min || val > max) return false;
     val_ = val;
     tok.ignore();
@@ -299,7 +299,7 @@ match_long(long & val_, long min, long max)
 }
     
 long
-Parse_Context::
+ParseContext::
 expect_long(long min, long max, const char * error)
 {
     long result;
@@ -308,13 +308,13 @@ expect_long(long min, long max, const char * error)
 }
 
 bool
-Parse_Context::
+ParseContext::
 match_unsigned_long(unsigned long & val_, unsigned long min,
                          unsigned long max)
 {
     Revert_Token tok(*this);
     unsigned long val = 0;
-    if (!ML::match_unsigned_long(val, *this)) return false;
+    if (!MLDB::match_unsigned_long(val, *this)) return false;
     if (val < min || val > max) return false;
     val_ = val;
     tok.ignore();
@@ -322,7 +322,7 @@ match_unsigned_long(unsigned long & val_, unsigned long min,
 }
 
 unsigned long
-Parse_Context::
+ParseContext::
 expect_unsigned_long(unsigned long min, unsigned long max,
                           const char * error)
 {
@@ -332,12 +332,12 @@ expect_unsigned_long(unsigned long min, unsigned long max,
 }
 
 bool
-Parse_Context::
+ParseContext::
 match_long_long(long long & val_, long long min, long long max)
 {
     Revert_Token tok(*this);
     long long val = 0;
-    if (!ML::match_long_long(val, *this)) return false;
+    if (!MLDB::match_long_long(val, *this)) return false;
     if (val < min || val > max) return false;
     val_ = val;
     tok.ignore();
@@ -345,7 +345,7 @@ match_long_long(long long & val_, long long min, long long max)
 }
     
 long long
-Parse_Context::
+ParseContext::
 expect_long_long(long long min, long long max, const char * error)
 {
     long long result;
@@ -354,13 +354,13 @@ expect_long_long(long long min, long long max, const char * error)
 }
 
 bool
-Parse_Context::
+ParseContext::
 match_unsigned_long_long(unsigned long long & val_, unsigned long long min,
                          unsigned long long max)
 {
     Revert_Token tok(*this);
     unsigned long long val = 0;
-    if (!ML::match_unsigned_long_long(val, *this)) return false;
+    if (!MLDB::match_unsigned_long_long(val, *this)) return false;
     if (val < min || val > max) return false;
     val_ = val;
     tok.ignore();
@@ -368,7 +368,7 @@ match_unsigned_long_long(unsigned long long & val_, unsigned long long min,
 }
 
 unsigned long long
-Parse_Context::
+ParseContext::
 expect_unsigned_long_long(unsigned long long min, unsigned long long max,
                           const char * error)
 {
@@ -378,18 +378,18 @@ expect_unsigned_long_long(unsigned long long min, unsigned long long max,
 }
 
 bool
-Parse_Context::
+ParseContext::
 match_float(float & val, float min, float max, bool lenient)
 {
     Revert_Token t(*this);
-    if (!ML::match_float(val, *this, lenient)) return false;
+    if (!MLDB::match_float(val, *this, lenient)) return false;
     if (val < min || val > max) return false;
     t.ignore();
     return true;
 }
 
 float
-Parse_Context::
+ParseContext::
 expect_float(float min, float max, const char * error, bool lenient)
 {
     float val;
@@ -399,18 +399,18 @@ expect_float(float min, float max, const char * error, bool lenient)
 }
 
 bool
-Parse_Context::
+ParseContext::
 match_double(double & val, double min, double max, bool lenient)
 {
     Revert_Token t(*this);
-    if (!ML::match_float(val, *this, lenient)) return false;
+    if (!MLDB::match_float(val, *this, lenient)) return false;
     if (val < min || val > max) return false;
     t.ignore();
     return true;
 }
 
 double
-Parse_Context::
+ParseContext::
 expect_double(double min, double max, const char * error, bool lenient)
 {
     double val;
@@ -420,7 +420,7 @@ expect_double(double min, double max, const char * error, bool lenient)
 }
 
 std::string
-Parse_Context::
+ParseContext::
 where() const
 {
     if (!eof()) {
@@ -443,21 +443,21 @@ where() const
 }
 
 void
-Parse_Context::
+ParseContext::
 exception(const std::string & message) const
 {
     throw Exception(where() + ": " + message, filename_, line_, col_);
 }
 
 void
-Parse_Context::
+ParseContext::
 exception(const char * message) const
 {
     throw Exception(where() + ": " + string(message), filename_, line_, col_);
 }
 
 void
-Parse_Context::
+ParseContext::
 exception_fmt(const char * fmt, ...) const
 {
     va_list ap;
@@ -468,7 +468,7 @@ exception_fmt(const char * fmt, ...) const
 }
 
 bool
-Parse_Context::
+ParseContext::
 match_literal_str(const char * start, size_t len)
 {
     Revert_Token token(*this);
@@ -487,7 +487,7 @@ match_literal_str(const char * start, size_t len)
 }
 
 void
-Parse_Context::
+ParseContext::
 next_buffer()
 {
     //cerr << "next_buffer: ofs_ = " << ofs_ << " line_ = " << line_
@@ -497,7 +497,7 @@ next_buffer()
 
     if (current_ == buffers_.end()) {
         return; // eof
-        throw ML::Exception("Parse_Context: asked for new buffer when already "
+        throw MLDB::Exception("ParseContext: asked for new buffer when already "
                             " at end");
     }
     else {
@@ -530,7 +530,7 @@ next_buffer()
 }
 
 void
-Parse_Context::
+ParseContext::
 goto_ofs(uint64_t ofs, size_t line, size_t col,
          bool in_destructor)
 {
@@ -573,11 +573,11 @@ goto_ofs(uint64_t ofs, size_t line, size_t col,
         return;
     }
 
-    exception_fmt("Parse_Context::goto_ofs(): couldn't find position %zd (l%zdc%zd)", ofs, line, col);
+    exception_fmt("ParseContext::goto_ofs(): couldn't find position %zd (l%zdc%zd)", ofs, line, col);
 }
 
 std::string
-Parse_Context::
+ParseContext::
 text_between(uint64_t ofs1, uint64_t ofs2) const
 {
     std::string result;
@@ -601,7 +601,7 @@ text_between(uint64_t ofs1, uint64_t ofs2) const
 }
 
 void
-Parse_Context::
+ParseContext::
 free_buffers()
 {
     /* Free buffers so long as a) it's not the current buffer, and b)
@@ -619,8 +619,8 @@ free_buffers()
     }
 }
 
-std::list<Parse_Context::Buffer>::iterator
-Parse_Context::
+std::list<ParseContext::Buffer>::iterator
+ParseContext::
 read_new_buffer()
 {
     if (!stream_) return buffers_.end();
@@ -671,16 +671,16 @@ read_new_buffer()
 }
 
 void
-Parse_Context::
+ParseContext::
 set_chunk_size(size_t size)
 {
     if (size == 0)
-        throw ML::Exception("Parse_Context::chunk_size(): invalid chunk size");
+        throw MLDB::Exception("ParseContext::chunk_size(): invalid chunk size");
     chunk_size_ = size;
 }
 
 size_t
-Parse_Context::
+ParseContext::
 readahead_available() const
 {
     if (eof()) return 0;
@@ -697,7 +697,7 @@ readahead_available() const
 }
 
 size_t
-Parse_Context::
+ParseContext::
 total_buffered() const
 {
     if (eof()) return 0;
@@ -712,4 +712,4 @@ total_buffered() const
     return result;
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/base/parse_context.h
+++ b/base/parse_context.h
@@ -21,22 +21,22 @@
 #include <memory>
 
 
-namespace ML {
+namespace MLDB {
 
 
 /*****************************************************************************/
 /* PARSE_CONTEXT                                                             */
 /*****************************************************************************/
 
-struct Parse_Context {
+struct ParseContext {
     static const std::string CONSOLE;
 
-    struct Exception: ML::Exception {
+    struct Exception: MLDB::Exception {
         Exception(const char * what,
                   std::string filename,
                   int row,
                   int col) noexcept
-            : ML::Exception(what),
+            : MLDB::Exception(what),
               filename(std::move(filename)),
               row(row),
               col(col)
@@ -47,7 +47,7 @@ struct Parse_Context {
                   std::string filename,
                   int row,
                   int col) noexcept
-            : ML::Exception(what),
+            : MLDB::Exception(what),
               filename(std::move(filename)),
               row(row),
               col(col)
@@ -64,28 +64,28 @@ struct Parse_Context {
     };
     
     /** Create but don't initialize. */
-    Parse_Context();
+    ParseContext();
 
     /** Initialize from a filename, loading the file and uncompressing if
         necessary. */
-    explicit Parse_Context(const std::string & filename);
+    explicit ParseContext(const std::string & filename);
     
     /** Initialize from a memory region. */
-    Parse_Context(const std::string & filename, const char * start,
+    ParseContext(const std::string & filename, const char * start,
                   const char * finish, unsigned line = 1, unsigned col = 1);
 
-    Parse_Context(const std::string & filename, const char * start,
+    ParseContext(const std::string & filename, const char * start,
                   size_t length, unsigned line = 1, unsigned col = 1);
 
     /** Default chunk size. */
     enum { DEFAULT_CHUNK_SIZE = 65500 };
 
     /** Initialize from an istream. */
-    Parse_Context(const std::string & filename, std::istream & stream,
+    ParseContext(const std::string & filename, std::istream & stream,
                   unsigned line = 1, unsigned col = 1,
                   size_t chunk_size = DEFAULT_CHUNK_SIZE);
 
-    ~Parse_Context();
+    ~ParseContext();
 
     /** Initialize from a filename, loading the file and uncompressing if
         necessary. */
@@ -108,7 +108,7 @@ struct Parse_Context {
 
     /** Increment.  Note that it always sets up the buffer such that more
         characters are available. */
-    JML_ALWAYS_INLINE Parse_Context & operator ++ ()
+    JML_ALWAYS_INLINE ParseContext & operator ++ ()
     {
         if (eof()) exception("unexpected EOF");
 
@@ -122,7 +122,7 @@ struct Parse_Context {
         return *this;
     }
 
-    Parse_Context & operator += (int steps)
+    ParseContext & operator += (int steps)
     {
         for (int i = 0; i < steps; i++) {
             operator ++();
@@ -549,12 +549,12 @@ protected:
         the address of multiple tokens is always descending).  Tokens may
         not be used from more than one thread.
 
-        They are stored as a doubly linked list.  The Parse_Context
+        They are stored as a doubly linked list.  The ParseContext
         structure maintains a pointer to the earliest one.
     */
     struct Token {
     protected:
-        Token(Parse_Context & context)
+        Token(ParseContext & context)
             : context(&context),
               ofs(context.ofs_), line(context.line_), col(context.col_),
               prev(0), next(0)
@@ -581,7 +581,7 @@ protected:
         {
             //std::cerr << "deleting token " << this << std::endl;
             if (context)
-                throw ML::Exception("Parse_Context::Token::~Token(): "
+                throw MLDB::Exception("ParseContext::Token::~Token(): "
                                     "active token was destroyed");
         }
         
@@ -606,7 +606,7 @@ protected:
                 // result is.
                 if (in_destructor)
                     return;
-                throw ML::Exception("Parse_Context::Token::apply(): logic error: "
+                throw MLDB::Exception("ParseContext::Token::apply(): logic error: "
                                     "applied token was not the latest one");
             }
 
@@ -633,7 +633,7 @@ protected:
                 if (context->first_token_ != this) {
                     if (in_destructor)
                         return;
-                    throw ML::Exception("Parse_Context::Token::ignore(): "
+                    throw MLDB::Exception("ParseContext::Token::ignore(): "
                                         "logic error: no prev but not first");
                 }
                 context->first_token_ = next;
@@ -644,7 +644,7 @@ protected:
                 if (context->last_token_ != this) {
                     if (in_destructor)
                         return;
-                    throw ML::Exception("Parse_Context::Token::ignore(): "
+                    throw MLDB::Exception("ParseContext::Token::ignore(): "
                                         "logic error: no next but not last");
                 }
                 context->last_token_ = prev;
@@ -656,7 +656,7 @@ protected:
             context = 0;
         }
 
-        Parse_Context * context;   ///< The Parse_Context object that owns us
+        ParseContext * context;   ///< The ParseContext object that owns us
 
         uint64_t ofs;              ///< Offset for this token
         unsigned line;             ///< Line number for this token
@@ -666,7 +666,7 @@ protected:
         Token * prev;              ///< The previous token in the series
         Token * next;              ///< The next token in the series
 
-        friend struct Parse_Context;
+        friend struct ParseContext;
     };
     
 public:
@@ -674,7 +674,7 @@ public:
         to revert back to its position once it goes out of scope.  Used for
         speculative parsing. */
     struct Revert_Token : public Token {
-        Revert_Token(Parse_Context & context)
+        Revert_Token(ParseContext & context)
             : Token(context)
         {
         }
@@ -695,9 +695,9 @@ public:
 
     /** A token that, unless stop() is called, will cause the parse context
         to remember the text from there onwards.  Used to force the
-        Parse_Context to buffer text from a certain point onwards. */
+        ParseContext to buffer text from a certain point onwards. */
     struct Hold_Token : public Token {
-        Hold_Token(Parse_Context & context)
+        Hold_Token(ParseContext & context)
             : Token(context)
         {
         }
@@ -715,7 +715,7 @@ public:
         std::string captured() const
         {
             if (!context)
-                throw ML::Exception("hold token hasn't captured any text");
+                throw MLDB::Exception("hold token hasn't captured any text");
 
             return context->text_between(ofs, context->get_offset());
         }
@@ -776,5 +776,5 @@ private:
     std::shared_ptr<std::istream> ownedStream_;
 };
 
-} // namespace ML
+} // namespace MLDB
 

--- a/base/testing/thread_pool_test.cc
+++ b/base/testing/thread_pool_test.cc
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE (thread_pool_idle_cpu_usage)
     ThreadPool threadPool(32);
     // let it start up and settle down
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    ML::Timer timer;
+    Timer timer;
     std::this_thread::sleep_for(std::chrono::seconds(1));
     double elapsedCpu = timer.elapsed_cpu();
     double elapsedWall = timer.elapsed_wall();
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE (thread_pool_no_busy_looping)
     BOOST_CHECK_EQUAL(threadPool.jobsSubmitted(), 0);
     std::atomic<int> finished(0);
 
-    ML::Timer timer;
+    Timer timer;
 
     threadPool.add([&] () {std::this_thread::sleep_for(std::chrono::milliseconds(100)); finished = 1;});
  
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(thread_pool_test)
     
     uint64_t numJobs = 1000000;
 
-    ML::Timer timer;
+    Timer timer;
 
     for (uint64_t i = 0;  i < numJobs;  ++i)
         pool.add(work);

--- a/base/thread_pool.cc
+++ b/base/thread_pool.cc
@@ -24,7 +24,7 @@ using namespace std;
 
 namespace MLDB {
 
-static ML::Env_Option<int, true /* trace */>
+static EnvOption<int, true /* trace */>
 NUM_CPUS("NUM_CPUS", std::thread::hardware_concurrency());
 
 int numCpus()
@@ -116,7 +116,7 @@ struct ThreadPool::Itl: public std::enable_shared_from_this<ThreadPool::Itl> {
     };
 
     /// This allows us to have one threadEntry per thread
-    ML::ThreadSpecificInstanceInfo<ThreadEntry, void> threadEntries;
+    ThreadSpecificInstanceInfo<ThreadEntry, void> threadEntries;
 
     /// Our internal worker threads
     std::vector<std::thread> workers;
@@ -425,7 +425,7 @@ struct ThreadPool::Itl: public std::enable_shared_from_this<ThreadPool::Itl> {
         } catch (const std::exception & exc) {
             finished += 1;
             cerr << "ERROR: job submitted to ThreadPool of type "
-                 << ML::demangle(job.target_type())
+                 << demangle(job.target_type())
                  << " threw exception: " << exc.what() << endl;
             cerr << "A Job in a ThreadPool which throws an exception "
                  << "causes the program to crash, which is happening now"
@@ -435,8 +435,8 @@ struct ThreadPool::Itl: public std::enable_shared_from_this<ThreadPool::Itl> {
         JML_CATCH_ALL {
             finished += 1;
             cerr << "ERROR: job submitted to ThreadPool of type "
-                 << ML::demangle(job.target_type())
-                 << " threw exception " << ML::getExceptionString() << endl;
+                 << demangle(job.target_type())
+                 << " threw exception " << getExceptionString() << endl;
             cerr << "A Job in a ThreadPool which throws an exception "
                  << "causes the program to crash, which is happening now"
                  << endl;

--- a/builtin/filtered_dataset.h
+++ b/builtin/filtered_dataset.h
@@ -32,7 +32,7 @@ struct FilteredDataset : public Dataset {
     virtual void recordRowItl(const RowPath & rowName,
           const std::vector<std::tuple<ColumnPath, CellValue, Date> > & vals)
     {
-        throw ML::Exception("Dataset type doesn't allow recording");
+        throw MLDB::Exception("Dataset type doesn't allow recording");
     }
 
     // these methods are usually not overriden by the dataset specialization - don't implement

--- a/builtin/id_hash.h
+++ b/builtin/id_hash.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** id_hash.h                                                      -*- C++ -*-
     Jeremy Barnes, 1 March 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Data structure for storage of efficiencly mergeable hash values with a bitmap
     associated with each one.
@@ -47,7 +46,7 @@ struct IdHashFn {
     }
 };
 
-struct IdHashOps : public ML::PairOps<uint64_t, uint32_t, IdHashFn, IdHashBucket> {
+struct IdHashOps : public PairOps<uint64_t, uint32_t, IdHashFn, IdHashBucket> {
 
     template<typename Storage>
     static size_t hashKey(IdHashBucket bucket, int capacity,
@@ -112,7 +111,7 @@ struct IdHashOps : public ML::PairOps<uint64_t, uint32_t, IdHashFn, IdHashBucket
         return res;
 
         using namespace std;
-        cerr << ML::format("key = %016llx res = %016llx",
+        cerr << MLDB::format("key = %016llx res = %016llx",
                            (unsigned long long)key,
                            (unsigned long long)res)
              << endl;
@@ -130,15 +129,15 @@ struct IdHashOps : public ML::PairOps<uint64_t, uint32_t, IdHashFn, IdHashBucket
 };
 
 #if 1
-typedef ML::Lightweight_Hash<uint64_t,
+typedef Lightweight_Hash<uint64_t,
                              uint32_t,
                              IdHashBucket,
                              IdHashBucket,
                              IdHashOps,
-                             ML::LogMemStorage<IdHashBucket> > 
+                             LogMemStorage<IdHashBucket> > 
 IdHash;
 #else
-typedef ML::Lightweight_Hash<uint64_t,
+typedef Lightweight_Hash<uint64_t,
                              uint32_t,
                              IdHashBucket,
                              IdHashBucket,

--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -98,7 +98,7 @@ struct JoinedDataset::Itl
     std::vector<RowEntry> rows;
 
     /// Map from row hash to the row
-    ML::Lightweight_Hash<RowHash, int64_t> rowIndex;
+    Lightweight_Hash<RowHash, int64_t> rowIndex;
 
     /// Index of a row hash for a left or right dataset to a list of
     /// rows it's part of in the output.

--- a/builtin/merge_hash_entries.h
+++ b/builtin/merge_hash_entries.h
@@ -118,7 +118,7 @@ struct MergeHashEntryBucket {
 
         auto newData = (MergeHashEntry *)malloc(newCap * sizeof(MergeHashEntry));
         if (!newData) {
-            throw ML::Exception("not enough memory to allocate %d",
+            throw MLDB::Exception("not enough memory to allocate %d",
                                 (int) (newCap * sizeof(MergeHashEntry)));
         }
         std::copy(data, data + size_, newData);
@@ -256,7 +256,7 @@ extractAndMerge(size_t numElementsToMerge,
                 return;
             }
             else if (first >= last) {
-                throw ML::Exception("first should come before last");
+                throw MLDB::Exception("first should come before last");
             }
             else if (last == first + 1) {
                 // One of them

--- a/builtin/merged_dataset.cc
+++ b/builtin/merged_dataset.cc
@@ -72,7 +72,7 @@ struct MergedDataset::Itl
         //}
 
         if (datasets.empty())
-            throw ML::Exception("Attempt to merge no datasets together");
+            throw MLDB::Exception("Attempt to merge no datasets together");
 
 
         std::sort(datasets.begin(), datasets.end(),
@@ -278,7 +278,7 @@ struct MergedDataset::Itl
     {
         uint32_t bitmap = getRowBitmap(rowHash);
         if (!bitmap)
-            throw ML::Exception("Row not known");
+            throw MLDB::Exception("Row not known");
 
         int bit = ML::lowest_bit(bitmap, -1);
         return datasets[bit]->getMatrixView()->getRowPath(rowHash);
@@ -288,7 +288,7 @@ struct MergedDataset::Itl
     {
         uint32_t bitmap = getRowBitmap(rowName);
         if (!bitmap)
-            throw ML::Exception("Row not known");
+            throw MLDB::Exception("Row not known");
 
         int bit = ML::lowest_bit(bitmap, -1);
         MatrixNamedRow result = datasets[bit]->getMatrixView()->getRow(rowName);
@@ -319,7 +319,7 @@ struct MergedDataset::Itl
         uint32_t bitmap = getColumnBitmap(columnHash);
 
         if (bitmap == 0)
-            throw ML::Exception("Column not found in merged dataset");
+            throw MLDB::Exception("Column not found in merged dataset");
 
         int bit = ML::lowest_bit(bitmap, -1);
 
@@ -352,7 +352,7 @@ struct MergedDataset::Itl
     {
         uint32_t bitmap = getColumnBitmap(columnName);
         if (!bitmap)
-            throw ML::Exception("Column not known");
+            throw MLDB::Exception("Column not known");
 
         int bit = ML::lowest_bit(bitmap, -1);
         bitmap = bitmap & ~(1 << bit);
@@ -367,7 +367,7 @@ struct MergedDataset::Itl
 
         // TODO: fill in the stats...
 
-        throw ML::Exception("MergedDataset::getColumnStats() not finished");
+        throw MLDB::Exception("MergedDataset::getColumnStats() not finished");
     }
 #endif
 
@@ -376,7 +376,7 @@ struct MergedDataset::Itl
     {
         uint32_t bitmap = getColumnBitmap(columnHash);
         if (!bitmap)
-            throw ML::Exception("Column not known");
+            throw MLDB::Exception("Column not known");
 
         int bit = ML::lowest_bit(bitmap, -1);
         MatrixColumn result = datasets[bit]->getColumnIndex()->getColumn(columnHash);

--- a/builtin/merged_dataset.h
+++ b/builtin/merged_dataset.h
@@ -50,7 +50,7 @@ struct MergedDataset: public Dataset {
     virtual void recordRowItl(const RowPath & rowName,
           const std::vector<std::tuple<ColumnPath, CellValue, Date> > & vals)
     {
-        throw ML::Exception("Dataset type doesn't allow recording");
+        throw MLDB::Exception("Dataset type doesn't allow recording");
     }
 
     virtual std::shared_ptr<MatrixView> getMatrixView() const;

--- a/builtin/sampled_dataset.cc
+++ b/builtin/sampled_dataset.cc
@@ -42,15 +42,15 @@ SampledDatasetConfig() :
 void validateConfig(SampledDatasetConfig * config)
 {
     if (config->rows != 0 && config->fraction != 0) {
-        throw ML::Exception(SampledDataset::getErrorMsg("The 'rows' and 'fraction' parameters "
+        throw MLDB::Exception(SampledDataset::getErrorMsg("The 'rows' and 'fraction' parameters "
                     "cannot be set at the same time."));
     }
     if (config->rows != 0 && config->fraction != 0) {
-        throw ML::Exception(SampledDataset::getErrorMsg("The 'rows' or 'fraction' parameters "
+        throw MLDB::Exception(SampledDataset::getErrorMsg("The 'rows' or 'fraction' parameters "
                     "need to be set."));
     }
     if(config->rows == 0 && (config->fraction > 1 || config->fraction <= 0)) {
-        throw ML::Exception(SampledDataset::getErrorMsg(ML::format("The 'fraction' parameter needs to "
+        throw MLDB::Exception(SampledDataset::getErrorMsg(MLDB::format("The 'fraction' parameter needs to "
                     "be between 0 and 1. Value provided is '%0.4f'", config->fraction)));
     }
 }
@@ -122,7 +122,7 @@ struct SampledDataset::Itl
                                             : rows.size() * config.fraction;
 
         if(!config.withReplacement && numRows > rows.size()) {
-            throw ML::Exception("Requested more rows without replacement than "
+            throw MLDB::Exception("Requested more rows without replacement than "
                     "available number of rows in original dataset.");
         }
         sampledRowsHash.reserve(numRows);
@@ -157,7 +157,7 @@ struct SampledDataset::Itl
     {
         auto rowName = matrix->getRowPath(row);
         if(!knownRow(rowName))
-            throw ML::Exception("Can't get name of unknown row");
+            throw MLDB::Exception("Can't get name of unknown row");
 
         return rowName;
     }
@@ -244,7 +244,7 @@ struct SampledDataset::Itl
     getTimestampRange() const
     {
         // TODO MLDB-1262
-        throw ML::Exception("not implemented");
+        throw MLDB::Exception("not implemented");
         // return dataset->getTimestampRange();
     }
 
@@ -263,7 +263,7 @@ struct SampledDataset::Itl
         for(auto rowName : sampledRows) {
             auto it = rowIndex.find(rowName);
             if(it == rowIndex.end())
-                throw ML::Exception("Unknown row in index");
+                throw MLDB::Exception("Unknown row in index");
 
             col.rows.emplace_back(allRows[it->second]);
         }
@@ -274,7 +274,7 @@ struct SampledDataset::Itl
     virtual void recordRowItl(const RowPath & rowName,
           const std::vector<std::tuple<ColumnPath, CellValue, Date> > & vals)
     {
-        throw ML::Exception("'sampled' dataset type doesn't allow recording");
+        throw MLDB::Exception("'sampled' dataset type doesn't allow recording");
     }
 
 };

--- a/builtin/sub_dataset.cc
+++ b/builtin/sub_dataset.cc
@@ -50,7 +50,7 @@ struct SubDataset::Itl
     std::vector<NamedRowValue> subOutput;
     std::vector<PathElement> columnNames;
     std::vector<ColumnPath> fullFlattenedColumnNames;
-    ML::Lightweight_Hash<RowHash, int64_t> rowIndex;
+    Lightweight_Hash<RowHash, int64_t> rowIndex;
     Date earliest, latest;
     std::shared_ptr<ExpressionValueInfo> columnInfo;
 

--- a/builtin/transposed_dataset.cc
+++ b/builtin/transposed_dataset.cc
@@ -251,7 +251,7 @@ struct TransposedDataset::Itl
 
         stats = ColumnStats();
 
-        ML::Lightweight_Hash_Set<ColumnHash> columns;
+        Lightweight_Hash_Set<ColumnHash> columns;
         bool oneOnly = true;
         bool isNumeric = true;
 

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -271,7 +271,7 @@ uint64_t
 MatrixView::
 getRowColumnCount(const RowPath & row) const
 {
-    ML::Lightweight_Hash_Set<ColumnHash> cols;
+    Lightweight_Hash_Set<ColumnHash> cols;
     for (auto & c: getRow(row).columns)
         cols.insert(std::get<0>(c));
     return cols.size();
@@ -316,7 +316,7 @@ getColumnStats(const ColumnPath & column, ColumnStats & stats) const
 
     stats = ColumnStats();
 
-    ML::Lightweight_Hash_Set<RowHash> rows;
+    Lightweight_Hash_Set<RowHash> rows;
     bool oneOnly = true;
     bool isNumeric = true;
 
@@ -507,8 +507,8 @@ Dataset(MldbServer * server)
 {
 }
 
-ML::Env_Option<int> RETURN_OS_MEMORY("RETURN_OS_MEMORY", 1);
-ML::Env_Option<int> PRINT_OS_MEMORY("PRINT_OS_MEMORY", 0);
+EnvOption<int> RETURN_OS_MEMORY("RETURN_OS_MEMORY", 1);
+EnvOption<int> PRINT_OS_MEMORY("PRINT_OS_MEMORY", 0);
 
 
 Dataset::
@@ -547,7 +547,7 @@ Dataset::
 recordRowItl(const RowPath & rowName,
              const std::vector<std::tuple<ColumnPath, CellValue, Date> > & vals)
 {
-    throw ML::Exception(("Dataset type '" + getType() + "' doesn't allow recording").rawString());
+    throw MLDB::Exception(("Dataset type '" + getType() + "' doesn't allow recording").rawString());
 }
 
 std::pair<Date, Date>
@@ -579,7 +579,7 @@ getTimestampRange() const
             result.first = std::get<1>(c).toTimestamp();
         else if (std::get<0>(c) == cmax)
             result.second = std::get<1>(c).toTimestamp();
-        else throw ML::Exception("unknown output of timestamp range query");
+        else throw MLDB::Exception("unknown output of timestamp range query");
     }
     
     return result;
@@ -589,7 +589,7 @@ Date
 Dataset::
 quantizeTimestamp(Date timestamp) const
 {
-    throw ML::Exception(("Dataset type '" + getType() + "' doesn't allow recording and thus doesn't quantize timestamps").rawString());
+    throw MLDB::Exception(("Dataset type '" + getType() + "' doesn't allow recording and thus doesn't quantize timestamps").rawString());
 }
 
 void 
@@ -2109,7 +2109,7 @@ handleRequest(RestConnection & connection,
               RestRequestParsingContext & context) const
 {
     Json::Value error;
-    error["error"] = "Dataset of type '" + ML::type_name(*this)
+    error["error"] = "Dataset of type '" + MLDB::type_name(*this)
         + "' does not respond to custom route '" + context.remaining + "'";
     error["details"]["verb"] = request.verb;
     error["details"]["resource"] = request.resource;
@@ -2164,9 +2164,9 @@ template<typename T>
 std::vector<T> frame(std::vector<T> & vec, ssize_t offset, ssize_t limit)
 {
     if (offset < 0)
-        throw ML::Exception("Offset can't be negative");
+        throw MLDB::Exception("Offset can't be negative");
     if (limit < -1)
-        throw ML::Exception("Limit can be positive, 0 or -1");
+        throw MLDB::Exception("Limit can be positive, 0 or -1");
 
     if (offset > vec.size())
         offset = vec.size();

--- a/core/function.cc
+++ b/core/function.cc
@@ -131,7 +131,7 @@ FunctionInfo
 Function::
 getFunctionInfo() const
 {
-    throw HttpReturnException(400, "Function " + ML::type_name(*this)
+    throw HttpReturnException(400, "Function " + MLDB::type_name(*this)
                         + " needs to override getFunctionInfo()");
 }
 
@@ -142,7 +142,7 @@ handleRequest(RestConnection & connection,
               RestRequestParsingContext & context) const
 {
     Json::Value error;
-    error["error"] = "Function of type '" + ML::type_name(*this)
+    error["error"] = "Function of type '" + MLDB::type_name(*this)
         + "' does not respond to custom route '" + context.remaining + "'";
     error["details"]["verb"] = request.verb;
     error["details"]["resource"] = request.resource;

--- a/core/plugin.cc
+++ b/core/plugin.cc
@@ -60,7 +60,7 @@ handleRequest(RestConnection & connection,
               RestRequestParsingContext & context) const
 {
     Json::Value error;
-    error["error"] = "Plugin of type '" + ML::type_name(*this)
+    error["error"] = "Plugin of type '" + MLDB::type_name(*this)
         + "' does not respond to custom route '" + context.remaining + "'";
     error["details"]["verb"] = request.verb;
     error["details"]["resource"] = request.resource;
@@ -165,7 +165,7 @@ struct SharedLibraryPlugin::Itl {
         if (!handle) {
             char * error = dlerror();
             ExcAssert(error);
-            throw ML::Exception("couldn't find plugin library '%s': %s",
+            throw MLDB::Exception("couldn't find plugin library '%s': %s",
                                 path.c_str(), error);
         }
 

--- a/core/value_function.h
+++ b/core/value_function.h
@@ -133,7 +133,7 @@ struct ValueFunctionT: public ValueFunction {
     virtual Output call(Input input) const
     {
         throw HttpReturnException(500, "ValueFunctionT type "
-                                  + ML::type_name(*this)
+                                  + MLDB::type_name(*this)
                                   + " needs to override call()");
     }
 

--- a/ext/svdlibc/las2.cc
+++ b/ext/svdlibc/las2.cc
@@ -1293,7 +1293,7 @@ void imtqlb(long n, double d[], double e[], double bnd[],
 	    g = (d[l+1] - p) / (2.0 * e[l]);
 
             if (!isfinite(g))
-                throw ML::Exception("NaN or infinite g value; probably you "
+                throw MLDB::Exception("NaN or infinite g value; probably you "
                                     "have asked for more singular values than "
                                     "the effective rank of the matrix");
 
@@ -1460,7 +1460,7 @@ void imtql2(long nm, long n, double d[], double e[], double z[],
 	    g = d[m] - p + e[l] / (g + svd_fsign(r, g));
 
             if (!isfinite(g))
-                throw ML::Exception("NaN or infinite g value; probably you "
+                throw MLDB::Exception("NaN or infinite g value; probably you "
                                     "have asked for more singular values than "
                                     "the effective rank of the matrix");
 

--- a/ext/svdlibc/svdlib.cc
+++ b/ext/svdlibc/svdlib.cc
@@ -187,7 +187,7 @@ void svd_opa(SMat A, double *x, double *y) {
     long *pointr = A->pointr, *rowind = A->rowind;
     double *value = A->value;
 
-    //cerr << "svd_opa: x = " << ML::distribution<float>(x, x + A->cols) << endl;
+    //cerr << "svd_opa: x = " << distribution<float>(x, x + A->cols) << endl;
    
     SVDCount[SVD_MXV]++;
     memset(y, 0, A->rows * sizeof(double));
@@ -213,7 +213,7 @@ void svd_opb(SMat A, double *x, double *y) {
 
   double temp[A->rows];
 
-  //cerr << "svd_opb: x = " << ML::distribution<float>(x, x + A->cols) << endl;
+  //cerr << "svd_opb: x = " << distribution<float>(x, x + A->cols) << endl;
 
   SVDCount[SVD_MXV] += 2;
   memset(y, 0, n * sizeof(double));
@@ -233,7 +233,7 @@ void svd_opb(SMat A, double *x, double *y) {
   }
 
   //cerr << "svd_opb: returned "
-  //     << ML::distribution<float>(y, y + A->cols) << endl;
+  //     << distribution<float>(y, y + A->cols) << endl;
 
   return;
 }
@@ -358,7 +358,7 @@ default_store(long n, long isw, long j, double *s)
         svd_fatalError("svdLAS2: failed to allocate LanStore[%d]", j + MAXLL);
     }
     //cerr << "svd_store " << j << ": s = "
-    //     << ML::distribution<float>(s, s + n) << endl;
+    //     << distribution<float>(s, s + n) << endl;
     svd_dcopy(n, s, 1, LanStore[j + MAXLL], 1);
     break;
   case RETRQ:	

--- a/ext/svdlibc/svdutil.cc
+++ b/ext/svdlibc/svdutil.cc
@@ -16,7 +16,7 @@
 
 
 using namespace std;
-
+using namespace MLDB;
 
 
 long *svd_longArray(long size, char empty, const char *name) {
@@ -52,18 +52,18 @@ void svd_error(const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
 
-  string message = ML::vformat(fmt, args);
+  string message = MLDB::vformat(fmt, args);
   va_end(args);
-  throw ML::Exception("SVD Error: " + message);
+  throw MLDB::Exception("SVD Error: " + message);
 }
 
 void svd_fatalError(const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
 
-  string message = ML::vformat(fmt, args);
+  string message = vformat(fmt, args);
   va_end(args);
-  throw ML::Exception("SVD Fatal Error: " + message);
+  throw MLDB::Exception("SVD Fatal Error: " + message);
 }
 
 /************************************************************** 
@@ -369,7 +369,7 @@ double svd_pythag(double a, double b) {
       }
 
       if (iter == 1000) {
-          throw ML::Exception("svd_pythag infinite loop: %f, %f",
+          throw MLDB::Exception("svd_pythag infinite loop: %f, %f",
                           a, b);
       }
    }

--- a/ext/tf_load_kernels.cc
+++ b/ext/tf_load_kernels.cc
@@ -16,9 +16,6 @@
 #include <cassert>
 
 using namespace std;
-#if JML_INTEL_ISA
-using namespace ML;
-#endif
 
 namespace MLDB {
 

--- a/http/curl_wrapper.cc
+++ b/http/curl_wrapper.cc
@@ -23,7 +23,7 @@ namespace CurlWrapper {
 
 
     RuntimeError::RuntimeError(const std::string & what, CURLcode code) :
-        ML::Exception(what), code(code)
+        MLDB::Exception(what), code(code)
     {}
     
     CURLcode RuntimeError::whatCode() const
@@ -68,7 +68,7 @@ namespace CurlWrapper {
     void Easy::add_header_option(const RestParams& headers)
     {
         if (header_list != nullptr)
-            throw ML::Exception("header option has already been set. Call reset to before reusing an Easy object");
+            throw MLDB::Exception("header option has already been set. Call reset to before reusing an Easy object");
         
         for (auto&& header : headers) {
             header_list = curl_slist_append(header_list,

--- a/http/curl_wrapper.h
+++ b/http/curl_wrapper.h
@@ -24,7 +24,7 @@ namespace MLDB
 namespace CurlWrapper {
     class Easy;
 
-    class RuntimeError : public ML::Exception
+    class RuntimeError : public MLDB::Exception
     {
     public:
         RuntimeError(const std::string & reason, CURLcode code);

--- a/http/http_client.cc
+++ b/http/http_client.cc
@@ -51,7 +51,7 @@ HttpClient::
 setHttpClientImplVersion(int version)
 {
     if (version != 1) {
-        throw ML::Exception("invalid value for 'version': "
+        throw MLDB::Exception("invalid value for 'version': "
                             + to_string(version));
     }
     httpClientImplVersion = version;
@@ -66,10 +66,10 @@ HttpClient(LegacyEventLoop & eventLoop,
     bool isHttps(baseUrl.compare(0, 8, "https://") == 0);
 
     if (baseUrl.compare(0, 7, "http://") != 0 && !isHttps) {
-        throw ML::Exception("'url' has an invalid value: " + baseUrl);
+        throw MLDB::Exception("'url' has an invalid value: " + baseUrl);
     }
     if (numParallel < 1) {
-        throw ML::Exception("'numParallel' must at least be equal to 1");
+        throw MLDB::Exception("'numParallel' must at least be equal to 1");
     }
 
     if (implVersion == 0) {
@@ -80,7 +80,7 @@ HttpClient(LegacyEventLoop & eventLoop,
         impl_.reset(new HttpClientImplV1(baseUrl, numParallel, queueSize));
     }
     else {
-        throw ML::Exception("invalid httpclient impl version");
+        throw MLDB::Exception("invalid httpclient impl version");
     }
 
     auto & msgLoop = eventLoop_.loop();
@@ -151,7 +151,7 @@ HttpClient::
 sendExpect100Continue(bool value)
 {
     if (value) {
-        throw ML::Exception("HttpClient has no support for"
+        throw MLDB::Exception("HttpClient has no support for"
                             " 'Expect: 100 Continue' requests");
     }
 }

--- a/http/http_client_callbacks.cc
+++ b/http/http_client_callbacks.cc
@@ -56,7 +56,7 @@ errorMessage(HttpClientError errorCode)
     case HttpClientError::RecvError:
         return recvError;
     default:
-        throw ML::Exception("invalid error code");
+        throw MLDB::Exception("invalid error code");
     };
 }
 

--- a/http/http_client_impl_v1.cc
+++ b/http/http_client_impl_v1.cc
@@ -78,7 +78,7 @@ HttpClientImplV1(const string & baseUrl, int numParallel, int queueSize)
       nextAvail_(0)
 {
     if (queueSize > 0) {
-        throw ML::Exception("'queueSize' semantics not implemented");
+        throw MLDB::Exception("'queueSize' semantics not implemented");
     }
 
     bool success(false);
@@ -88,7 +88,7 @@ HttpClientImplV1(const string & baseUrl, int numParallel, int queueSize)
 
     fd_ = epoll_create1(EPOLL_CLOEXEC);
     if (fd_ == -1) {
-        throw ML::Exception(errno, "epoll_create");
+        throw MLDB::Exception(errno, "epoll_create");
     }
 
     addFd(wakeup_.fd(), false, EPOLLIN);
@@ -115,7 +115,7 @@ HttpClientImplV1(const string & baseUrl, int numParallel, int queueSize)
                                               CURL_SOCKET_TIMEOUT, 0,
                                               &runningHandles);
     if (rc != ::CURLM_OK) {
-        throw ML::Exception("curl error " + to_string(rc));
+        throw MLDB::Exception("curl error " + to_string(rc));
     }
 
     success = true;
@@ -182,7 +182,7 @@ addFd(int fd, bool isMod, int flags)
     }
     if (rc == -1) {
 	if (errno != EBADF) {
-            throw ML::Exception(errno, "epoll_ctl");
+            throw MLDB::Exception(errno, "epoll_ctl");
         }
     }
 }
@@ -282,7 +282,7 @@ processOne()
                 continue;
             }
             else {
-                throw ML::Exception(errno, "epoll_wait");
+                throw MLDB::Exception(errno, "epoll_wait");
             }
         }
     }
@@ -323,7 +323,7 @@ handleWakeupEvent()
             CURLMcode code = ::curl_multi_add_handle(multi_.get(),
                                                      conn->easy_);
             if (code != CURLM_CALL_MULTI_PERFORM && code != CURLM_OK) {
-                throw ML::Exception("failing to add handle to multi");
+                throw MLDB::Exception("failing to add handle to multi");
             }
         }
     }
@@ -337,7 +337,7 @@ handleTimerEvent()
     ssize_t len = ::read(timerFd_, &misses, sizeof(misses));
     if (len == -1) {
         if (errno != EAGAIN) {
-            throw ML::Exception(errno, "read timerd");
+            throw MLDB::Exception(errno, "read timerd");
         }
     }
     int runningHandles;
@@ -345,7 +345,7 @@ handleTimerEvent()
                                               CURL_SOCKET_TIMEOUT, 0,
                                               &runningHandles);
     if (rc != ::CURLM_OK) {
-        throw ML::Exception("curl error " + to_string(rc));
+        throw MLDB::Exception("curl error " + to_string(rc));
     }
     checkMultiInfos();
 }
@@ -367,7 +367,7 @@ handleMultiEvent(const ::epoll_event & event)
                                               actionFlags,
                                               &runningHandles);
     if (rc != ::CURLM_OK) {
-        throw ML::Exception("curl error " + to_string(rc));
+        throw MLDB::Exception("curl error " + to_string(rc));
     }
 
     checkMultiInfos();
@@ -392,7 +392,7 @@ checkMultiInfos()
             CURLMcode code = ::curl_multi_remove_handle(multi_.get(),
                                                         conn->easy_);
             if (code != CURLM_CALL_MULTI_PERFORM && code != CURLM_OK) {
-                throw ML::Exception("failed to remove handle to multi");
+                throw MLDB::Exception("failed to remove handle to multi");
             }
             releaseConnection(conn);
             wakeup_.signal();
@@ -430,7 +430,7 @@ onCurlSocketEvent(CURL *e, curl_socket_t fd, int what, void *sockp)
         if (sockp == nullptr) {
             CURLMcode rc = ::curl_multi_assign(multi_.get(), fd, this);
             if (rc != ::CURLM_OK) {
-                throw ML::Exception("curl error " + to_string(rc));
+                throw MLDB::Exception("curl error " + to_string(rc));
             }
         }
     }
@@ -454,7 +454,7 @@ onCurlTimerEvent(long timeoutMs)
     // cerr << "onCurlTimerEvent: timeout = " + to_string(timeoutMs) + "\n";
 
     if (timeoutMs < -1) {
-        throw ML::Exception("unhandled timeout value: %ld", timeoutMs);
+        throw MLDB::Exception("unhandled timeout value: %ld", timeoutMs);
     }
 
     struct itimerspec timespec;
@@ -465,7 +465,7 @@ onCurlTimerEvent(long timeoutMs)
     }
     int res = ::timerfd_settime(timerFd_, 0, &timespec, nullptr);
     if (res == -1) {
-        throw ML::Exception(errno, "timerfd_settime");
+        throw MLDB::Exception(errno, "timerfd_settime");
     }
 
     if (timeoutMs == 0) {
@@ -474,7 +474,7 @@ onCurlTimerEvent(long timeoutMs)
                                                   CURL_SOCKET_TIMEOUT, 0,
                                                   &runningHandles);
         if (rc != ::CURLM_OK) {
-            throw ML::Exception("curl error " + to_string(rc));
+            throw MLDB::Exception("curl error " + to_string(rc));
         }
         checkMultiInfos();
     }
@@ -616,14 +616,14 @@ onCurlHeader(const char * data, size_t size)
             size_t oldTokenIdx(0);
             size_t tokenIdx = headerLine.find(" ");
             if (tokenIdx == string::npos || tokenIdx >= lineSize) {
-                throw ML::Exception("malformed header");
+                throw MLDB::Exception("malformed header");
             }
             string version = headerLine.substr(oldTokenIdx, tokenIdx);
 
             oldTokenIdx = tokenIdx + 1;
             tokenIdx = headerLine.find(" ", oldTokenIdx);
             if (tokenIdx == string::npos || tokenIdx >= lineSize) {
-                throw ML::Exception("malformed header");
+                throw MLDB::Exception("malformed header");
             }
             int code = stoi(headerLine.substr(oldTokenIdx, tokenIdx));
 

--- a/http/http_exception.h
+++ b/http/http_exception.h
@@ -20,15 +20,15 @@ namespace MLDB {
 /// the outer exception.
 constexpr int KEEP_HTTP_CODE = -1;
 
-struct HttpReturnException: public ML::Exception {
+struct HttpReturnException: public MLDB::Exception {
     HttpReturnException(int httpCode, const Utf8String & message, Any details = Any())
-        : ML::Exception(message.rawData()), message(message), httpCode(httpCode), details(details)
+        : MLDB::Exception(message.rawData()), message(message), httpCode(httpCode), details(details)
     {
     }
 
 #if 0
     HttpReturnException(int httpCode, const std::string & message, Any details = Any())
-        : ML::Exception(message), message(message), httpCode(httpCode),details(details)
+        : MLDB::Exception(message), message(message), httpCode(httpCode),details(details)
     {
     }
 #endif
@@ -68,7 +68,7 @@ struct HttpReturnException: public ML::Exception {
     HttpReturnException(int httpCode, const std::string & message,
                         const Str & key, Val&& val,
                         OtherKeyValuePairs&&... otherKeyValuePairs)
-        : ML::Exception(message), message(message), httpCode(httpCode)
+        : MLDB::Exception(message), message(message), httpCode(httpCode)
     {
         Json::Value ourDetails;
         addListToDetails(ourDetails, key, std::forward<Val>(val),
@@ -81,7 +81,7 @@ struct HttpReturnException: public ML::Exception {
     HttpReturnException(int httpCode, const Utf8String & message,
                         const Str & key, Val&& val,
                         OtherKeyValuePairs&&... otherKeyValuePairs)
-        : ML::Exception(message.rawData()), message(message), httpCode(httpCode)
+        : MLDB::Exception(message.rawData()), message(message), httpCode(httpCode)
     {
         Json::Value ourDetails;
         addListToDetails(ourDetails, key, std::forward<Val>(val),

--- a/http/http_header.cc
+++ b/http/http_header.cc
@@ -15,7 +15,6 @@
 #include "mldb/types/pair_description.h"
 
 using namespace std;
-using namespace ML;
 
 
 namespace {
@@ -82,7 +81,7 @@ uriEscaped() const
             for (char c: str.rawString()) {
                 if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
                     result += c;
-                else result += ML::format("%%%02x", c);
+                else result += MLDB::format("%%%02x", c);
             }
             return result;
         };
@@ -133,7 +132,7 @@ struct RestParamsDescription: public ValueDescriptionT<RestParams> {
     virtual void parseJsonTyped(RestParams * val,
                                 JsonParsingContext & context) const
     {
-        throw ML::Exception("Can't parse JSON for RestParams");
+        throw MLDB::Exception("Can't parse JSON for RestParams");
     }
 
     virtual void printJsonTyped(const RestParams * val,
@@ -172,7 +171,7 @@ swap(HttpHeader & other)
 namespace {
 
 std::string
-expectUrlEncodedString(ML::Parse_Context & context,
+expectUrlEncodedString(ParseContext & context,
                        string delimiters)
 {
     string result;
@@ -230,7 +229,7 @@ parse(const std::string & headerAndData, bool checkBodyLength)
         HttpHeader parsed;
 
         // Parse http
-        ML::Parse_Context context("request header",
+        ParseContext context("request header",
                                   headerAndData.c_str(),
                                   headerAndData.c_str()
                                       + headerAndData.length());
@@ -274,7 +273,7 @@ parse(const std::string & headerAndData, bool checkBodyLength)
                     c = tolower(c);
 
                 if (transferEncoding != "chunked")
-                    throw ML::Exception("unknown transfer-encoding");
+                    throw MLDB::Exception("unknown transfer-encoding");
                 parsed.isChunked = true;
             }
             else {
@@ -392,7 +391,7 @@ getHeader(const std::string & key) const
 {
     auto it = headers.find(key);
     if (it == headers.end())
-        throw ML::Exception("couldn't find header " + key);
+        throw MLDB::Exception("couldn't find header " + key);
     return it->second;
 }
 

--- a/http/http_monitor.h
+++ b/http/http_monitor.h
@@ -185,7 +185,7 @@ HttpMonitorHandler<Handler, arg>::
 sendErrorResponse(int code, const Json::Value & error)
 {
     std::string encodedError = error.toString();
-    send(ML::format("HTTP/1.1 %d Pants are on fire\r\n"
+    send(MLDB::format("HTTP/1.1 %d Pants are on fire\r\n"
                     "Content-Type: application/json\r\n"
                     "Access-Control-Allow-Origin: *\r\n"
                     "Content-Length: %zd\r\n"
@@ -210,7 +210,7 @@ sendResponse(const Json::Value & response)
          "sendResponse");
     };
 
-    send(ML::format("HTTP/1.1 200 OK\r\n"
+    send(MLDB::format("HTTP/1.1 200 OK\r\n"
                     "Content-Type: application/json\r\n"
                     "Access-Control-Allow-Origin: *\r\n"
                     "Content-Length: %zd\r\n"

--- a/http/http_parsers.cc
+++ b/http/http_parsers.cc
@@ -22,7 +22,7 @@ using namespace MLDB;
 /* HTTP PARSER :: BUFFER STATE                                              */
 /****************************************************************************/
 
-struct HttpParser::BufferState : public ML::Parse_Context {
+struct HttpParser::BufferState : public ParseContext {
     BufferState(const char * start, size_t length, bool fromBuffer);
 
     /* skip as many characters as possible until character "c" is found */
@@ -68,7 +68,7 @@ antoi(const char * start, const char * end, int base = 10)
             neg = true;
         }
         else {
-            throw ML::Exception("Cannot negate non base 10");
+            throw MLDB::Exception("Cannot negate non base 10");
         }
         start++;
     }
@@ -88,11 +88,11 @@ antoi(const char * start, const char * end, int base = 10)
             digit = *ptr - 'a' + 10;
         }
         else {
-            throw ML::Exception("expected digit");
+            throw MLDB::Exception("expected digit");
         }
         if (digit > base) {
             intptr_t offset = ptr - start;
-            throw ML::Exception("digit '%c' (%d) exceeds base '%d'"
+            throw MLDB::Exception("digit '%c' (%d) exceeds base '%d'"
                                 " at offset '%d'",
                                 *ptr, digit, base, offset);
         }
@@ -225,9 +225,9 @@ parseHeaders(BufferState & state)
     string multiline;
     unsigned int numLines(0);
 
-    std::unique_ptr<ML::Parse_Context::Revert_Token> token;
+    std::unique_ptr<ParseContext::Revert_Token> token;
 
-    token.reset(new ML::Parse_Context::Revert_Token(state));
+    token.reset(new ParseContext::Revert_Token(state));
 
     /* header line parsing */
     while (*state != '\r' || numLines > 0) {
@@ -264,7 +264,7 @@ parseHeaders(BufferState & state)
                 numLines = 0;
             }
             token->ignore();
-            token.reset(new ML::Parse_Context::Revert_Token(state));
+            token.reset(new ParseContext::Revert_Token(state));
         }
     }
     if (state.get_offset() + 1 == state.total_buffered()) {
@@ -370,7 +370,7 @@ parseChunkedBody(BufferState & state)
 
     /* we loop as long as there are chunks to process */
     while (chunkSize != 0) {
-        ML::Parse_Context::Revert_Token token(state);
+        ParseContext::Revert_Token token(state);
         const char * sizeStart = state.get_offset_ptr();
         if (!state.skip_to_char('\r', false)) {
             return false;
@@ -411,7 +411,7 @@ bool
 HttpParser::
 parseBlockBody(BufferState & state)
 {
-    ML::Parse_Context::Revert_Token token(state);
+    ParseContext::Revert_Token token(state);
 
     size_t chunkSize = min<size_t>(state.readahead_available(), remainingBody_);
     // cerr << "toSend: " + to_string(chunkSize) + "\n";
@@ -443,7 +443,7 @@ finalizeParsing()
 
 HttpParser::BufferState::
 BufferState(const char * start, size_t length, bool fromBuffer)
-    : ML::Parse_Context(ML::Parse_Context::CONSOLE, start, start + length),
+    : ParseContext(ParseContext::CONSOLE, start, start + length),
       start_(start), fromBuffer_(fromBuffer)
 {
 }
@@ -457,7 +457,7 @@ skip_to_char(char c, bool throwOnEol)
             return true;
         }
         else if (throwOnEol && match_eol(false)) {
-            throw ML::Exception("unexpected end of line");
+            throw MLDB::Exception("unexpected end of line");
         }
         operator ++();
     }
@@ -481,14 +481,14 @@ parseFirstLine(BufferState & state)
         return false;
     }
 
-    ML::Parse_Context::Revert_Token token(state);
+    ParseContext::Revert_Token token(state);
     if (!state.match_literal_str("HTTP/", 5)) {
-        throw ML::Exception("version must start with 'HTTP/'");
+        throw MLDB::Exception("version must start with 'HTTP/'");
     }
 
     if (!state.skip_to_char(' ', true)) {
         /* post-version ' ' not found even though size is sufficient */
-        throw ML::Exception("version too long");
+        throw MLDB::Exception("version too long");
     }
     size_t versionEnd = state.get_offset();
 
@@ -496,7 +496,7 @@ parseFirstLine(BufferState & state)
     const char * codeStartPtr = state.get_offset_ptr();
     if (!state.skip_to_char(' ', true)) {
         /* post-code ' ' not found even though size is sufficient */
-        throw ML::Exception("code too long");
+        throw MLDB::Exception("code too long");
     }
     const char * codeEndPtr = state.get_offset_ptr();
     int code = antoi(codeStartPtr, codeEndPtr);
@@ -530,7 +530,7 @@ parseFirstLine(BufferState & state)
 {
     /* request line parsing */
 
-    ML::Parse_Context::Revert_Token token(state);
+    ParseContext::Revert_Token token(state);
     size_t methodStart = state.get_offset();
     if (!state.skip_to_char(' ', true)) {
         return false;
@@ -546,7 +546,7 @@ parseFirstLine(BufferState & state)
     state++;
 
     if (!state.match_literal_str("HTTP/", 5)) {
-        throw ML::Exception("version must start with 'HTTP/'");
+        throw MLDB::Exception("version must start with 'HTTP/'");
     }
     size_t versionStart = urlStart + urlSize + 1;
     /* we skip the whole "reason" string */

--- a/http/http_rest_proxy.cc
+++ b/http/http_rest_proxy.cc
@@ -20,7 +20,6 @@
 #include "http_rest_proxy_impl.h"
 
 using namespace std;
-using namespace ML;
 
 
 namespace MLDB {
@@ -70,7 +69,7 @@ getHeader(const std::string & name) const
 {
     auto p = hasHeader(name);
     if (!p)
-        throw ML::Exception("required header " + name + " not found");
+        throw MLDB::Exception("required header " + name + " not found");
     return p->second;
 }
 
@@ -134,7 +133,7 @@ urlEncode(const std::string & str)
                 
         if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
             result += c;
-        else result += ML::format("%%%02X", c);
+        else result += MLDB::format("%%%02X", c);
     }
     return result;
 }
@@ -149,7 +148,7 @@ urlEncode(const Utf8String & str)
                 
         if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
             result += c;
-        else result += ML::format("%%%02X", c);
+        else result += MLDB::format("%%%02X", c);
     }
     return result;
 }
@@ -408,7 +407,7 @@ perform(const std::string & verb,
         if (content.data) {
             myRequest.add_option(CURLOPT_POSTFIELDSIZE, content.size);
             myRequest.add_data_option(CURLOPT_POSTFIELDS, content.data);
-            curlHeaders.emplace_back(make_pair("Content-Length", ML::format("%lld", content.size)));
+            curlHeaders.emplace_back(make_pair("Content-Length", MLDB::format("%lld", content.size)));
             curlHeaders.emplace_back(make_pair("Content-Type", content.contentType));
         }
         else {

--- a/http/http_socket_handler.cc
+++ b/http/http_socket_handler.cc
@@ -107,7 +107,7 @@ onReceivedData(const char * data, size_t size)
         parser_.feed(data, size);
         requestReceive();
     }
-    catch (const ML::Exception & exc) {
+    catch (const MLDB::Exception & exc) {
         requestClose();
     }
 }
@@ -121,7 +121,7 @@ onReceiveError(const boost::system::error_code & ec, size_t bufferSize)
         requestClose();
     }
     else {
-        throw ML::Exception("unhandled error: " + ec.message());
+        throw MLDB::Exception("unhandled error: " + ec.message());
     }
 }
 

--- a/http/testing/MLDB-1016-http-connection-overflow.cc
+++ b/http/testing/MLDB-1016-http-connection-overflow.cc
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE( test_connection_overflow )
         if (res == 0)
             break;
         if (res == -1)
-            throw ML::Exception(errno, "Failed to read()");
+            throw MLDB::Exception(errno, "Failed to read()");
         bytesRead += res;
     }
 

--- a/http/testing/http_client_bench.cc
+++ b/http/testing/http_client_bench.cc
@@ -193,14 +193,14 @@ int main(int argc, char *argv[])
     }
 
     if (concurrency == 0) {
-        throw ML::Exception("'concurrency' must be specified");
+        throw MLDB::Exception("'concurrency' must be specified");
     }
     if (serverConcurrency == 0) {
         serverConcurrency = concurrency;
     }
 
     if (payloadSize == 0) {
-        throw ML::Exception("'payload-size' must be specified");
+        throw MLDB::Exception("'payload-size' must be specified");
     }
 
     string payload;
@@ -228,11 +228,11 @@ int main(int argc, char *argv[])
     if (clientiface != "none") {
         cerr << "launching client\n";
         if (maxReqs == 0) {
-            throw ML::Exception("'max-reqs' must be specified");
+            throw MLDB::Exception("'max-reqs' must be specified");
         }
 
         if (!(method == "GET" || method == "POST" || method == "PUT")) {
-            throw ML::Exception("invalid method:" + method);
+            throw MLDB::Exception("invalid method:" + method);
         }
 
         string baseUrl;
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
             httpMethod = PUT;
         }
         else {
-            throw ML::Exception("unknown method: "  + method);
+            throw MLDB::Exception("unknown method: "  + method);
         }
 
         double delta;
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
             delta = ThreadedModelBench(httpMethod, baseUrl, payload, maxReqs, concurrency);
         }
         else {
-            throw ML::Exception("invalid 'model'");
+            throw MLDB::Exception("invalid 'model'");
         }
         double qps = maxReqs / delta;
         double bps = double(maxReqs * payload.size()) / delta;

--- a/http/testing/http_client_test.cc
+++ b/http/testing/http_client_test.cc
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE( test_http_client_put_multi )
     auto makeBody = [&] (size_t i) {
         int multiplier = (i < maxRequests / 2) ? -2 : 2;
         size_t bodySize = 2000 + multiplier * i;
-        string body = ML::format("%.4x", bodySize);
+        string body = MLDB::format("%.4x", bodySize);
         size_t rndSize = bodySize - body.size();
         body += randomString(rndSize);
 

--- a/http/testing/http_long_header_test.cc
+++ b/http/testing/http_long_header_test.cc
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE( test_accept_speed )
 
             bytesDone += data.size();
             if (bytesDone > 1000000)
-                throw ML::Exception("allowed infinite headers");
+                throw MLDB::Exception("allowed infinite headers");
             HttpConnectionHandler::handleData(data);
         }
 
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE( test_accept_speed )
         if (res > 0)
             written += res;
         else if (res == 0)
-            throw ML::Exception("nothing written");
+            throw MLDB::Exception("nothing written");
         else {
             writeError = errno;
             cerr << strerror(errno) << endl;

--- a/http/testing/http_parsers_test.cc
+++ b/http/testing/http_parsers_test.cc
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE( test_bad_request2 )
     HttpHeader header;
     header.parse(badRequest);
     JML_TRACE_EXCEPTIONS(false);
-    BOOST_CHECK_THROW(jsonDecodeStr<Json::Value>(header.knownData), ML::Parse_Context::Exception);
+    BOOST_CHECK_THROW(jsonDecodeStr<Json::Value>(header.knownData), ParseContext::Exception);
     BOOST_CHECK_THROW(Json::Value val2 = Json::parse(header.knownData), Json::Exception);
 }
 
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE( http_request_100_continue_test )
     /* we get an exception because the parser expects a valid request first
        line after the rejection of the expectation. */
     JML_TRACE_EXCEPTIONS(false);
-    BOOST_CHECK_THROW(parser.feed(requestBody), ML::Exception);
+    BOOST_CHECK_THROW(parser.feed(requestBody), MLDB::Exception);
 }
 #endif
 

--- a/io/asio_timer.cc
+++ b/io/asio_timer.cc
@@ -25,7 +25,7 @@ StrandHolder::
 init(void * strand, const std::type_info * type)
 {
     if (type != &typeid(boost::asio::strand))
-        throw ML::Exception("StrandHolder initialized from " + ML::demangle(type->name()) + " not boost::asio::strand");
+        throw MLDB::Exception("StrandHolder initialized from " + demangle(type->name()) + " not boost::asio::strand");
     this->strand = strand;
 }
 
@@ -197,7 +197,7 @@ struct AsioTimer::Impl {
                      << " strand " << state->strand
                      << endl;
                 if (!doneBacktrace) {
-                    ML::backtrace();
+                    backtrace();
                     doneBacktrace = true;
                 }
             }

--- a/io/async_event_source.cc
+++ b/io/async_event_source.cc
@@ -74,7 +74,7 @@ init(double timePeriodSeconds,
      bool singleThreaded)
 {
     if (timerFd != -1)
-        throw ML::Exception("double initialization of periodic event source");
+        throw MLDB::Exception("double initialization of periodic event source");
 
     this->timePeriodSeconds = timePeriodSeconds;
     this->onTimeout = onTimeout;
@@ -82,13 +82,13 @@ init(double timePeriodSeconds,
 
     timerFd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
     if (timerFd == -1)
-        throw ML::Exception(errno, "timerfd_create");
+        throw MLDB::Exception(errno, "timerfd_create");
 
     itimerspec spec;
     
     int res = clock_gettime(CLOCK_MONOTONIC, &spec.it_value);
     if (res == -1)
-        throw ML::Exception(errno, "clock_gettime");
+        throw MLDB::Exception(errno, "clock_gettime");
     uint64_t seconds, nanoseconds;
     seconds = timePeriodSeconds;
     nanoseconds = (timePeriodSeconds - seconds) * 1000000000;
@@ -111,7 +111,7 @@ init(double timePeriodSeconds,
 
     res = timerfd_settime(timerFd, 0, &spec, 0);
     if (res == -1)
-        throw ML::Exception(errno, "timerfd_settime");
+        throw MLDB::Exception(errno, "timerfd_settime");
 }
 
 PeriodicEventSource::
@@ -140,9 +140,9 @@ processOne()
         if (res == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
             break;
         if (res == -1)
-            throw ML::Exception(errno, "timerfd read");
+            throw MLDB::Exception(errno, "timerfd read");
         else if (res != 8)
-            throw ML::Exception("timerfd read: wrong number of bytes: %d",
+            throw MLDB::Exception("timerfd read: wrong number of bytes: %d",
                                 res);
         onTimeout(numWakeups);
         break;

--- a/io/async_event_source.h
+++ b/io/async_event_source.h
@@ -108,7 +108,7 @@ struct AsyncEventSource {
     virtual void connected(MessageLoop * parent)
     {
         if (parent_)
-            throw ML::Exception("attempt to connect AsyncEventSource "
+            throw MLDB::Exception("attempt to connect AsyncEventSource "
                                 "to two parents");
         parent_ = parent;
     }

--- a/io/async_writer_source.cc
+++ b/io/async_writer_source.cc
@@ -70,10 +70,10 @@ AsyncWriterSource::
 setFd(int newFd)
 {
     if (fd_ != -1) {
-        throw ML::Exception("fd already set: %d", fd_);
+        throw MLDB::Exception("fd already set: %d", fd_);
     }
     if (!isFileFlagSet(newFd, O_NONBLOCK)) {
-        throw ML::Exception("file decriptor is blocking");
+        throw MLDB::Exception("file decriptor is blocking");
     }
 
     addFd(queue_.selectFd(), true, false);
@@ -112,7 +112,7 @@ write(string data, const OnWriteResult & onWriteResult)
         result = queue_.push_back(AsyncWrite(move(data), onWriteResult));
     }
     else {
-        throw ML::Exception("cannot write while queue is disabled");
+        throw MLDB::Exception("cannot write while queue is disabled");
     }
 
     return result;
@@ -155,7 +155,7 @@ handleReadReady()
                 break;
             }
             if (s == -1) {
-                throw ML::Exception(errno, "read");
+                throw MLDB::Exception(errno, "read");
             }
             else {
                 break;
@@ -214,7 +214,7 @@ requestClose()
         queue_.push_back(AsyncWrite("", nullptr));
     }
     else {
-        throw ML::Exception("already closed/ing\n");
+        throw MLDB::Exception("already closed/ing\n");
     }
 }
 
@@ -301,7 +301,7 @@ flush()
                 /* This exception indicates a lack of code in the handling of
                    errno. In a perfect world, it should never ever be
                    thrown. */
-                throw ML::Exception(errno, "unhandled write error");
+                throw MLDB::Exception(errno, "unhandled write error");
             }
         }
     }

--- a/io/epoll_loop.cc
+++ b/io/epoll_loop.cc
@@ -26,7 +26,7 @@ EpollLoop(const OnException & onException)
 {
     epollFd_ = ::epoll_create(666);
     if (epollFd_ == -1)
-        throw ML::Exception(errno, "epoll_create");
+        throw MLDB::Exception(errno, "epoll_create");
 }
 
 EpollLoop:: 
@@ -64,7 +64,7 @@ loop(int maxEvents, int timeout)
                     if (errno == EINTR) {
                         continue;
                     }
-                    throw ML::Exception(errno, "epoll_wait");
+                    throw MLDB::Exception(errno, "epoll_wait");
                 }
                 break;
             }
@@ -135,7 +135,7 @@ performAddFd(int fd, bool readerFd, bool writerFd, bool modify, bool oneshot)
                           + " fd=" + to_string(fd)
                           + " readerFd=" + to_string(readerFd)
                           + " writerFd=" + to_string(writerFd));
-        throw ML::Exception(errno, message);
+        throw MLDB::Exception(errno, message);
     }
 
     if (!modify) {
@@ -153,10 +153,10 @@ removeFd(int fd, bool unregisterCallback)
 
     int res = epoll_ctl(epollFd_, EPOLL_CTL_DEL, fd, 0);
     if (res == -1) {
-        throw ML::Exception(errno, "epoll_ctl DEL " + to_string(fd));
+        throw MLDB::Exception(errno, "epoll_ctl DEL " + to_string(fd));
     }
     if (numFds_ == 0) {
-        throw ML::Exception("inconsistent number of fds registered");
+        throw MLDB::Exception("inconsistent number of fds registered");
     }
     numFds_--;
 
@@ -172,7 +172,7 @@ registerFdCallback(int fd, const EpollCallback & cb)
     std::unique_lock<mutex> guard(callbackLock_);
     if (delayedUnregistrations_.count(fd) == 0) {
         if (fdCallbacks_.find(fd) != fdCallbacks_.end()) {
-            throw ML::Exception("callback already registered for fd");
+            throw MLDB::Exception("callback already registered for fd");
         }
     }
     else {
@@ -188,7 +188,7 @@ unregisterFdCallback(int fd, bool delayed,
 {
     std::unique_lock<mutex> guard(callbackLock_);
     if (fdCallbacks_.find(fd) == fdCallbacks_.end()) {
-        throw ML::Exception("callback not registered for fd");
+        throw MLDB::Exception("callback not registered for fd");
     }
     if (delayed) {
         ExcAssert(delayedUnregistrations_.count(fd) == 0);

--- a/io/epoller.cc
+++ b/io/epoller.cc
@@ -18,7 +18,6 @@
 #include "mldb/types/date.h"
 
 using namespace std;
-using namespace ML;
 
 namespace MLDB {
 
@@ -52,7 +51,7 @@ init(int maxFds, int timeout)
 
     epoll_fd = epoll_create(maxFds);
     if (epoll_fd == -1)
-        throw ML::Exception(errno, "EndpointBase epoll_create()");
+        throw MLDB::Exception(errno, "EndpointBase epoll_create()");
 
     timeout_ = timeout;
 }
@@ -79,7 +78,7 @@ removeFd(int fd)
     
     if (res == -1) {
         if (errno != EBADF)
-            throw ML::Exception("epoll_ctl DEL fd %d: %s", fd,
+            throw MLDB::Exception("epoll_ctl DEL fd %d: %s", fd,
                                 strerror(errno));
     }
 
@@ -87,7 +86,7 @@ removeFd(int fd)
         numFds_--;
     }
     else {
-        throw ML::Exception("too many file descriptors removed");
+        throw MLDB::Exception("too many file descriptors removed");
     }
 }
 
@@ -110,7 +109,7 @@ handleEvents(int usToWait, int nEvents,
         = afterSleep_ ? afterSleep_ : this->afterSleep;
 
     if (nEvents <= 0)
-        throw ML::Exception("can't wait for no events");
+        throw MLDB::Exception("can't wait for no events");
 
     if (nEvents > MaxEvents)
         nEvents = MaxEvents;
@@ -181,7 +180,7 @@ poll() const
         if (res == -1 && errno == EINTR)
             continue;
         if (res == -1)
-            throw ML::Exception("ppoll in Epoller::poll");
+            throw MLDB::Exception("ppoll in Epoller::poll");
 
         return res > 0;
     }
@@ -213,7 +212,7 @@ performAddFd(int fd, void * data, bool oneshot, bool restart)
     int res = epoll_ctl(epoll_fd, action, fd, &event);
 
     if (res == -1)
-        throw ML::Exception("epoll_ctl: %s (fd=%d, epollfd=%d, oneshot=%d,"
+        throw MLDB::Exception("epoll_ctl: %s (fd=%d, epollfd=%d, oneshot=%d,"
                             " restart=%d)",
                             strerror(errno), fd, epoll_fd, oneshot, restart);
 }

--- a/io/message_loop.cc
+++ b/io/message_loop.cc
@@ -100,7 +100,7 @@ MessageLoop::
 start(const OnStop & onStop)
 {
     if (numThreadsCreated)
-        throw ML::Exception("already have started message loop");
+        throw MLDB::Exception("already have started message loop");
 
     shutdown_ = false;
 
@@ -122,7 +122,7 @@ MessageLoop::
 startSync()
 {
     if (numThreadsCreated)
-        throw ML::Exception("already have started message loop");
+        throw MLDB::Exception("already have started message loop");
 
     ++numThreadsCreated;
 
@@ -172,7 +172,7 @@ addSource(const std::string & name,
     }
 
     // cerr << "addSource: " << source.get()
-    //      << " (" << ML::type_name(*source) << ")"
+    //      << " (" << MLDB::type_name(*source) << ")"
     //      << " needsPoll: " << source->needsPoll
     //      << " in msg loop: " << this
     //      << " needsPoll: " << needsPoll
@@ -255,7 +255,7 @@ runWorkerThread()
 {
     Date lastCheck = Date::now();
 
-    ML::Duty_Cycle_Timer duty;
+    Duty_Cycle_Timer duty;
 
     while (!shutdown_) {
         Date start = Date::now();
@@ -369,14 +369,14 @@ handleEpollEvent(epoll_event & event)
     if (debug) {
         ExcAssert(source->poll());
         cerr << "message loop " << this << " with parent " << parent_
-             << " handing source " << ML::type_name(*source) << " poll result "
+             << " handing source " << MLDB::type_name(*source) << " poll result "
              << Epoller::poll() << endl;
     }
 
     int res = source->processOne();
 
     if (debug) {
-        cerr << "source " << ML::type_name(*source) << " had processOne() result " << res << endl;
+        cerr << "source " << MLDB::type_name(*source) << " had processOne() result " << res << endl;
         cerr << "poll() is now " << Epoller::poll() << endl;
     }
 
@@ -409,7 +409,7 @@ processAddSource(const SourceEntry & entry)
         return;
 
     // cerr << "processAddSource: " << entry.source.get()
-    //      << " (" << ML::type_name(*entry.source) << ")"
+    //      << " (" << MLDB::type_name(*entry.source) << ")"
     //      << " needsPoll: " << entry.source->needsPoll
     //      << " in msg loop: " << this
     //      << " needsPoll: " << needsPoll

--- a/io/message_loop.h
+++ b/io/message_loop.h
@@ -146,7 +146,7 @@ private:
     
     void wakeupMainThread();
 
-    typedef ML::Spinlock Lock;
+    typedef Spinlock Lock;
     typedef std::lock_guard<Lock> Guard;
 
     struct SourceEntry

--- a/io/port_range_service.cc
+++ b/io/port_range_service.cc
@@ -17,7 +17,6 @@
 #include <cstring>
 
 using namespace std;
-using namespace ML;
 
 namespace MLDB {
 
@@ -56,7 +55,7 @@ fromJson(const Json::Value & val)
             return PortRange(first, last);
         }
     }
-    throw ML::Exception("unknown port range " + val.toString());
+    throw MLDB::Exception("unknown port range " + val.toString());
 }
 
 

--- a/io/port_range_service.h
+++ b/io/port_range_service.h
@@ -44,27 +44,27 @@ struct PortRange
         char * endPtr = 0;
         first = strtol(rangeSpec.c_str(), &endPtr, 10);
         if (errno)
-            throw ML::Exception(errno, "strtol() parsing first port in '" + rangeSpec + "'");
+            throw MLDB::Exception(errno, "strtol() parsing first port in '" + rangeSpec + "'");
         if (first <= 0 || first >= 65536)
-            throw ML::Exception("first port number %d out of range parsing '%s'",
+            throw MLDB::Exception("first port number %d out of range parsing '%s'",
                                 first, rangeSpec.c_str());
         if (*endPtr == 0) {
             last = first + 1;
             return;
         }
         else if (*endPtr != '-')
-            throw ML::Exception("Range spec is <int> or <int>-<int> parsing "
+            throw MLDB::Exception("Range spec is <int> or <int>-<int> parsing "
                                 + rangeSpec);
         
         last = strtol(endPtr + 1, &endPtr, 10);
         if (errno)
-            throw ML::Exception(errno, "strtol() parsing last port in'"
+            throw MLDB::Exception(errno, "strtol() parsing last port in'"
                                 + rangeSpec + "'");
         if (last <= 0 || last >= 65536)
-            throw ML::Exception("last port number %d out of range parsing '%s'",
+            throw MLDB::Exception("last port number %d out of range parsing '%s'",
                                 last, rangeSpec.c_str());
         if (*endPtr != 0)
-            throw ML::Exception("extra junk after last port parsing '%s'",
+            throw MLDB::Exception("extra junk after last port parsing '%s'",
                                 rangeSpec.c_str());
     }
 

--- a/io/tcp_acceptor.cc
+++ b/io/tcp_acceptor.cc
@@ -98,7 +98,7 @@ findHandlerPtr(TcpSocketHandler * handler)
         }
     }
 
-    throw ML::Exception("socket handler not found");
+    throw MLDB::Exception("socket handler not found");
 }
 
 /* FIXME: inefficient implementation */

--- a/io/tcp_acceptor_impl.cc
+++ b/io/tcp_acceptor_impl.cc
@@ -81,7 +81,7 @@ listen(const PortRange & portRange, const string & hostname, int backlog)
     }
 
     if (!v4Endpoint_.isOpen() && !v6Endpoint_.isOpen()) {
-        throw ML::Exception("impossible to bind to specified port(s)");
+        throw MLDB::Exception("impossible to bind to specified port(s)");
     }
 }
 
@@ -160,7 +160,7 @@ open(const asio::ip::tcp::endpoint & asioEndpoint,
                 break;
             }
             if (ec != asio::error::address_in_use) {
-                throw ML::Exception("error binding socket: " + ec.message());
+                throw MLDB::Exception("error binding socket: " + ec.message());
             }
         }
         if (bound) {

--- a/io/testing/async_writer_bench.cc
+++ b/io/testing/async_writer_bench.cc
@@ -57,7 +57,7 @@ pair<int, int> makePipePair()
 {
     int fds[2];
     if (pipe2(fds, O_NONBLOCK) == -1) {
-        throw ML::Exception(errno, "pipe2");
+        throw MLDB::Exception(errno, "pipe2");
     }
 
     return {fds[1], fds[0]};
@@ -81,25 +81,25 @@ pair<int, int> makeTcpSocketPair()
 
     int listener = socket(AF_INET, SOCK_STREAM, 0);
     if (listener == -1) {
-        throw ML::Exception(errno, "socket");
+        throw MLDB::Exception(errno, "socket");
     }
 
     if (bind(listener, (const struct sockaddr *) &addr, addrLen) == -1) {
-        throw ML::Exception(errno, "bind");
+        throw MLDB::Exception(errno, "bind");
     }
 
     if (listen(listener, 666) == -1) {
-        throw ML::Exception(errno, "listen");
+        throw MLDB::Exception(errno, "listen");
     }
 
     if (getsockname(listener, (sockaddr *) &addr, &addrLen) == -1) {
-        throw ML::Exception(errno, "getsockname");
+        throw MLDB::Exception(errno, "getsockname");
     }
 
     /* writer */
     int writer = socket(AF_INET, SOCK_STREAM, 0);
     if (writer == -1) {
-        throw ML::Exception(errno, "socket");
+        throw MLDB::Exception(errno, "socket");
     }
 
 #if 0
@@ -108,19 +108,19 @@ pair<int, int> makeTcpSocketPair()
         if (setsockopt(writer,
                        IPPROTO_TCP, TCP_NODELAY,
                        (char *) &flag, sizeof(int)) == -1) {
-            throw ML::Exception(errno, "setsockopt TCP_NODELAY");
+            throw MLDB::Exception(errno, "setsockopt TCP_NODELAY");
         }
     }
 #endif
 
     if (connect(writer, (const struct sockaddr *) &addr, addrLen) == -1) {
-        throw ML::Exception(errno, "connect");
+        throw MLDB::Exception(errno, "connect");
     }
     setFileFlag(writer, O_NONBLOCK);
 
     int reader = accept(listener, (struct sockaddr *) &addr, &addrLen);
     if (reader == -1) {
-        throw ML::Exception(errno, "accept");
+        throw MLDB::Exception(errno, "accept");
     }
     setFileFlag(reader, O_NONBLOCK);
 
@@ -145,7 +145,7 @@ void doBench(const string & label,
     int numMissed(0);
     auto onWriteResult = [&] (AsyncWriteResult result) {
         if (result.error != 0) {
-            throw ML::Exception("write error");
+            throw MLDB::Exception("write error");
         }
         numWriteResults++;
         if (numWriteResults == numMessages) {

--- a/io/testing/epoll_test.cc
+++ b/io/testing/epoll_test.cc
@@ -52,7 +52,7 @@ void thread1Fn(atomic<int> & stage, int epollFd, int pipeFds[2])
     ::fprintf(stderr, "thread 1: arming fd\n");
     int rc = ::epoll_ctl(epollFd, EPOLL_CTL_ADD, pipeFds[0], &armEvent);
     if (rc == -1) {
-        throw ML::Exception(errno, "epoll_ctl");
+        throw MLDB::Exception(errno, "epoll_ctl");
     }
 
     stage = 1; ML::futex_wake(stage);
@@ -60,13 +60,13 @@ void thread1Fn(atomic<int> & stage, int epollFd, int pipeFds[2])
     ::fprintf(stderr, "thread 1: waiting 1\n");
     rc = ::epoll_wait(epollFd, &event, 1, -1);
     if (rc == -1) {
-        throw ML::Exception(errno, "epoll_wait");
+        throw MLDB::Exception(errno, "epoll_wait");
     }
 
     ::fprintf(stderr, "thread 1: reading 1\n");
     rc = ::read(pipeFds[0], &readData, sizeof(readData));
     if (rc == -1) {
-        throw ML::Exception(errno, "read");
+        throw MLDB::Exception(errno, "read");
     }
     ExcAssertEqual(rc, sizeof(readData));
     ExcAssertEqual(readData, 1);
@@ -76,7 +76,7 @@ void thread1Fn(atomic<int> & stage, int epollFd, int pipeFds[2])
     ::fprintf(stderr, "thread 1: reading 2\n");
     rc = ::read(pipeFds[0], &readData, sizeof(readData));
     if (rc == -1) {
-        throw ML::Exception(errno, "read");
+        throw MLDB::Exception(errno, "read");
     }
     ExcAssertEqual(rc, sizeof(readData));
     ExcAssertEqual(readData, 0x1fffffff);
@@ -102,13 +102,13 @@ void thread1Fn(atomic<int> & stage, int epollFd, int pipeFds[2])
     ::fprintf(stderr, "thread 1: rearming\n");
     rc = ::epoll_ctl(epollFd, EPOLL_CTL_MOD, pipeFds[0], &armEvent);
     if (rc == -1) {
-        throw ML::Exception(errno, "epoll_ctl");
+        throw MLDB::Exception(errno, "epoll_ctl");
     }
 
     ::fprintf(stderr, "thread 1: epoll_wait for final payload\n");
     rc = ::epoll_wait(epollFd, &event, 1, 2000);
     if (rc == -1) {
-        throw ML::Exception(errno, "epoll_wait");
+        throw MLDB::Exception(errno, "epoll_wait");
     }
     else if (rc == 0)
         ::fprintf(stderr, "thread 1: second epoll wait has no event\n");
@@ -130,7 +130,7 @@ void thread2Fn(atomic<int> & stage, int epollFd, int pipeFds[2])
     uint32_t writeData(1);
     int rc = ::write(pipeFds[1], &writeData, sizeof(writeData));
     if (rc == -1) {
-        throw ML::Exception(errno, "write");
+        throw MLDB::Exception(errno, "write");
     }
     ExcAssert(rc == sizeof(writeData));
     ::fprintf(stderr, "thread 2: payload 1 written\n");
@@ -138,7 +138,7 @@ void thread2Fn(atomic<int> & stage, int epollFd, int pipeFds[2])
     writeData = 0x1fffffff;
     rc = ::write(pipeFds[1], &writeData, sizeof(writeData));
     if (rc == -1) {
-        throw ML::Exception(errno, "write");
+        throw MLDB::Exception(errno, "write");
     }
     ExcAssert(rc == sizeof(writeData));
     ::fprintf(stderr, "thread 2: payload 2 written\n");
@@ -152,7 +152,7 @@ void thread2Fn(atomic<int> & stage, int epollFd, int pipeFds[2])
     writeData = 0x12345678;
     rc = ::write(pipeFds[1], &writeData, sizeof(writeData));
     if (rc == -1) {
-        throw ML::Exception(errno, "write");
+        throw MLDB::Exception(errno, "write");
     }
     ExcAssert(rc == sizeof(writeData));
     ::fprintf(stderr, "thread 2: payload 3 written\n");
@@ -167,12 +167,12 @@ BOOST_AUTO_TEST_CASE( test_epolloneshot )
 {
     int epollFd = ::epoll_create(666);
     if (epollFd == -1) {
-        throw ML::Exception(errno, "epoll_create");
+        throw MLDB::Exception(errno, "epoll_create");
     }
 
     int pipeFds[2];
     if (::pipe2(pipeFds, O_NONBLOCK) == -1) {
-        throw ML::Exception(errno, "pipe2");
+        throw MLDB::Exception(errno, "pipe2");
     }
 
     atomic<int> stage(0);

--- a/jml/db/compact_size_types.cc
+++ b/jml/db/compact_size_types.cc
@@ -112,7 +112,7 @@ void encode_compact(char * & first, char * last, unsigned long long val)
     int len = idx + 1;
 
     if (first + len > last)
-        throw ML::Exception("not enough space to encode compact_size_t");
+        throw MLDB::Exception("not enough space to encode compact_size_t");
 
     /* Pack it into the back bytes. */
     for (int i = len-1;  i >= 0;  --i) {

--- a/jml/db/portable_iarchive.h
+++ b/jml/db/portable_iarchive.h
@@ -1,9 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* portable_iarchive.h                                             -*- C++ -*-
    Jeremy Barnes, 13 March 2005
    Copyright (c) 2005 Jeremy Barnes.  All rights reserved.
-
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
 
    ---
@@ -11,8 +9,7 @@
    Portable format for iarchives.
 */
 
-#ifndef __db__portable_iarchive_h__
-#define __db__portable_iarchive_h__
+#pragma once
 
 #include <algorithm>
 #include "serialization_order.h"
@@ -36,6 +33,7 @@ class multi_array;
 
 namespace ML {
 
+using namespace MLDB;
 class File_Read_Buffer;
 
 namespace DB {
@@ -361,7 +359,3 @@ public:
 
 } // namespace DB
 } // namespace ML
-
-#endif /* __db__portable_iarchive_h__ */
-
-

--- a/jml/db/portable_oarchive.h
+++ b/jml/db/portable_oarchive.h
@@ -1,9 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* portable_oarchive.h                                             -*- C++ -*-
    Jeremy Barnes, 17 March 2005
    Copyright (c) 2005 Jeremy Barnes.  All rights reserved.
-   
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.   
 
 
    ---
@@ -11,8 +9,7 @@
    Portable output archive.
 */
 
-#ifndef __db__portable_oarchive_h__
-#define __db__portable_oarchive_h__
+#pragma once
 
 
 #include <algorithm>
@@ -38,6 +35,8 @@ class const_multi_array_ref;
 } // namespace boost
 
 namespace ML {
+using namespace MLDB;
+
 namespace DB {
 
 
@@ -294,5 +293,3 @@ private:
 
 } // namespace DB
 } // namespace ML
-
-#endif /* __db__portable_oarchive_h__ */

--- a/jml/stats/auc.h
+++ b/jml/stats/auc.h
@@ -1,20 +1,20 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* auc.h                                                           -*- C++ -*-
    Jeremy Barnes, 9 November 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Functionality to calculate area under the curve statistics.
 */
 
-#ifndef __jml__stats__auc_h__
-#define __jml__stats__auc_h__
+#pragma once
 
 #include <vector>
 #include "mldb/arch/exception.h"
 #include <iostream>
 
 namespace ML {
+
+using namespace MLDB;
 
 struct AUC_Entry {
     AUC_Entry(float model = 0.0, bool target = false, float weight = 1.0)
@@ -97,5 +97,3 @@ calc_auc(const std::vector<Float1> & outputs,
 }
 
 } // namespace ML
-
-#endif /* __jml__stats__auc_h__ */

--- a/jml/stats/distribution.h
+++ b/jml/stats/distribution.h
@@ -23,12 +23,12 @@
 
 #include <type_traits>
 
-namespace ML {
+namespace MLDB {
 
 inline void wrong_sizes_exception(const char * op, int size1, int size2)
 {
-    throw Exception(format("distribution: operation %s between different sized "
-                           "distributions %d and %d", op, size1, size2));
+    throw MLDB::Exception("distribution: operation %s between different sized "
+                          "distributions %d and %d", op, size1, size2);
 }
 
 
@@ -497,4 +497,4 @@ bool equal_impl(const distribution<T, U> & d1,
     return (d1 == d2).all();
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/jml/stats/distribution_ops.h
+++ b/jml/stats/distribution_ops.h
@@ -1,18 +1,14 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* distribution_ops.h                                              -*- C++ -*-
    Jeremy Barnes, 2 Febryary 2005
    Copyright (c) 2005 Jeremy Barnes.  All rights reserved.
-   
-
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.   
 
    ---
 
    Operations on distributions.
 */
 
-#ifndef __utils__distribution_ops_h__
-#define __utils__distribution_ops_h__
+#pragma once
 
 #include "distribution.h"
 #include "mldb/jml/math/bound.h"
@@ -21,7 +17,7 @@
 #include "mldb/arch/math_builtins.h"
 #include <cmath>
 
-namespace ML {
+namespace MLDB {
 
 template<typename F, class Underlying>
 distribution<F, Underlying> bound(const distribution<F, Underlying> & dist, F min, F max)
@@ -229,6 +225,4 @@ distribution<bool> isnan(const distribution<F, Underlying> & dist)
 
 using ::isnan;
 
-} // namespace ML
-
-#endif /* __utils__distribution_ops_h__ */
+} // namespace MLDB

--- a/jml/stats/distribution_simd.h
+++ b/jml/stats/distribution_simd.h
@@ -15,7 +15,7 @@
 #include "mldb/arch/simd_vector.h"
 #include "mldb/compiler/compiler.h"
 
-namespace ML {
+namespace MLDB {
 
 template<>
 JML_ALWAYS_INLINE float
@@ -202,4 +202,4 @@ exp(const distribution<double, Underlying> & dist)
     return result;
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/jml/stats/rmse.h
+++ b/jml/stats/rmse.h
@@ -1,19 +1,19 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* rmse.h                                                          -*- C++ -*-
    Jeremy Barnes, 9 November 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Root Mean Squared Error calculation routines.
 */
 
-#ifndef __jml__stats__rmse_h__
-#define __jml__stats__rmse_h__
+#pragma once
 
 #include "mldb/jml/stats/distribution.h"
 #include "mldb/jml/stats/distribution_ops.h"
 
 namespace ML {
+
+using namespace MLDB;
 
 template<typename Float1, typename Float2>
 double
@@ -36,6 +36,3 @@ calc_rmse(const distribution<Float1> & outputs,
 
 
 } // namespace ML
-
-
-#endif /* __jml__stats__rmse_h__ */

--- a/jml/utils/circular_buffer.h
+++ b/jml/utils/circular_buffer.h
@@ -1,23 +1,23 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
+// 
 
 /* circular_buffer.h                                               -*- C++ -*-
    Jeremy Barnes, 7 December 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Circular buffer structure, that will grow to hold whatever we put in it.
    O(1) insertion and deletion at the front and at the back.  Kind of like
    a deque, but much lighter weight.
 */
 
-#ifndef __jml__utils__circular_buffer_h__
-#define __jml__utils__circular_buffer_h__
+#pragma once
 
 #include <vector>
 #include "mldb/arch/exception.h"
 #include <boost/iterator/iterator_facade.hpp>
 #include <iostream> // debug
 
-namespace ML {
+namespace MLDB {
 
 template<typename T, class CircularBuffer>
 struct Circular_Buffer_Iterator
@@ -641,7 +641,4 @@ operator << (std::ostream & stream,
 }
 
 
-} // namespace ML
-
-
-#endif /* __jml__utils__circular_buffer_h__ */
+} // namespace MLDB

--- a/jml/utils/configuration.cc
+++ b/jml/utils/configuration.cc
@@ -14,7 +14,7 @@
 
 
 using namespace std;
-
+using namespace MLDB;
 
 namespace ML {
 
@@ -148,7 +148,7 @@ void
 Configuration::
 load(const std::string & filename)
 {
-    Parse_Context context(filename);
+    MLDB::ParseContext context(filename);
     parse(context);
 }
 
@@ -156,7 +156,7 @@ void
 Configuration::
 parse_string(const std::string & str, const std::string & filename)
 {
-    Parse_Context context(filename, str.c_str(), str.c_str() + str.size());
+    ParseContext context(filename, str.c_str(), str.c_str() + str.size());
     parse(context);
 }
 
@@ -170,7 +170,7 @@ struct Found_End_Name {
     }
 };
 
-std::string expect_name(Parse_Context & context)
+std::string expect_name(ParseContext & context)
 {
     std::string result;
     if (!context.match_text(result, Found_End_Name())
@@ -186,7 +186,7 @@ struct Found_End_Value {
     }
 };
 
-std::string expect_value(Parse_Context & context)
+std::string expect_value(ParseContext & context)
 {
     std::string result;
     if (!context.match_text(result, Found_End_Value())
@@ -199,7 +199,7 @@ std::string expect_value(Parse_Context & context)
 
 void
 Configuration::
-parse(Parse_Context & context)
+parse(ParseContext & context)
 {
     string scope;
 
@@ -349,7 +349,7 @@ throwOnUnknwonKeys(
         keys.end());
 
     if (!keys.empty()) {
-        throw ML::Exception("Unknown key(s) encountered in config: %s",
+        throw MLDB::Exception("Unknown key(s) encountered in config: %s",
                             boost::algorithm::join(keys, " ").c_str());
     }
 }

--- a/jml/utils/configuration.h
+++ b/jml/utils/configuration.h
@@ -1,14 +1,12 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* configuration.h                                                 -*- C++ -*-
    Jeremy Barnes, 3 April 2006
    Copyright (c) 2006 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Functions to allow key-based configuration files.
 */
 
-#ifndef __utils__configuration_h__
-#define __utils__configuration_h__
+#pragma once
 
 #include <map>
 #include <memory>
@@ -20,10 +18,12 @@
 #include "mldb/jml/utils/string_functions.h"
 #include "enum_info.h"
 
+namespace MLDB {
+struct ParseContext;
+} // namespace MLDB
 
 namespace ML {
-
-struct Parse_Context;
+using namespace MLDB;
 
 /*****************************************************************************/
 /* CONFIGURATION                                                             */
@@ -87,7 +87,7 @@ public:
     void load(const std::string & filename);
     void parse_string(const std::string & str, const std::string & filename);
     void parse_command_line(const std::vector<std::string> & options);
-    void parse(Parse_Context & context);
+    void parse(MLDB::ParseContext & context);
 
     void parse_value(std::string & val, const std::string & str,
                      const std::string & full_key) const
@@ -233,6 +233,3 @@ std::ostream & operator << (std::ostream & stream,
                             const Configuration::Accessor & acc);
 
 } // namespace ML
-
-
-#endif /* __utils__configuration_h__ */

--- a/jml/utils/csv.cc
+++ b/jml/utils/csv.cc
@@ -15,13 +15,13 @@
 using namespace std;
 
 
-namespace ML {
+namespace MLDB {
 
 namespace {
 static const string literalDoubleQuote("\"\"");
 } // file scope
 
-std::string expect_csv_field(Parse_Context & context, bool & another,
+std::string expect_csv_field(ParseContext & context, bool & another,
                              char separator)
 {
     bool quoted = false;
@@ -88,7 +88,7 @@ std::string expect_csv_field(Parse_Context & context, bool & another,
 }
 
 std::vector<std::string>
-expect_csv_row(Parse_Context & context, int length, char separator)
+expect_csv_row(ParseContext & context, int length, char separator)
 {
     //    cerr << "*** parsing" << endl;
 
@@ -139,4 +139,4 @@ std::string csv_escape(const std::string & s)
     return result;
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/jml/utils/csv.h
+++ b/jml/utils/csv.h
@@ -10,9 +10,9 @@
 #include <string>
 #include <vector>
 
-namespace ML {
+namespace MLDB {
 
-struct Parse_Context;
+struct ParseContext;
 
 
 /**
@@ -33,18 +33,18 @@ private:
 
 /** Expect a CSV field from the given parse context.  Another will be set
     to true if there is still another field in the CSV row. */
-std::string expect_csv_field(Parse_Context & context, bool & another,
+std::string expect_csv_field(ParseContext & context, bool & another,
                              char separator = ',');
 
 
 /** Expect a row of CSV from the given parse context.  If length is not -1,
     then the extact number of fields required is given in that parameter. */
 std::vector<std::string>
-expect_csv_row(Parse_Context & context, int length = -1, char separator = ',');
+expect_csv_row(ParseContext & context, int length = -1, char separator = ',');
 
 /** Convert the string to a CSV representation, escaping everything that
     needs to be escaped. */
 std::string csv_escape(const std::string & s);
 
-} // namespace ML
+} // namespace MLDB
 

--- a/jml/utils/enum_info.h
+++ b/jml/utils/enum_info.h
@@ -1,20 +1,17 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* enum_info.h                                                     -*- C++ -*-
    Jeremy Barnes, 3 April 2006
    Copyright (c) 2006 Jeremy Barnes.  All rights reserved.
-
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Functions to allow us to know the contents of enumerations.
 */
 
-#ifndef __utils__enum_info_h__
-#define __utils__enum_info_h__
+#pragma once
 
 #include <string>
 #include <map>
 #include <atomic>
-
+#include "mldb/arch/exception.h"
 
 namespace ML {
 
@@ -89,9 +86,9 @@ enum_value(const std::string & name)
     }
     typename values_type::const_iterator found = values.load()->find(name);
     if (found == values.load()->end())
-        throw Exception("couldn't parse '" + name + "' as "
-                        + Enum_Info<Enum>::NAME + " (possibilities are "
-                        + enum_values<Enum>());
+        throw MLDB::Exception("couldn't parse '" + name + "' as "
+                        + ML::Enum_Info<Enum>::NAME + " (possibilities are "
+                        + ::ML::enum_values<Enum>());
     return found->second;
 }
 
@@ -108,5 +105,3 @@ struct Enum_Info<type> { \
 } // namespace ML
 
 } // namespace ML
-
-#endif /* __utils__enum_info_h__ */

--- a/jml/utils/environment.h
+++ b/jml/utils/environment.h
@@ -17,7 +17,7 @@
 #include <iostream>
 
 
-namespace ML {
+namespace MLDB {
 
 
 /*****************************************************************************/
@@ -53,9 +53,9 @@ public:
 /** An environment option variable */
 
 template<typename T, bool Trace = false>
-class Env_Option {
+class EnvOption {
 public:
-    Env_Option(const std::string & var_name, const T & def)
+    EnvOption(const std::string & var_name, const T & def)
         : t_(def), specified_(false)
     {
         const Environment & env = Environment::instance();
@@ -87,4 +87,4 @@ private:
     bool specified_;
 
 };
-} // namespace ML
+} // namespace MLDB

--- a/jml/utils/file_functions.cc
+++ b/jml/utils/file_functions.cc
@@ -32,7 +32,7 @@
 
 
 using namespace std;
-
+using namespace MLDB;
 
 namespace ML {
 
@@ -76,7 +76,7 @@ std::string get_link_target(const std::string & link)
 
 std::string get_name_from_fd(int fd)
 {
-    string fname = format("/proc/self/fd/%d", fd);
+    string fname = MLDB::format("/proc/self/fd/%d", fd);
     return get_link_target(fname);
 }
 
@@ -185,11 +185,11 @@ void syncFile(const std::string & filename)
 {
     int fd = ::open(filename.c_str(), O_RDONLY);
     if (fd == -1)
-        throw ML::Exception(errno, "syncFile for " + filename);
+        throw MLDB::Exception(errno, "syncFile for " + filename);
     ML::Call_Guard guard([=] () { close(fd); });
     int res = fdatasync(fd);
     if (res == -1)
-        throw ML::Exception(errno, "fdatasync for " + filename);
+        throw MLDB::Exception(errno, "fdatasync for " + filename);
 }
 
 
@@ -231,16 +231,16 @@ class File_Read_Buffer::MMap_Region
         return result;
     }
 
-    static ML::Spinlock & lock()
+    static Spinlock & lock()
     {
-        static ML::Spinlock result;
+        static Spinlock result;
         return result;
     }
 
 public:
     static std::shared_ptr<MMap_Region> get(int fd)
     {
-        std::lock_guard<ML::Spinlock> guard(lock());
+        std::lock_guard<Spinlock> guard(lock());
 
         inode_type inode = get_inode(fd);
         std::weak_ptr<MMap_Region> & ptr = cache()[inode];
@@ -260,7 +260,7 @@ public:
     {
         if  (size) munmap((void *)start, size);
 
-        std::lock_guard<ML::Spinlock> guard(lock());
+        std::lock_guard<Spinlock> guard(lock());
         if (cache()[inode].expired())
             cache().erase(inode);
     }

--- a/jml/utils/guard.h
+++ b/jml/utils/guard.h
@@ -1,16 +1,13 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* guard.h                                                         -*- C++ -*-
    Jeremy Barnes, 13 February 2007
    Copyright (c) 2007 Jeremy Barnes.  All rights reserved.
-
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
 
    ---
 */
 
-#ifndef __utils__guard_h__
-#define __utils__guard_h__
+#pragma once
 
 #include "mldb/compiler/compiler.h"
 #include <functional>
@@ -71,7 +68,5 @@ Call_Guard call_guard(Fn fn, bool condition = true)
 #endif
 
 
-} // namespace ML
+} // namespace MLDB
 
-
-#endif /* __utils__guard_h__ */

--- a/jml/utils/hex_dump.cc
+++ b/jml/utils/hex_dump.cc
@@ -21,10 +21,10 @@ void hex_dump(const void * mem, size_t total_memory, size_t max_size)
     const char * buffer = (const char *)mem;
 
     for (unsigned i = 0;  i < total_memory && i < max_size;  i += 16) {
-        cerr << format("%04x | ", i);
+        cerr << MLDB::format("%04x | ", i);
         for (unsigned j = i;  j < i + 16;  ++j) {
             if (j < total_memory)
-                cerr << format("%02x ", (int)*(unsigned char *)(buffer + j));
+                cerr << MLDB::format("%02x ", (int)*(unsigned char *)(buffer + j));
             else cerr << "   ";
         }
         

--- a/jml/utils/lightweight_hash.h
+++ b/jml/utils/lightweight_hash.h
@@ -1,14 +1,12 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* lightweight_hash.h                                              -*- C++ -*-
    Jeremy Barnes, 8 December 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    A lightweight invasive hash map.
 */
 
-#ifndef __jml__utils__lightweight_hash_h__
-#define __jml__utils__lightweight_hash_h__
+#pragma once
 
 #include "mldb/arch/exception.h"
 #include <boost/iterator/iterator_facade.hpp>
@@ -23,7 +21,7 @@
 #include <functional>
 #include <atomic>
 
-namespace ML {
+namespace MLDB {
 
 
 /*****************************************************************************/
@@ -176,7 +174,7 @@ struct MemStorage {
     void reserve(size_t newCapacity)
     {
         if (vals_)
-            throw ML::Exception("can't double initialize storage");
+            throw MLDB::Exception("can't double initialize storage");
             
         // We allocate one extra bucket and shift things so that index -1 has
         // a valid bucket
@@ -283,7 +281,7 @@ struct LogMemStorage {
     void reserve(size_t newCapacity)
     {
         if (vals_)
-            throw ML::Exception("can't double initialize storage");
+            throw MLDB::Exception("can't double initialize storage");
         
         if (newCapacity == 0) return;
 
@@ -602,7 +600,7 @@ protected:
         Key key = Ops::getKey(toInsert);
         ssize_t bucket = find_bucket(key);
         if (bucket != NO_BUCKET && Ops::bucketIsFull(storage_, bucket))
-            throw ML::Exception("must_insert of value already there");
+            throw MLDB::Exception("must_insert of value already there");
         return insert_new(bucket, toInsert);
     }
 
@@ -1282,7 +1280,4 @@ private:
 };
 
 
-} // file scope
-
-
-#endif /* __jml__utils__lightweight_hash_h__ */
+} // namespace MLDB

--- a/jml/utils/map_reduce.h
+++ b/jml/utils/map_reduce.h
@@ -148,7 +148,7 @@ parallelMapInOrderReduceInEqualWorkChunks
     }
     
     if (totalWork == 0)
-        throw ML::Exception("total work must not be zero");
+        throw MLDB::Exception("total work must not be zero");
     
     // Now group them into contiguous chunks (ranges of iterators to process)
     // such that each chunk gets a roughly even amount of work.

--- a/jml/utils/profile.h
+++ b/jml/utils/profile.h
@@ -1,14 +1,12 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* profile.h                                                       -*- C++ -*-
    Jeremy Barnes, 15 February 2007
    Copyright (c) 2007 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Profiling code.
 */
 
-#ifndef __utils__profile_h__
-#define __utils__profile_h__
+#pragma once
 
 #include <boost/timer.hpp>
 #include "mldb/arch/timers.h"
@@ -47,7 +45,7 @@ struct StackProfilerSeed {
 
 struct StackProfiler {
     boost::timer t;
-    ML::Timer wall;
+    MLDB::Timer wall;
     StackProfilerSeed& seed;
     StackProfiler(StackProfilerSeed& seed) : seed(seed)   
     {
@@ -64,7 +62,7 @@ struct StackProfiler {
 
 struct StackProfilerAverage {
 
-    ML::Timer wall;
+    MLDB::Timer wall;
     std::atomic<int>& count;
     std::atomic<double>& sum;
     const char* label;
@@ -151,5 +149,3 @@ ML::StackProfilerSeed label##__stack_profile_seed(label##__stack_profile_string)
 ML::StackProfiler label##__stack_profile(label##__stack_profile_seed);
 
 } // namespace ML
-
-#endif /* __utils__profile_h__ */

--- a/jml/utils/ring_buffer.h
+++ b/jml/utils/ring_buffer.h
@@ -1,15 +1,13 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* ring_buffer.h                                                   -*- C++ -*-
    Jeremy Barnes, 25 May 2012
    Copyright (c) 2012 Datacratic.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Ring buffer for when there are one or more producers and one consumer
    chasing each other.
 */
 
-#ifndef __jml_utils__ring_buffer_h__
-#define __jml_utils__ring_buffer_h__
+#pragma once
 
 #include <vector>
 #include "mldb/arch/futex.h"
@@ -18,6 +16,8 @@
 #include <thread>
 
 namespace ML {
+
+using namespace MLDB;
 
 template<typename Request>
 struct RingBufferBase {
@@ -261,7 +261,7 @@ struct RingBufferSRMW : public RingBufferBase<Request> {
         return *this;
     }
 
-    typedef ML::Spinlock Mutex;
+    typedef Spinlock Mutex;
     mutable Mutex mutex; // todo: get rid of...
     typedef std::unique_lock<Mutex> Guard;
     
@@ -402,5 +402,3 @@ struct RingBufferSRMW : public RingBufferBase<Request> {
 };
 
 } // namespace ML
-
-#endif /* __jml_utils__ring_buffer_h__ */

--- a/jml/utils/string_functions.cc
+++ b/jml/utils/string_functions.cc
@@ -19,7 +19,9 @@
 #include <stdlib.h>
 #include <boost/algorithm/string.hpp>
 
+
 using namespace std;
+using namespace MLDB;
 
 
 namespace ML {
@@ -43,7 +45,7 @@ std::string format(const char * fmt, ...)
     va_list ap;
     va_start(ap, fmt);
     try {
-        string result = vformat(fmt, ap);
+        string result = MLDB::vformat(fmt, ap);
         va_end(ap);
         return result;
     }
@@ -158,7 +160,7 @@ antoi(const char * start, const char * end, int base)
             neg = true;
         }
         else {
-            throw ML::Exception("Cannot negate non base 10");
+            throw MLDB::Exception("Cannot negate non base 10");
         }
         start++;
     }
@@ -178,11 +180,11 @@ antoi(const char * start, const char * end, int base)
             digit = *ptr - 'a' + 10;
         }
         else {
-            throw ML::Exception("expected digit");
+            throw MLDB::Exception("expected digit");
         }
         if (digit > base) {
             intptr_t offset = ptr - start;
-            throw ML::Exception("digit '%c' (%d) exceeds base '%d'"
+            throw MLDB::Exception("digit '%c' (%d) exceeds base '%d'"
                                 " at offset '%d'",
                                 *ptr, digit, base, offset);
         }

--- a/jml/utils/string_functions.h
+++ b/jml/utils/string_functions.h
@@ -11,8 +11,7 @@
    Functions for the manipulation of strings.
 */
 
-#ifndef __utils__string_functions_h__
-#define __utils__string_functions_h__
+#pragma once
 
 #include <sstream>
 #include <string>
@@ -70,6 +69,3 @@ unsigned replace_all(std::string & haystack, const std::string & search,
 std::string trim(const std::string & other);
 
 } // namespace ML
-
-
-#endif /* __utils__string_functions_h__ */

--- a/jml/utils/testing/circular_buffer_test.cc
+++ b/jml/utils/testing/circular_buffer_test.cc
@@ -22,6 +22,7 @@
 
 using namespace ML;
 using namespace std;
+using namespace MLDB;
 
 using boost::unit_test::test_suite;
 

--- a/jml/utils/testing/configuration_test.cc
+++ b/jml/utils/testing/configuration_test.cc
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE( test1 )
     BOOST_CHECK(config2.find(t, "type"));
 
     BOOST_CHECK_EQUAL(t, "bagging");
-    BOOST_CHECK_THROW(config2["hello"] = "hello", ML::Exception);
+    BOOST_CHECK_THROW(config2["hello"] = "hello", MLDB::Exception);
 
     Configuration config3(config2, "weak_learner",
                           Configuration::PREFIX_APPEND);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE( test1 )
     t = "";
     BOOST_CHECK(config3.find(t, "type"));
     BOOST_CHECK_EQUAL(t, "boosting");
-    BOOST_CHECK_THROW(config3["hello"] = "hello", ML::Exception);
+    BOOST_CHECK_THROW(config3["hello"] = "hello", MLDB::Exception);
 
     Configuration config4(config3, "weak_learner",
                           Configuration::PREFIX_APPEND);
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE( test1 )
     t = "";
     BOOST_CHECK(config4.find(t, "type"));
     BOOST_CHECK_EQUAL(t, "decision_tree");
-    BOOST_CHECK_THROW(config4["hello"] = "hello", ML::Exception);
+    BOOST_CHECK_THROW(config4["hello"] = "hello", MLDB::Exception);
 
     config["bagged_boosted_trees.weak_learner.weak_learner.type"]
         = "naive_bayes";

--- a/jml/utils/testing/csv_parsing_test.cc
+++ b/jml/utils/testing/csv_parsing_test.cc
@@ -20,12 +20,13 @@
 
 using namespace std;
 using namespace ML;
+using namespace MLDB;
 
 using boost::unit_test::test_suite;
 
 vector<string> parseCsvLine(const std::string & line)
 {
-    ML::Parse_Context context(line, line.c_str(), line.c_str() + line.size());
+    ParseContext context(line, line.c_str(), line.c_str() + line.size());
     return expect_csv_row(context);
 }
 

--- a/jml/utils/testing/environment_test.cc
+++ b/jml/utils/testing/environment_test.cc
@@ -16,7 +16,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/auto_unit_test.hpp>
 
-using namespace ML;
+using namespace MLDB;
 
 using boost::unit_test::test_suite;
 

--- a/jml/utils/testing/lightweight_hash_test.cc
+++ b/jml/utils/testing/lightweight_hash_test.cc
@@ -22,6 +22,7 @@
 #include "live_counting_obj.h"
 
 using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 BOOST_AUTO_TEST_CASE(test1)
@@ -207,7 +208,7 @@ BOOST_AUTO_TEST_CASE(test_insert_guard_object)
 
     int nobj = 100;
 
-    ML::Lightweight_Hash<int, int> h;
+    Lightweight_Hash<int, int> h;
         
     for (unsigned j = 0;  j < nobj;  ++j) {
         BOOST_CHECK_EQUAL(h.size(), j);

--- a/jml/utils/testing/live_counting_obj.h
+++ b/jml/utils/testing/live_counting_obj.h
@@ -12,7 +12,7 @@
 #include "mldb/arch/exception.h"
 #include <atomic>
 
-namespace ML {
+namespace MLDB {
 
 volatile size_t constructed = 0, destroyed = 0;
 
@@ -131,4 +131,4 @@ std::ostream & operator << (std::ostream & stream, const Obj & obj)
     return stream << obj.val;
 }
 
-} // namespace ML
+} // namespace MLDB

--- a/jml/utils/testing/parse_context_test.cc
+++ b/jml/utils/testing/parse_context_test.cc
@@ -29,6 +29,7 @@
 #include <locale.h>
 
 using namespace ML;
+using namespace MLDB;
 using namespace std;
 
 using boost::unit_test::test_suite;
@@ -40,7 +41,7 @@ BOOST_AUTO_TEST_CASE( test_float_parsing )
     for (unsigned i = 0;  i < 1000;  ++i) {
         float f = random() / 100000000.0;
         string s = format("%.6f", f);
-        Parse_Context pc(s, s.c_str(), s.c_str() + s.length());
+        ParseContext pc(s, s.c_str(), s.c_str() + s.length());
         float f2 = pc.expect_float();
         string s2 = format("%.6f", f2);
         
@@ -53,7 +54,7 @@ BOOST_AUTO_TEST_CASE( test_float_parsing2 )
     for (unsigned i = 0;  i < 1000;  ++i) {
         float f = random() + random() / 100000000.0;
         string s = format("%.6f", f);
-        Parse_Context pc(s, s.c_str(), s.c_str() + s.length());
+        ParseContext pc(s, s.c_str(), s.c_str() + s.length());
         float f2 = pc.expect_float();
         string s2 = format("%.6f", f2);
         
@@ -66,7 +67,7 @@ BOOST_AUTO_TEST_CASE( test_double_parsing )
     for (unsigned i = 0;  i < 1000;  ++i) {
         double f = random() / 100000000.0;
         string s = format("%.6f", f);
-        Parse_Context pc(s, s.c_str(), s.c_str() + s.length());
+        ParseContext pc(s, s.c_str(), s.c_str() + s.length());
         double f2 = pc.expect_double();
         string s2 = format("%.6f", f2);
         
@@ -82,7 +83,7 @@ BOOST_AUTO_TEST_CASE( test_double_parsing2 )
 
         for (unsigned i = 0;  i < 100;  ++i) {
 
-            string fmt = ML::format("%%.%df", digits);
+            string fmt = MLDB::format("%%.%df", digits);
 
             double f = random() + random() / 100000000.0;
             string s = format(fmt.c_str(), f);
@@ -92,7 +93,7 @@ BOOST_AUTO_TEST_CASE( test_double_parsing2 )
             if (digits < 18)
                 f = f3;
 
-            Parse_Context pc(s, s.c_str(), s.c_str() + s.length());
+            ParseContext pc(s, s.c_str(), s.c_str() + s.length());
             double f2 = pc.expect_double();
             string s2 = format(fmt.c_str(), f2);
             string s3 = format(fmt.c_str(), f3);
@@ -117,9 +118,9 @@ BOOST_AUTO_TEST_CASE( test_double_parsing2 )
             cerr << "f = " << f << " s = " << s << " f2 = "
                  << f2 << " f3 = " << f3 << endl;
 
-            cerr << "u1 = " << ML::format("%016llx\n", u1)
-                 << "u2 = " << ML::format("%016llx\n", u2)
-                 << "u3 = " << ML::format("%016llx\n", u3);
+            cerr << "u1 = " << MLDB::format("%016llx\n", u1)
+                 << "u2 = " << MLDB::format("%016llx\n", u2)
+                 << "u3 = " << MLDB::format("%016llx\n", u3);
 #endif
 
             // Make sure that strtod can parse it back to the same number
@@ -139,7 +140,7 @@ BOOST_AUTO_TEST_CASE( test_double_parsing3 )
 {
     double f = 1877212.719993526;
     string s = "1877212.719993526";
-    Parse_Context pc(s, s.c_str(), s.c_str() + s.length());
+    ParseContext pc(s, s.c_str(), s.c_str() + s.length());
     double f2 = pc.expect_double();
     char * end = (char *)(s.c_str() + s.length());
     double f3 = strtod(s.c_str(), &end);
@@ -157,7 +158,7 @@ BOOST_AUTO_TEST_CASE( test_large_double_parsing )
     double f = 9.5637941572227e+307;
     string s = "9.5637941572227e+307";
     const char* sp = s.c_str();
-    Parse_Context pcs(s, sp, sp + s.length());
+    ParseContext pcs(s, sp, sp + s.length());
     double f2 = pcs.expect_double();
     char * end = (char *)(s.c_str() + s.length());
     double f3 = strtod(s.c_str(), &end);
@@ -179,9 +180,9 @@ BOOST_AUTO_TEST_CASE( test_difficult_double_parsing )
    for (long long i: ints_representable_as_double) {
         string s = format("%lld", i);
         const char* sp = s.c_str();
-        Parse_Context pcs(s, sp, sp + s.length());
+        ParseContext pcs(s, sp, sp + s.length());
         {
-            Parse_Context::Revert_Token tok(pcs);
+            ParseContext::Revert_Token tok(pcs);
             double f2 = pcs.expect_double();
             std::cout << i << " " << (long long) f2 << std::endl;
             BOOST_CHECK_EQUAL(i, (long long) f2);
@@ -200,9 +201,9 @@ BOOST_AUTO_TEST_CASE( test_difficult_double_parsing )
    for (long long i: ints_not_representable_as_double) {
        string s = format("%lld", i);
        const char* sp = s.c_str();
-       Parse_Context pcs(s, sp, sp + s.length());
+       ParseContext pcs(s, sp, sp + s.length());
        {
-           Parse_Context::Revert_Token tok(pcs);
+           ParseContext::Revert_Token tok(pcs);
            double f2 = pcs.expect_double();
            std::cout << std::setprecision(18) << strtod(sp, nullptr) << " " << f2 << std::endl;
            BOOST_CHECK_EQUAL(strtod(sp, nullptr), f2);
@@ -216,7 +217,7 @@ BOOST_AUTO_TEST_CASE( test_difficult_double_parsing )
 void test_long_long(long long value)
 {
     string s = format("%lld", value);
-    Parse_Context pc(s, s.c_str(), s.c_str() + s.length());
+    ParseContext pc(s, s.c_str(), s.c_str() + s.length());
     long long value2 = pc.expect_long_long(value);
     BOOST_CHECK_EQUAL(value, value2);
 }
@@ -233,7 +234,7 @@ BOOST_AUTO_TEST_CASE( test_long_long_parsing )
 
 static const char * testUnicode_str = "0026\n026";
 
-void run_test_unicode(Parse_Context & context)
+void run_test_unicode(ParseContext & context)
 {
     int j = -1 ;
     BOOST_CHECK(context.match_hex4(j));
@@ -248,14 +249,14 @@ void run_test_unicode(Parse_Context & context)
 BOOST_AUTO_TEST_CASE( test_Unicode )
 {
     {
-        Parse_Context context("test unicode",
+        ParseContext context("test unicode",
                               testUnicode_str, testUnicode_str + strlen(testUnicode_str));
         run_test_unicode(context);
     }
 }
 static const char * test1_str = "Here \t is a\tparse context\nwith two\ni mean 3 lines";
 
-void run_test1(Parse_Context & context)
+void run_test1(ParseContext & context)
 {
     BOOST_CHECK(!context.eof());
     BOOST_CHECK_EQUAL(context.get_offset(), 0);
@@ -306,7 +307,7 @@ void run_test1(Parse_Context & context)
     BOOST_CHECK(context.eof());
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(*context, ML::Exception);
+        BOOST_CHECK_THROW(*context, MLDB::Exception);
     }
     BOOST_CHECK_EQUAL(context.get_offset(), strlen(test1_str));
 }
@@ -316,7 +317,7 @@ BOOST_AUTO_TEST_CASE( test1 )
     cerr << "starting test1" << endl;
 
     {
-        Parse_Context context("test",
+        ParseContext context("test",
                               test1_str, test1_str + strlen(test1_str));
         run_test1(context);
     }
@@ -326,7 +327,7 @@ BOOST_AUTO_TEST_CASE( test1 )
     for (unsigned i = 0;  sizes[i];  ++i) {
         cerr << "starting test1 with size " << sizes[i] << endl;
         istringstream stream(test1_str);
-        Parse_Context context("test", stream, 1, 1, sizes[i]);
+        ParseContext context("test", stream, 1, 1, sizes[i]);
         run_test1(context);
         cerr << "done test" << endl;
    }
@@ -344,18 +345,18 @@ BOOST_AUTO_TEST_CASE( test2 )
         stream << test1_str;
     }
 
-    Parse_Context context(tmp_filename);
+    ParseContext context(tmp_filename);
 
     run_test1(context);
 }
 
-std::string expect_feature_name(Parse_Context & c)
+std::string expect_feature_name(ParseContext & c)
 {
     std::string result;
     /* We have a backslash escaped name. */
     bool after_backslash = false;
     
-    Parse_Context::Revert_Token tok(c);
+    ParseContext::Revert_Token tok(c);
     
     int len = 0;
     while (c && *c != '\n') {
@@ -389,7 +390,7 @@ std::string expect_feature_name(Parse_Context & c)
 BOOST_AUTO_TEST_CASE( test3 )
 {
     string header = "LABEL X Y";
-    Parse_Context context("test file", header.c_str(),
+    ParseContext context("test file", header.c_str(),
                           header.c_str() + header.size());
 
     BOOST_CHECK(context);
@@ -406,7 +407,7 @@ BOOST_AUTO_TEST_CASE( test3 )
 BOOST_AUTO_TEST_CASE( test4 )
 {
     string file = "LABEL X Y\n1 0 0\n0 1 0\n0 0 1\n1 1 1\n";
-    Parse_Context context("test file", file.c_str(),
+    ParseContext context("test file", file.c_str(),
                           file.c_str() + file.size());
     
     BOOST_CHECK(context);
@@ -432,7 +433,7 @@ BOOST_AUTO_TEST_CASE( test4 )
 BOOST_AUTO_TEST_CASE( test5 )
 {
     string file = "1.234e-05";
-    Parse_Context context("test file", file.c_str(),
+    ParseContext context("test file", file.c_str(),
                           file.c_str() + file.size());
 
     float f = context.expect_float();
@@ -444,7 +445,7 @@ BOOST_AUTO_TEST_CASE( test5 )
 BOOST_AUTO_TEST_CASE( test6 )
 {
     string file = "33 nan nan 1 nan nan 2 -nan +nan";
-    Parse_Context context("test file", file.c_str(),
+    ParseContext context("test file", file.c_str(),
                           file.c_str() + file.size());
 
     float f = context.expect_float();
@@ -491,7 +492,7 @@ BOOST_AUTO_TEST_CASE( test_big_chunk_size )
     
     istringstream stream(s);
 
-    Parse_Context context("test file", stream);
+    ParseContext context("test file", stream);
     
     // 1G, can't possibly fit on stack
     context.set_chunk_size(1024 * 1024 * 1024);
@@ -523,7 +524,7 @@ BOOST_AUTO_TEST_CASE( test_chunking_stream1 )
     for (unsigned i = 0;  i < nchunk_sizes;  ++i) {
         istringstream stream(s);
 
-        Parse_Context context("test file", stream, 1, 1, 1);
+        ParseContext context("test file", stream, 1, 1, 1);
         
         context.set_chunk_size(chunk_sizes[i]);
 
@@ -575,7 +576,7 @@ void test_csv_data_size(int chunk_size, vector<vector<string> > & reference)
     cerr << "input_file = " << input_file << endl;
 
     MLDB::filter_istream stream(input_file);
-    Parse_Context context(input_file, stream);
+    ParseContext context(input_file, stream);
 
     context.set_chunk_size(chunk_size);
 
@@ -623,7 +624,7 @@ BOOST_AUTO_TEST_CASE( test_token )
 {
     string s = "aaabac";
     istringstream stream(s);
-    Parse_Context context("test", stream, 1, 1, 1 /* chunk size */);
+    ParseContext context("test", stream, 1, 1, 1 /* chunk size */);
     
     BOOST_CHECK_EQUAL(context.readahead_available(), 1);
     BOOST_CHECK_EQUAL(context.total_buffered(), 1);
@@ -631,7 +632,7 @@ BOOST_AUTO_TEST_CASE( test_token )
     BOOST_CHECK_EQUAL(context.get_offset(), 0);
 
     {
-        Parse_Context::Revert_Token token(context);
+        ParseContext::Revert_Token token(context);
 
         BOOST_CHECK_EQUAL(*context, 'a');
         BOOST_CHECK_EQUAL(context.total_buffered(), 1);
@@ -657,7 +658,7 @@ BOOST_AUTO_TEST_CASE( test_token )
         BOOST_CHECK_EQUAL(context.total_buffered(), 6);
         BOOST_CHECK_EQUAL(context.get_offset(), 5);
         ++context;
-        Parse_Context::Revert_Token token2(context);
+        ParseContext::Revert_Token token2(context);
     }
 
     BOOST_CHECK_EQUAL(context.get_offset(), 0);
@@ -669,7 +670,7 @@ BOOST_AUTO_TEST_CASE( test_token )
 BOOST_AUTO_TEST_CASE(test_dodgy_float_parsing1)
 {
     string s = "3eabd3c2-825c-11e0-a4a8-0026b937c890";
-    Parse_Context c1(s, s.c_str(), s.c_str() + s.length());
+    ParseContext c1(s, s.c_str(), s.c_str() + s.length());
     double d = -1.0;
     BOOST_CHECK(c1.match_double(d));
     BOOST_CHECK_EQUAL(d, 3.0);
@@ -679,7 +680,7 @@ BOOST_AUTO_TEST_CASE(test_dodgy_float_parsing1)
 BOOST_AUTO_TEST_CASE(test_dodgy_float_parsing2)
 {
     string s = "Englewood";
-    Parse_Context c1(s, s.c_str(), s.c_str() + s.length());
+    ParseContext c1(s, s.c_str(), s.c_str() + s.length());
     double d = -1.0;
     BOOST_CHECK(!c1.match_double(d));
     BOOST_CHECK_EQUAL(d, -1.0);
@@ -689,7 +690,7 @@ BOOST_AUTO_TEST_CASE(test_dodgy_float_parsing2)
 BOOST_AUTO_TEST_CASE(test_dodgy_float_parsing3)
 {
     string s = "";
-    Parse_Context c1(s, s.c_str(), s.c_str() + s.length());
+    ParseContext c1(s, s.c_str(), s.c_str() + s.length());
     double d = -1.0;
     BOOST_CHECK(!c1.match_double(d));
     BOOST_CHECK_EQUAL(d, -1.0);
@@ -698,7 +699,7 @@ BOOST_AUTO_TEST_CASE(test_dodgy_float_parsing3)
 BOOST_AUTO_TEST_CASE(test_dodgy_float_parsing4)
 {
     string s = "-";
-    Parse_Context c1(s, s.c_str(), s.c_str() + s.length());
+    ParseContext c1(s, s.c_str(), s.c_str() + s.length());
     double d = -1.0;
     BOOST_CHECK(!c1.match_double(d));
     BOOST_CHECK_EQUAL(d, -1.0);
@@ -707,7 +708,7 @@ BOOST_AUTO_TEST_CASE(test_dodgy_float_parsing4)
 BOOST_AUTO_TEST_CASE(test_dodgy_float_parsing5)
 {
     string s = "+";
-    Parse_Context c1(s, s.c_str(), s.c_str() + s.length());
+    ParseContext c1(s, s.c_str(), s.c_str() + s.length());
     double d = -1.0;
     BOOST_CHECK(!c1.match_double(d));
     BOOST_CHECK_EQUAL(d, -1.0);
@@ -716,7 +717,7 @@ BOOST_AUTO_TEST_CASE(test_dodgy_float_parsing5)
 BOOST_AUTO_TEST_CASE(test_match_literal_at_eof)
 {
     string s = "hello";
-    Parse_Context c1(s, s.c_str(), s.c_str() + s.length());
+    ParseContext c1(s, s.c_str(), s.c_str() + s.length());
     BOOST_CHECK(c1.match_literal("hello"));
     BOOST_CHECK(!c1.match_literal("one"));
 }
@@ -724,12 +725,12 @@ BOOST_AUTO_TEST_CASE(test_match_literal_at_eof)
 BOOST_AUTO_TEST_CASE(test_revert_token_at_eof)
 {
     string s = "a";
-    Parse_Context c1(s, s.c_str(), s.c_str() + s.length());
+    ParseContext c1(s, s.c_str(), s.c_str() + s.length());
     ++c1;
-    Parse_Context::Hold_Token token1(c1);
+    ParseContext::Hold_Token token1(c1);
     try {
-        Parse_Context::Revert_Token token(c1);
-        throw ML::Exception("hello");
+        ParseContext::Revert_Token token(c1);
+        throw MLDB::Exception("hello");
     } catch (const std::exception & exc) {
         cerr << "got exception " << exc.what() << endl;
     }

--- a/jml/utils/testing/string_functions_test.cc
+++ b/jml/utils/testing/string_functions_test.cc
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE( test_antoi )
     BOOST_CHECK(antoi(d, d + 2) == -1);
 
     const char * p = "patate";
-    BOOST_CHECK_THROW(antoi(p, p + 6), ML::Exception);
+    BOOST_CHECK_THROW(antoi(p, p + 6), MLDB::Exception);
 }
 
 BOOST_AUTO_TEST_CASE( test_string_replace_in_place )

--- a/logging/logging.cc
+++ b/logging/logging.cc
@@ -65,7 +65,7 @@ void Logging::FileWriter::open(char const * filename, char const mode) {
     else if (mode == 'w')
         file.open(filename);
     else
-        throw ML::Exception("File mode not recognized");
+        throw MLDB::Exception("File mode not recognized");
 
     if(!file) {
         std::cerr << "unable to open log file '" << filename << "'" << std::endl;
@@ -353,7 +353,7 @@ void Logging::Thrower::operator&(std::ostream & stream) {
     text.str("");
     loggingMutex.unlock();
 
-    throw ML::Exception(message);
+    throw MLDB::Exception(message);
 }
 
 } // namespace MLDB

--- a/ml/algebra/irls.cc
+++ b/ml/algebra/irls.cc
@@ -35,7 +35,7 @@ double erf(double x)
 double erfinv(double y)
 {
     // TODO: if we use boost here, then Valgrind doesn't work
-    throw ML::Exception("no error function inverse available");
+    throw MLDB::Exception("no error function inverse available");
     //return std::erfinv(y);
 }
 

--- a/ml/algebra/irls.h
+++ b/ml/algebra/irls.h
@@ -1,14 +1,12 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* irls.h                                                          -*- C++ -*-
    Jeremy Barnes, 19 March 2004
    Copyright (c) 2004 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Iteratively Reweighted Least Squares.
 */
 
-#ifndef __boosting__irls_h__
-#define __boosting__irls_h__
+#pragma once
 
 #include <vector>
 #include <boost/multi_array.hpp>
@@ -17,6 +15,8 @@
 #include "mldb/jml/utils/enum_info.h"
 
 namespace ML {
+
+using namespace MLDB;
 
 /*****************************************************************************/
 /* Regularization                                                            */
@@ -369,6 +369,4 @@ perform_irls(const distribution<double> & correct,
 
 DECLARE_ENUM_INFO(ML::Link_Function, 5);
 DECLARE_ENUM_INFO(ML::Regularization, 3);
-
-#endif /* __boosting__irls_h__ */
 

--- a/ml/algebra/least_squares.cc
+++ b/ml/algebra/least_squares.cc
@@ -276,7 +276,7 @@ struct RidgeRegressionIteration {
 
     void run(const distribution<Float> & singular_values,
              const boost::multi_array<Float, 2> & A,
-             const ML::distribution<Float> & b,
+             const distribution<Float> & b,
              const boost::multi_array<Float, 2> & VT,
              const boost::multi_array<Float, 2> & U,
              const boost::multi_array<Float, 2> & GK,
@@ -412,7 +412,7 @@ template<typename Float>
 struct RidgeRegressionIterations: public std::vector<RidgeRegressionIteration<Float> > {
     void run(const distribution<Float> & singular_values,
              const boost::multi_array<Float, 2> & A,
-             const ML::distribution<Float> & b,
+             const distribution<Float> & b,
              const boost::multi_array<Float, 2> & VT,
              const boost::multi_array<Float, 2> & U,
              const boost::multi_array<Float, 2> & GK,
@@ -690,7 +690,7 @@ lasso_regression_impl(const boost::multi_array<Float, 2> & A,
         if (iter >= maxIter) {
             // if we stopped after max iteration and not because we have
             // converge, let's issue a warning
-            cerr << ML::format("LASSO did not converge in %i iterations, last "
+            cerr << MLDB::format("LASSO did not converge in %i iterations, last "
                                " max_step > eps (%f > %f)",
                                iter, max_step, epsilon);
             break;

--- a/ml/algebra/matrix_ops.h
+++ b/ml/algebra/matrix_ops.h
@@ -28,7 +28,7 @@ operator << (std::ostream & stream, const boost::multi_array<Float, 2> & m)
     for (unsigned i = 0;  i < m.shape()[0];  ++i) {
         stream << "    [";
         for (unsigned j = 0;  j < m.shape()[1];  ++j)
-            stream << ML::format(" %8.3g", m[i][j]);
+            stream << MLDB::format(" %8.3g", m[i][j]);
         stream << " ]" << std::endl;
     }
     return stream;
@@ -55,6 +55,7 @@ inline void warmup_cache_all_levels(const double * mem, size_t n)
 }
 
 namespace ML {
+using namespace MLDB;
 // Copy a chunk of a matrix transposed to another place
 template<typename Float>
 void copy_transposed(boost::multi_array<Float, 2> & A,
@@ -200,16 +201,16 @@ std::string print_size(const boost::multi_array<Float, 2> & array)
 /*****************************************************************************/
 
 template<typename FloatR, typename Float1, typename Float2>
-ML::distribution<FloatR>
+distribution<FloatR>
 multiply_r(const boost::multi_array<Float1, 2> & A,
-           const ML::distribution<Float2> & b)
+           const distribution<Float2> & b)
 {
     if (b.size() != A.shape()[1])
         throw Exception(format("multiply(matrix, vector): "
                                "shape (%dx%d) x (%dx1) wrong",
                                (int)A.shape()[0], (int)A.shape()[1],
                                (int)b.size()));
-    ML::distribution<FloatR> result(A.shape()[0], 0.0);
+    distribution<FloatR> result(A.shape()[0], 0.0);
     for (unsigned i = 0;  i < A.shape()[0];  ++i)
         result[i] = SIMD::vec_dotprod_dp(&A[i][0], &b[0], A.shape()[1]);
     //for (unsigned j = 0;  j < A.shape()[1];  ++j)
@@ -221,7 +222,7 @@ template<typename Float1, typename Float2>
 //JML_ALWAYS_INLINE
 distribution<typename float_traits<Float1, Float2>::return_type>
 multiply(const boost::multi_array<Float1, 2> & A,
-         const ML::distribution<Float2> & b)
+         const distribution<Float2> & b)
 {
     return multiply_r<typename float_traits<Float1, Float2>::return_type>(A, b);
 }
@@ -230,7 +231,7 @@ template<typename Float1, typename Float2>
 //JML_ALWAYS_INLINE
 distribution<typename float_traits<Float1, Float2>::return_type>
 operator * (const boost::multi_array<Float1, 2> & A,
-            const ML::distribution<Float2> & b)
+            const distribution<Float2> & b)
 {
     typedef typename float_traits<Float1, Float2>::return_type FloatR;
     return multiply_r<FloatR, Float1, Float2>(A, b);
@@ -242,8 +243,8 @@ operator * (const boost::multi_array<Float1, 2> & A,
 /*****************************************************************************/
 
 template<typename FloatR, typename Float1, typename Float2>
-ML::distribution<FloatR>
-multiply_r(const ML::distribution<Float2> & b,
+distribution<FloatR>
+multiply_r(const distribution<Float2> & b,
            const boost::multi_array<Float1, 2> & A)
 {
     if (b.size() != A.shape()[0])
@@ -252,7 +253,7 @@ multiply_r(const ML::distribution<Float2> & b,
                                (int)b.size(),
                                (int)A.shape()[0], (int)A.shape()[1]));
 
-    ML::distribution<FloatR> result(A.shape()[1], 0.0);
+    distribution<FloatR> result(A.shape()[1], 0.0);
 #if 1 // more accurate
     std::vector<double> accum(A.shape()[1], 0.0);
     using namespace std;
@@ -276,7 +277,7 @@ multiply_r(const ML::distribution<Float2> & b,
 template<typename Float1, typename Float2>
 //JML_ALWAYS_INLINE
 distribution<typename float_traits<Float1, Float2>::return_type>
-multiply(const ML::distribution<Float2> & b,
+multiply(const distribution<Float2> & b,
          const boost::multi_array<Float1, 2> & A)
 {
     return multiply_r<typename float_traits<Float1, Float2>::return_type>(b, A);
@@ -285,7 +286,7 @@ multiply(const ML::distribution<Float2> & b,
 template<typename Float1, typename Float2>
 //JML_ALWAYS_INLINE
 distribution<typename float_traits<Float1, Float2>::return_type>
-operator * (const ML::distribution<Float2> & b,
+operator * (const distribution<Float2> & b,
             const boost::multi_array<Float1, 2> & A)
 {
     typedef typename float_traits<Float1, Float2>::return_type FloatR;
@@ -303,7 +304,7 @@ multiply_r(const boost::multi_array<Float1, 2> & A,
            const boost::multi_array<Float2, 2> & B)
 {
     if (A.shape()[1] != B.shape()[0])
-        throw ML::Exception("Incompatible matrix sizes");
+        throw MLDB::Exception("Incompatible matrix sizes");
 
     boost::multi_array<FloatR, 2> X(boost::extents[A.shape()[0]][B.shape()[1]]);
     Float2 bentries[A.shape()[1]];
@@ -372,7 +373,7 @@ multiply_transposed(const boost::multi_array<Float1, 2> & A,
     int As1 = A.shape()[1];
 
     if (A.shape()[1] != BT.shape()[1])
-        throw ML::Exception("Incompatible matrix sizes");
+        throw MLDB::Exception("Incompatible matrix sizes");
 
     boost::multi_array<FloatR, 2> X(boost::extents[As0][Bs0]);
     for (unsigned j = 0;  j < Bs0;  ++j) {
@@ -408,7 +409,7 @@ add_r(const boost::multi_array<Float1, 2> & A,
 {
     if (A.shape()[0] != B.shape()[0]
         || A.shape()[1] != B.shape()[1])
-        throw ML::Exception("Incompatible matrix sizes");
+        throw MLDB::Exception("Incompatible matrix sizes");
     
     boost::multi_array<FloatR, 2> X(boost::extents[A.shape()[0]][A.shape()[1]]);
 
@@ -450,7 +451,7 @@ subtract_r(const boost::multi_array<Float1, 2> & A,
 {
     if (A.shape()[0] != B.shape()[0]
         || A.shape()[1] != B.shape()[1])
-        throw ML::Exception("Incompatible matrix sizes");
+        throw MLDB::Exception("Incompatible matrix sizes");
     
     boost::multi_array<FloatR, 2> X(boost::extents[A.shape()[0]][A.shape()[1]]);
 

--- a/ml/bucketing_probabilizer.cc
+++ b/ml/bucketing_probabilizer.cc
@@ -38,10 +38,10 @@ trainBucketingProbabilizer(
     auto ctr_buckets = predAccum.getCTRBuckets(num_buckets, calibrateToGroup,
             calibrateCountsRef);
     if(ctr_buckets.size()==1)
-        throw ML::Exception(ML::format("Problem with CTR buckets. Asked for "
+        throw MLDB::Exception(MLDB::format("Problem with CTR buckets. Asked for "
                     "%d buckets; only one back.", num_buckets));
     if(ctr_buckets.size()<num_buckets)
-        cerr << ML::format("WARNING. Asked for %d buckets, got %d back",
+        cerr << MLDB::format("WARNING. Asked for %d buckets, got %d back",
                 num_buckets, ctr_buckets.size()) << endl;
     
     return ctr_buckets;
@@ -88,7 +88,7 @@ autoTrainBucketingProbabilizer(Prediction_Accumulator & predAccum,
                 double imps = ctr_bucket.second.second;
                 double p = imps/totalImps / (1.0/ctr_buckets.size());
                 if (p < 0.1) {
-                    cout << ML::format("   Rejected because a bucket is only %0.3f "
+                    cout << MLDB::format("   Rejected because a bucket is only %0.3f "
                             "of what it should be. Min is 0.1", p) << endl;
                     done = false;
                     break;
@@ -112,18 +112,18 @@ autoTrainBucketingProbabilizer(Prediction_Accumulator & predAccum,
 
     cerr << "=== Probabilizer training will fail. Printing last 5 bucketing attemps ===" << endl;
     for(auto it = bucketsCache.begin(); it != bucketsCache.end(); it++) {
-        cerr << ML::format("  %d buckets:", it->first) << endl;
+        cerr << MLDB::format("  %d buckets:", it->first) << endl;
         for(const std::pair<double, std::pair<double, double>> & b : it->second) {
-        cerr << ML::format("     thresh: %0.4f     %0.6f/%0.6f = %0.8f", b.first,
+        cerr << MLDB::format("     thresh: %0.4f     %0.6f/%0.6f = %0.8f", b.first,
                 b.second.first, b.second.second, b.second.first/b.second.second) << endl;
         }
     }
-    throw ML::Exception("Unable to train probabilizer.");
+    throw MLDB::Exception("Unable to train probabilizer.");
 }
 Bucketing_Probabilizer::
 Bucketing_Probabilizer(const std::string & load_from)
 {
-    throw ML::Exception("deprecated");
+    throw MLDB::Exception("deprecated");
     //filter_istream stream(load_from);
     //ML::DB::Store_Reader store(stream);
     //reconstitute(store);
@@ -167,7 +167,7 @@ getBucketingProbabFromExpConfig(const std::string & trainedPath,
                 std::string errorMsg = "Error parsing JSON in file '" +
                     path + "':\n" +
                     reader.getFormattedErrorMessages();
-                throw ML::Exception(errorMsg);
+                throw MLDB::Exception(errorMsg);
             }
 
             return root;
@@ -235,7 +235,7 @@ doInit(const std::string & name, const std::string & prob_type,
             };
     }
     else {
-        throw ML::Exception("Unknown prob type '"+prob_type+"'");
+        throw MLDB::Exception("Unknown prob type '"+prob_type+"'");
     }
 
     // Precompute prob for buckets
@@ -253,7 +253,7 @@ size_t Bucketing_Probabilizer::
 getBucket(float score) const
 {
     if(ctr_buckets.size()==0)
-        throw ML::Exception("ctr buckets is empty!");
+        throw MLDB::Exception("ctr buckets is empty!");
 
     for(unsigned bucket_id=0; bucket_id<ctr_buckets.size(); bucket_id++) {
         if(ctr_buckets[bucket_id].first < score)
@@ -269,10 +269,10 @@ float Bucketing_Probabilizer::
 getProbForBucket(size_t bucket) const
 {
     if(ctr_buckets.size()==0)
-        throw ML::Exception("ctr buckets is empty!");
+        throw MLDB::Exception("ctr buckets is empty!");
 
     if(bucket >= ctr_buckets.size())
-        throw ML::Exception("bucket id out of bounds");
+        throw MLDB::Exception("bucket id out of bounds");
 
     return ctrs[bucket];
 }
@@ -281,7 +281,7 @@ float Bucketing_Probabilizer::
 getProb(float score) const
 {
     if(ctr_buckets.size()==0)
-        throw ML::Exception("ctr buckets is empty!");
+        throw MLDB::Exception("ctr buckets is empty!");
 
     for(unsigned bucket_id=0; bucket_id<ctr_buckets.size(); bucket_id++) {
         if(ctr_buckets[bucket_id].first < score)
@@ -341,7 +341,7 @@ reconstitute(ML::DB::Store_Reader & store)
     int version;
     store >> version;
     if (version != 1)
-        throw ML::Exception("wrong Bucketing_Probabilizer version!");
+        throw MLDB::Exception("wrong Bucketing_Probabilizer version!");
 
     store >> ctr_buckets >> ctrs >> 
         name >> type >> prob_type;

--- a/ml/confidence_intervals.cc
+++ b/ml/confidence_intervals.cc
@@ -47,7 +47,7 @@ void ConfidenceIntervals::init(std::string m) {
         method = CLOPPER_PEARSON;
     }
     else {
-        throw ML::Exception(ML::format("Unknown confidence interval method '%s'", m.c_str()));
+        throw MLDB::Exception(MLDB::format("Unknown confidence interval method '%s'", m.c_str()));
     }
 }
 
@@ -76,7 +76,7 @@ binomialUpperBound(int trials, int successes) const
     case WILSON:          return wilsonBinomialUpperLowerBound(trials, successes, UPPER);
     case CLOPPER_PEARSON: return math::binomial_distribution<>::find_upper_bound_on_p(trials, successes, alpha_);
     }
-    throw ML::Exception(ML::format("Unknown method '%s'", method));
+    throw MLDB::Exception(MLDB::format("Unknown method '%s'", method));
 }
 
 double
@@ -87,7 +87,7 @@ binomialLowerBound(int trials, int successes) const
     case WILSON:          return wilsonBinomialUpperLowerBound(trials, successes, LOWER);
     case CLOPPER_PEARSON: return math::binomial_distribution<>::find_lower_bound_on_p(trials, successes, alpha_);
     }
-    throw ML::Exception(ML::format("Unknown method '%s'", method));
+    throw MLDB::Exception(MLDB::format("Unknown method '%s'", method));
 }
 
 pair<double,double>
@@ -111,7 +111,7 @@ createBootstrapSamples(const vector<double>& sample, int replications,
 
     if(sampleSize ==0)
     {
-        throw ML::Exception("Can't compute bootstrap mean from empty sample");
+        throw MLDB::Exception("Can't compute bootstrap mean from empty sample");
     }
 
     ML::Thread_Context rng;
@@ -165,7 +165,7 @@ bootstrapMeanTwoSidedBound(const vector<double>& sample, int replications,
 void ConfidenceIntervals::assertClopperPearson() const
 {
     if (method != CLOPPER_PEARSON)
-        throw ML::Exception("Can only use this method with Clopper-Peason method!");
+        throw MLDB::Exception("Can only use this method with Clopper-Peason method!");
 }
         
 std::string ConfidenceIntervals::
@@ -175,7 +175,7 @@ print(Method m) const
     case WILSON:          return "wilson";
     case CLOPPER_PEARSON: return "clopper_pearson";
     default:
-        throw ML::Exception("Unknown method");
+        throw MLDB::Exception("Unknown method");
     }
 }
 
@@ -193,7 +193,7 @@ reconstitute(ML::DB::Store_Reader & store)
     int REQUIRED_V = 1;
     store >> version;
     if(version!=REQUIRED_V) {
-        throw ML::Exception(ML::format(
+        throw MLDB::Exception(MLDB::format(
                     "invalid ConfidenceInterval version! exptected %d, got %d", 
                     REQUIRED_V, version));
     }

--- a/ml/dense_classifier.cc
+++ b/ml/dense_classifier.cc
@@ -155,7 +155,7 @@ serialize(DB::Store_Writer & store) const
 
 float
 DenseClassifier::
-score(const ML::distribution<float> & features) const
+score(const distribution<float> & features) const
 {
     float mapper_output[mapping_.num_vars_expected_];
 
@@ -169,7 +169,7 @@ score(const ML::distribution<float> & features) const
 
 float
 DenseClassifier::
-scoreUnbiased(const ML::distribution<float> & features,
+scoreUnbiased(const distribution<float> & features,
               PipelineExecutionContext & context) const
 {
     float mapper_output[mapping_.num_vars_expected_];
@@ -184,7 +184,7 @@ scoreUnbiased(const ML::distribution<float> & features,
 
 ML::Label_Dist
 DenseClassifier::
-labelScores(const ML::distribution<float> & features) const
+labelScores(const distribution<float> & features) const
 {
     float mapper_output[mapping_.num_vars_expected_];
 
@@ -198,7 +198,7 @@ labelScores(const ML::distribution<float> & features) const
 
 ML::Label_Dist
 DenseClassifier::
-labelScoresUnbiased(const ML::distribution<float> & features,
+labelScoresUnbiased(const distribution<float> & features,
                     PipelineExecutionContext & context) const
 {
     float mapper_output[mapping_.num_vars_expected_];
@@ -213,7 +213,7 @@ labelScoresUnbiased(const ML::distribution<float> & features,
 
 std::pair<ML::Explanation, std::shared_ptr<Mutable_Feature_Set> >
 DenseClassifier::
-explain(const ML::distribution<float> & features,
+explain(const distribution<float> & features,
         int label) const
 {
     std::shared_ptr<Mutable_Feature_Set> fset
@@ -224,7 +224,7 @@ explain(const ML::distribution<float> & features,
 
 std::pair<ML::Explanation, std::shared_ptr<Mutable_Feature_Set> >
 DenseClassifier::
-explainUnbiased(const ML::distribution<float> & features,
+explainUnbiased(const distribution<float> & features,
                 int label,
                 PipelineExecutionContext & context) const
 {

--- a/ml/dense_classifier.h
+++ b/ml/dense_classifier.h
@@ -61,19 +61,19 @@ struct DenseClassifier {
     void serialize(ML::DB::Store_Writer & store) const;
 
     /** Calculate the score for a given feature set. */
-    float score(const ML::distribution<float> & features) const;
+    float score(const distribution<float> & features) const;
 
     /** Calculate the score for a given feature set. */
-    float scoreUnbiased(const ML::distribution<float> & features,
+    float scoreUnbiased(const distribution<float> & features,
                         PipelineExecutionContext & context) const;
 
     /** Calculate the label scores for a given feature set. */
     ML::Label_Dist
-    labelScores(const ML::distribution<float> & features) const;
+    labelScores(const distribution<float> & features) const;
 
     /** Calculate the label scores for a given feature set. */
     ML::Label_Dist
-    labelScoresUnbiased(const ML::distribution<float> & features,
+    labelScoresUnbiased(const distribution<float> & features,
                         PipelineExecutionContext & context) const;
 
     std::shared_ptr<ML::Classifier_Impl> classifier() const
@@ -103,7 +103,7 @@ struct DenseClassifier {
         to make the explanation.
     */
     std::pair<ML::Explanation, std::shared_ptr<ML::Mutable_Feature_Set> >
-    explain(const ML::distribution<float> & features,
+    explain(const distribution<float> & features,
             int label) const;
 
     /** Explain which features contributed to what extent to the
@@ -113,7 +113,7 @@ struct DenseClassifier {
         to make the explanation.
     */
     std::pair<ML::Explanation, std::shared_ptr<ML::Mutable_Feature_Set> >
-    explainUnbiased(const ML::distribution<float> & features,
+    explainUnbiased(const distribution<float> & features,
                     int label,
                     PipelineExecutionContext & context) const;
 

--- a/ml/dense_classifier_scorer.cc
+++ b/ml/dense_classifier_scorer.cc
@@ -190,7 +190,7 @@ dumpFeatureVectors(std::ostream & stream,
 
             std::tie(label, user, weight) = partition.getExample(exampleNum);
 
-            std::string line = ML::format("%d %f ", label, weight);
+            std::string line = MLDB::format("%d %f ", label, weight);
             std::string extraFeatures, comment;
             
             if (gfac)
@@ -316,7 +316,7 @@ trainProbabilizer(const DataPartition & partition,
     filter_ostream out("prob-in.txt");
 
     for (unsigned i = 0;  i < nd;  ++i) {
-        out << ML::format("%.15f %.16f %d\n",
+        out << MLDB::format("%.15f %.16f %d\n",
                           outputs[0][i],
                           outputs[1][i],
                           correct[i]);
@@ -486,7 +486,7 @@ explainFeaturesGeneric(const ML::Explanation & explanation,
         = classifier.mapping();
 
     // Get the feature weights
-    ML::distribution<float> weightsIn(arity);
+    distribution<float> weightsIn(arity);
     
     // And now break it down...
     for (auto & fw: explanation.feature_weights) {
@@ -546,12 +546,12 @@ reconstitute(ML::DB::Store_Reader & store)
     unsigned char version;
     store >> version;
     if (version > 2)
-        throw ML::Exception("unknown DenseClassifierScorer version "
+        throw MLDB::Exception("unknown DenseClassifierScorer version "
                             "to reconstitute");
     string tag;
     store >> tag;
     if (tag != "DenseClassifierScorer")
-        throw ML::Exception("unknown DenseClassifierScorer tag [" + tag + "]");
+        throw MLDB::Exception("unknown DenseClassifierScorer tag [" + tag + "]");
     if (version >= 2 )
         store >> truePositiveRate;
     else

--- a/ml/dense_classifier_scorer.h
+++ b/ml/dense_classifier_scorer.h
@@ -201,7 +201,7 @@ struct DenseClassifierScorerT
             = std::dynamic_pointer_cast<DenseFeatureGeneratorT<Args...> >
             (featureGenerator);
         if (!featureGeneratorCast)
-            throw ML::Exception("couldn't cast dense feature generator");
+            throw MLDB::Exception("couldn't cast dense feature generator");
     }
 
     /** Reconstitute from disk. */

--- a/ml/dense_feature_generator.cc
+++ b/ml/dense_feature_generator.cc
@@ -33,7 +33,7 @@ explain(int numFeatures) const
     std::string result;
 
     for (auto & v: sorted)
-        result += ML::format("%12.6f ", v.second) + v.first + "\n";
+        result += MLDB::format("%12.6f ", v.second) + v.first + "\n";
 
     return result;
 }
@@ -68,7 +68,7 @@ void
 DenseFeatureGenerator::
 serialize(ML::DB::Store_Writer & store) const
 {
-    throw ML::Exception("DenseFeatureGenerator " + ML::type_name(*this)
+    throw MLDB::Exception("DenseFeatureGenerator " + MLDB::type_name(*this)
                         + " doesn't support serialization/reconstitution");
 }
 
@@ -76,7 +76,7 @@ void
 DenseFeatureGenerator::
 reconstitute(ML::DB::Store_Reader & store)
 {
-    throw ML::Exception("DenseFeatureGenerator " + ML::type_name(*this)
+    throw MLDB::Exception("DenseFeatureGenerator " + MLDB::type_name(*this)
                         + " doesn't support serialization/reconstitution");
 }
 
@@ -84,7 +84,7 @@ std::pair<std::string, std::string>
 DenseFeatureGenerator::
 className() const
 {
-    throw ML::Exception("DenseFeatureGenerator " + ML::type_name(*this)
+    throw MLDB::Exception("DenseFeatureGenerator " + MLDB::type_name(*this)
                         + " doesn't support serialization/reconstitution");
 }
 
@@ -95,11 +95,11 @@ polyReconstitute(ML::DB::Store_Reader & store)
     unsigned char version;
     store >> version;
     if (version != 0)
-        throw ML::Exception("unexpected poly reconstitute version");
+        throw MLDB::Exception("unexpected poly reconstitute version");
     std::string tag;
     store >> tag;
     if (tag != "DenseFeatureGeneratorPoly")
-        throw ML::Exception("unexpected poly reconstitute tag "
+        throw MLDB::Exception("unexpected poly reconstitute tag "
                             + tag);
 
     std::string type, args;
@@ -109,7 +109,7 @@ polyReconstitute(ML::DB::Store_Reader & store)
     std::unique_lock<std::recursive_mutex> guard(registry.featureGeneratorsLock);
     auto it = registry.featureGenerators.find(type);
     if (it == registry.featureGenerators.end())
-        throw ML::Exception("couldn't reconstitute DenseFeatureGenerator "
+        throw MLDB::Exception("couldn't reconstitute DenseFeatureGenerator "
                             "of type " + type + " with args '" + args
                             + "'");
     auto result = it->second.factory(args);
@@ -117,7 +117,7 @@ polyReconstitute(ML::DB::Store_Reader & store)
 
     store >> tag;
     if (tag != "DenseFeatureGeneratorPolyEnd")
-        throw ML::Exception("unexpected poly reconstitute ending tag "
+        throw MLDB::Exception("unexpected poly reconstitute ending tag "
                             + tag);
 
     return result;
@@ -151,7 +151,7 @@ registerFactory(const std::string & className,
     FactoryRegistry & registry = getRegistry();
     std::unique_lock<std::recursive_mutex> guard(registry.featureGeneratorsLock);
     if (registry.featureGenerators.count(className))
-        throw ML::Exception("attempt to double register feature generator "
+        throw MLDB::Exception("attempt to double register feature generator "
                             + className);
     registry.featureGenerators[className].factory = factory;
 }

--- a/ml/distribution_pooler.cc
+++ b/ml/distribution_pooler.cc
@@ -21,20 +21,20 @@ using namespace ML;
 
 namespace MLDB {
 
-void DistributionPooler::add(std::shared_ptr<ML::distribution<float>> d)
+void DistributionPooler::add(std::shared_ptr<distribution<float>> d)
 {
     if(!init) {
         for(int i=0; i<d->size(); i++)
-            feature_vectors.push_back(ML::distribution<float>());
+            feature_vectors.push_back(distribution<float>());
         init = true;
     }
     for(int i=0; i<d->size(); i++)
         feature_vectors[i].push_back((*d)[i]);
 }
 
-ML::distribution<float> DistributionPooler::pool()
+distribution<float> DistributionPooler::pool()
 {
-    ML::distribution<float> d;
+    distribution<float> d;
     d.push_back(feature_vectors[0].size());
     for(int i=0; i<feature_vectors.size(); i++) {
         d.push_back(feature_vectors[i].min());

--- a/ml/distribution_pooler.h
+++ b/ml/distribution_pooler.h
@@ -24,12 +24,12 @@ namespace MLDB {
 struct DistributionPooler {
 public:
     DistributionPooler() { init = false;};
-    ML::distribution<float> pool();
-    void add(std::shared_ptr<ML::distribution<float>> d);
+    distribution<float> pool();
+    void add(std::shared_ptr<distribution<float>> d);
 
 private:
     bool init;
-    std::vector<ML::distribution<float>> feature_vectors;
+    std::vector<distribution<float>> feature_vectors;
 };
 
 }

--- a/ml/em.cc
+++ b/ml/em.cc
@@ -29,14 +29,14 @@ typedef boost::multi_array<double, 2> MatrixType;
 
 namespace ML {
 
-double distance(const ML::distribution<double> & x,
-                const ML::distribution<double> & y)
+double distance(const distribution<double> & x,
+                const distribution<double> & y)
 {
     return (x - y).two_norm();
 }
 
-double gaussianDistance(const ML::distribution<double> & pt,
-                        const ML::distribution<double> & origin,
+double gaussianDistance(const distribution<double> & pt,
+                        const distribution<double> & origin,
                         const MatrixType& covarianceMatrix, 
                         const  MatrixType & invertCovarianceMatrix,
                         float determinant)
@@ -62,10 +62,10 @@ double gaussianDistance(const ML::distribution<double> & pt,
 
 boost::multi_array<double, 2>
 EstimateCovariance(int i,
-                   const std::vector<ML::distribution<double>> & points, 
+                   const std::vector<distribution<double>> & points, 
                    const  MatrixType& distanceMatrix,
                    double totalWeight,
-                   ML::distribution<double> average)
+                   distribution<double> average)
 {
     boost::multi_array<double, 2> variant;
 
@@ -75,7 +75,7 @@ EstimateCovariance(int i,
     variant.resize(boost::extents[average.size()][average.size()]);
     for (int n = 0; n < distanceMatrix.shape()[0]; ++n)
     {
-        ML::distribution<double> pt = points[n] - average;
+        distribution<double> pt = points[n] - average;
         double distance = distanceMatrix[n][i];
         int dim = average.size();
         MatrixType variantPt(boost::extents[dim][dim]);
@@ -102,7 +102,7 @@ EstimateCovariance(int i,
 
 void
 EstimationMaximisation::
-train(const std::vector<ML::distribution<double>> & points,
+train(const std::vector<distribution<double>> & points,
       std::vector<int> & in_cluster,
       int nbClusters,
       int maxIterations,
@@ -111,7 +111,7 @@ train(const std::vector<ML::distribution<double>> & points,
     using namespace std;
 
     if (nbClusters < 2)
-        throw ML::Exception("EM with less than 2 clusters doesn't make any sense!");
+        throw MLDB::Exception("EM with less than 2 clusters doesn't make any sense!");
 
     boost::mt19937 rng;
     rng.seed(randomSeed);
@@ -237,7 +237,7 @@ train(const std::vector<ML::distribution<double>> & points,
 
             auto svdMatrix = clusters[i].covarianceMatrix;
             MatrixType VT,U;
-            ML::distribution<double> svalues;
+            distribution<double> svalues;
             ML::svd_square(svdMatrix, VT, U, svalues);
 
             //Remove small values and calculate pseudo determinant
@@ -270,7 +270,7 @@ train(const std::vector<ML::distribution<double>> & points,
 
 int
 EstimationMaximisation::
-assign(const ML::distribution<double> & point) const
+assign(const distribution<double> & point) const
 {
     boost::multi_array<double, 2> dummySoftAssignMatrix;
     return assign(point, dummySoftAssignMatrix, -1);
@@ -278,15 +278,15 @@ assign(const ML::distribution<double> & point) const
 
 int
 EstimationMaximisation::
-assign(const ML::distribution<double> & point,
+assign(const distribution<double> & point,
        boost::multi_array<double, 2>& distanceMatrix,
        int pIndex) const
 {
     using namespace std;
     if (clusters.size() == 0)
-        throw ML::Exception("Did you train your em?");
+        throw MLDB::Exception("Did you train your em?");
 
-    ML::distribution<double> distances(clusters.size());
+    distribution<double> distances(clusters.size());
     for (int i=0; i < clusters.size(); ++i) {
         distances[i]
             = gaussianDistance(point, clusters[i].centroid,
@@ -354,11 +354,11 @@ reconstitute(ML::DB::Store_Reader & store)
     std::string name;
     store >> name;
     if (name != "em")
-        throw ML::Exception("invalid name when loading a EM object");  
+        throw MLDB::Exception("invalid name when loading a EM object");  
     int version;
     store >> version;
     if (version != 1)
-        throw ML::Exception("invalid EM version");
+        throw MLDB::Exception("invalid EM version");
     int nbClusters;
     store >> nbClusters;
     clusters.clear();

--- a/ml/em.h
+++ b/ml/em.h
@@ -18,7 +18,7 @@ struct EstimationMaximisation
 {
     struct Cluster {
         double totalWeight;
-        ML::distribution<double> centroid;
+        distribution<double> centroid;
         boost::multi_array<double, 2> covarianceMatrix;
         boost::multi_array<double, 2> invertCovarianceMatrix;
         double pseudoDeterminant;
@@ -28,18 +28,18 @@ struct EstimationMaximisation
     std::vector<MLDB::Utf8String> columnNames;
 
     void
-    train(const std::vector<ML::distribution<double>> & points,
+    train(const std::vector<distribution<double>> & points,
           std::vector<int> & in_cluster,
           int nbClusters,
           int maxIterations,
           int randomSeed); 
 
     int
-    assign(const ML::distribution<double> & point,
+    assign(const distribution<double> & point,
            boost::multi_array<double, 2>& distanceMatrix,
            int pIndex) const;
     int
-    assign(const ML::distribution<double> & point) const;
+    assign(const distribution<double> & point) const;
   
     void serialize(ML::DB::Store_Writer & store) const;
     void reconstitute(ML::DB::Store_Reader & store);

--- a/ml/jml/boosted_stumps.cc
+++ b/ml/jml/boosted_stumps.cc
@@ -34,7 +34,7 @@ namespace ML {
 
 namespace {
 
-Env_Option<bool> profile("PROFILE_BOOSTED_STUMPS", false);
+EnvOption<bool> profile("PROFILE_BOOSTED_STUMPS", false);
 
 double t_train = 0.0, t_update = 0.0, t_predict = 0.0, t_accuracy = 0.0;
 

--- a/ml/jml/buckets.cc
+++ b/ml/jml/buckets.cc
@@ -16,6 +16,7 @@
 #include "mldb/arch/exception.h"
 
 using namespace std;
+using namespace MLDB;
 
 
 namespace ML {

--- a/ml/jml/classifier.h
+++ b/ml/jml/classifier.h
@@ -228,9 +228,9 @@ public:
             auto fs = feature_space();
             auto & fsr = *fs;
             throw Exception("Couldn't cast feature space of type "
-                            + demangle(typeid(fsr).name())
+                            + MLDB::demangle(typeid(fsr).name())
                             + " to "
-                            + demangle(typeid(Target_FS).name()));
+                            + MLDB::demangle(typeid(Target_FS).name()));
         }
         return result;
     }
@@ -688,9 +688,9 @@ public:
             auto fs = feature_space();
             auto & fsr = *fs;
             throw Exception("Couldn't cast feature space of type "
-                            + demangle(typeid(fsr).name())
+                            + MLDB::demangle(typeid(fsr).name())
                             + " to "
-                            + demangle(typeid(Target_FS).name()));
+                            + MLDB::demangle(typeid(Target_FS).name()));
         }
         return result;
     }

--- a/ml/jml/data_aliases.cc
+++ b/ml/jml/data_aliases.cc
@@ -19,7 +19,7 @@
 #include <mutex>
 
 using namespace std;
-
+using namespace MLDB;
 
 namespace ML {
 
@@ -60,7 +60,7 @@ aliases(const ML::Training_Data & dataset, const Feature & predicted)
 
     //cerr << "aliases" << endl;
     vector<tuple<int, uint64_t, float> > sorted[32];
-    ML::Spinlock sortedLocks[32];
+    Spinlock sortedLocks[32];
     //sorted.resize(dataset.example_count());
 
     auto doHash = [&] (int exampleNum)
@@ -71,7 +71,7 @@ aliases(const ML::Training_Data & dataset, const Feature & predicted)
 
             //cerr << "example " << exampleNum << " hash " << hash << endl;
 
-            std::unique_lock<ML::Spinlock> guard(sortedLocks[hash % 32]);
+            std::unique_lock<Spinlock> guard(sortedLocks[hash % 32]);
             sorted[hash % 32].emplace_back(exampleNum, hash, label);
         };
 
@@ -109,7 +109,7 @@ aliases(const ML::Training_Data & dataset, const Feature & predicted)
             else if (res == 1)
                 return 1;
             else if (res != 0)
-                throw ML::Exception("unexpected compare result");
+                throw MLDB::Exception("unexpected compare result");
 
             return 0;  // equal
         };

--- a/ml/jml/dense_features.cc
+++ b/ml/jml/dense_features.cc
@@ -417,7 +417,7 @@ parse(const std::string & name, Feature & feature) const
 
 bool
 Dense_Feature_Space::
-parse(Parse_Context & context, ML::Feature & feature) const
+parse(ParseContext & context, ML::Feature & feature) const
 {
     /* Todo: quoting, etc. */
     vector<pair<string, size_t> > names_and_lengths;
@@ -441,7 +441,7 @@ parse(Parse_Context & context, ML::Feature & feature) const
 
 void
 Dense_Feature_Space::
-expect(Parse_Context & context, ML::Feature & feature) const
+expect(ParseContext & context, ML::Feature & feature) const
 {
     if (!parse(context, feature))
         throw Exception("Expected name of feature");
@@ -752,7 +752,7 @@ struct Buffer {
 };
 
 std::tuple<size_t, size_t, string>
-get_sizes(Parse_Context & context,
+get_sizes(ParseContext & context,
           vector<unsigned> & row_start_ofs)
 {
     row_start_ofs.clear();
@@ -813,7 +813,7 @@ std::tuple<size_t, size_t, string>
 get_sizes(const std::string & filename,
           vector<unsigned> & row_start_ofs)
 {
-    Parse_Context context(filename);
+    ParseContext context(filename);
 
     return get_sizes(context, row_start_ofs);
 }
@@ -883,13 +883,13 @@ struct Dense_Training_Data::Data_Source {
     const char * data_end;
     mutable std::shared_ptr<MLDB::filter_istream> stream;
 
-    Parse_Context get_context() const
+    ParseContext get_context() const
     {
         if (data)
-            return Parse_Context(filename, data, data_end);
+            return ParseContext(filename, data, data_end);
         else {
             stream.reset(new MLDB::filter_istream(filename));
-            return Parse_Context(filename, *stream);
+            return ParseContext(filename, *stream);
         }
     }
 };
@@ -939,7 +939,7 @@ init(const std::vector<Data_Source> & data_sources,
         size_t my_row_count, my_var_count;
         string my_header;
 
-        Parse_Context context = data_sources[i].get_context();
+        ParseContext context = data_sources[i].get_context();
 
         std::tie(my_row_count, my_var_count, my_header)
             = get_sizes(context, row_start_ofs[i]);
@@ -990,7 +990,7 @@ init(const std::vector<Data_Source> & data_sources,
 
         //cerr << "parsing header " << header << endl;
 
-        Parse_Context context(data_sources[0].filename, header.c_str(),
+        ParseContext context(data_sources[0].filename, header.c_str(),
                               header.c_str() + header.size());
 
         while (context) {
@@ -1065,7 +1065,7 @@ init(const std::vector<Data_Source> & data_sources,
         //cerr << "trying to read..." << endl;
         for (unsigned i = first_nonempty;  i < data_sources.size();  ++i) {
 
-            Parse_Context context = data_sources[i].get_context();
+            ParseContext context = data_sources[i].get_context();
             
             /* Skip over the header */
             context.skip_line();

--- a/ml/jml/dense_features.h
+++ b/ml/jml/dense_features.h
@@ -172,8 +172,8 @@ public:
     virtual std::string print(const Feature & feature) const;
     virtual std::string print(const Feature & feature, float value) const;
     virtual void parse(const std::string & name, Feature & feature) const;
-    virtual bool parse(Parse_Context & context, Feature & feature) const;
-    virtual void expect(Parse_Context & context, Feature & feature) const;
+    virtual bool parse(ParseContext & context, Feature & feature) const;
+    virtual void expect(ParseContext & context, Feature & feature) const;
     virtual void serialize(DB::Store_Writer & store,
                            const Feature & feature) const;
     virtual void reconstitute(DB::Store_Reader & store,

--- a/ml/jml/feature.cc
+++ b/ml/jml/feature.cc
@@ -9,6 +9,8 @@
 #include "feature.h"
 #include "mldb/arch/format.h"
 
+using namespace MLDB;
+
 namespace ML {
 
 

--- a/ml/jml/feature_info.cc
+++ b/ml/jml/feature_info.cc
@@ -17,7 +17,7 @@
 
 
 using namespace std;
-
+using namespace MLDB;
 
 namespace ML {
 
@@ -250,7 +250,7 @@ std::string Feature_Info::print() const
 
 namespace {
 
-std::string expect_category_name(Parse_Context & context)
+std::string expect_category_name(ParseContext & context)
 {
     std::string result;
     
@@ -272,7 +272,7 @@ std::string expect_category_name(Parse_Context & context)
 
 } // file scope
 
-void Mutable_Feature_Info::parse(Parse_Context & context)
+void Mutable_Feature_Info::parse(ParseContext & context)
 {
     type_ = UNKNOWN;
     biased_ = false;

--- a/ml/jml/feature_info.h
+++ b/ml/jml/feature_info.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* feature_info.h                                                  -*- C++ -*-
    Jeremy Barnes, 16 February 2005
    Copyright (c) 2005 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Functions to deal with information on a feature.
 */
@@ -15,6 +14,10 @@
 #include "mldb/jml/db/persistent.h"
 #include "feature_set.h"
 #include "mldb/arch/threads.h"
+
+namespace MLDB {
+struct ParseContext;
+} // namespace MLDB
 
 namespace ML {
 
@@ -264,7 +267,7 @@ struct Mutable_Feature_Info : public Feature_Info {
     void set_grouping(bool grouping);
 
     /** Parse from a text file. */
-    void parse(Parse_Context & context);
+    void parse(ParseContext & context);
 
     /** Stop it from growing. */
     void freeze();

--- a/ml/jml/feature_set.cc
+++ b/ml/jml/feature_set.cc
@@ -21,6 +21,7 @@
 using namespace std;
 using namespace ML;
 using namespace ML::DB;
+using namespace MLDB;
 
 
 
@@ -209,7 +210,7 @@ std::string escape_feature_name(const std::string & feature)
     }
 }
 
-std::string expect_feature_name(Parse_Context & c)
+std::string expect_feature_name(ParseContext & c)
 {
     std::string result;
     if (c.match_literal('"')) {
@@ -218,7 +219,7 @@ std::string expect_feature_name(Parse_Context & c)
         bool after_backslash = false;
         int len = 0;
 
-        Parse_Context::Revert_Token tok(c);
+        ParseContext::Revert_Token tok(c);
 
         while (c && (*c != '"' || after_backslash)) {
             if ((!after_backslash && *c == '"') || *c == '\n') break;
@@ -246,7 +247,7 @@ std::string expect_feature_name(Parse_Context & c)
         /* We have a backslash escaped name. */
         bool after_backslash = false;
         
-        Parse_Context::Revert_Token tok(c);
+        ParseContext::Revert_Token tok(c);
 
         int len = 0;
         while (c && *c != '\n') {

--- a/ml/jml/feature_set.h
+++ b/ml/jml/feature_set.h
@@ -464,7 +464,7 @@ inline void swap(Mutable_Feature_Set & fs1,
 std::string escape_feature_name(const std::string & feature);
 
 /** Parse a feature name escaped by the escape_feature_name function. */
-std::string expect_feature_name(Parse_Context & c);
+std::string expect_feature_name(MLDB::ParseContext & c);
 
 } // namespace ML
 

--- a/ml/jml/feature_set_filter.h
+++ b/ml/jml/feature_set_filter.h
@@ -48,7 +48,7 @@ struct Feature_Set_Filter {
     void parse(const std::string & value,
                const Dense_Feature_Space & fs)
     {
-        Parse_Context context(value, value.c_str(),
+        ParseContext context(value, value.c_str(),
                               value.c_str() + value.size());
 
         context.skip_whitespace();

--- a/ml/jml/feature_space.cc
+++ b/ml/jml/feature_space.cc
@@ -45,15 +45,15 @@ std::string Feature_Space::print(const Feature & feature, float value) const
 
 void Feature_Space::parse(const std::string & name, Feature & feature) const
 {
-    Parse_Context context(name, name.c_str(), name.c_str() + name.length());
+    ParseContext context(name, name.c_str(), name.c_str() + name.length());
     if (parse(context, feature)) return;
     else throw Exception("Feature_Space::parse(): feature with name "
                          + name + " could not be parsed");
 }
 
-bool Feature_Space::parse(Parse_Context & context, Feature & feature) const
+bool Feature_Space::parse(ParseContext & context, Feature & feature) const
 {
-    Parse_Context::Revert_Token tok(context);
+    ParseContext::Revert_Token tok(context);
     if (!context.match_literal('(')) return false;
 
     int type;
@@ -76,7 +76,7 @@ bool Feature_Space::parse(Parse_Context & context, Feature & feature) const
 }
 
 void Feature_Space::
-expect(Parse_Context & context, Feature & feature) const
+expect(ParseContext & context, Feature & feature) const
 {
     if (!parse(context, feature))
         context.exception("expected feature tuple '(type arg1 arg2)'");

--- a/ml/jml/feature_space.h
+++ b/ml/jml/feature_space.h
@@ -123,8 +123,8 @@ public:
         into a tuple.
 
         In the case that the tuple can't be parsed, it should return \p false.
-        In this case, the Parse_Context object should remain unmodified.  The
-        Parse_Context::Token helper class is very useful for this.  It is not
+        In this case, the ParseContext object should remain unmodified.  The
+        ParseContext::Token helper class is very useful for this.  It is not
         necessary to keep the feature parameter unmodified, however.
 
         \param context       the parse context pointing to the feature to be
@@ -143,7 +143,7 @@ public:
         values:
 
         \code
-        Parse_Context cxt(...);
+        ParseContext cxt(...);
         std::shared_ptr<Feature_Space> fs(...);
 
         vector<Feature> features(1);
@@ -154,7 +154,7 @@ public:
         The default implementation is capable of parsing the same
         representation as the default implementation of the print() method.
     */
-    virtual bool parse(Parse_Context & context, Feature & feature) const;
+    virtual bool parse(ParseContext & context, Feature & feature) const;
 
     /** Parse the name of a feature. */
     virtual void parse(const std::string & name, Feature & feature) const;
@@ -180,7 +180,7 @@ public:
         \endcode
         
     */
-    virtual void expect(Parse_Context & context, Feature & feature) const;
+    virtual void expect(ParseContext & context, Feature & feature) const;
 
     /** Serialize a feature.  This method is called to write a feature to a
         binary store.

--- a/ml/jml/glz_classifier.cc
+++ b/ml/jml/glz_classifier.cc
@@ -373,7 +373,7 @@ explain(const Feature_Set & feature_set,
     }
 
     if(label_idx > weights.size() - 1) {
-        throw ML::Exception("label bigger than weight vector");
+        throw MLDB::Exception("label bigger than weight vector");
     }
 
     for (unsigned j = 0;  j < features.size();  ++j) {
@@ -479,7 +479,7 @@ reconstitute(DB::Store_Reader & store)
         }
     }
     else {
-        throw ML::Exception("Unknown GLZ classifier version %d", (int)version);
+        throw MLDB::Exception("Unknown GLZ classifier version %d", (int)version);
     }
     
     compact_size_t guard(store);

--- a/ml/jml/judy_array.h
+++ b/ml/jml/judy_array.h
@@ -443,7 +443,7 @@ struct judyl_base {
     {
         data_type * pvalue = jlg(key);
         if (pvalue) return *pvalue;
-        throw ML::Exception("value not present in array");
+        throw MLDB::Exception("value not present in array");
     }
 
     size_t memusage_() const

--- a/ml/jml/judy_multi_array.h
+++ b/ml/jml/judy_multi_array.h
@@ -55,7 +55,7 @@ struct judy_multi_array_base {
         unsigned long key_section = Extractor().template get<Level-1>(key);
         auto it = array.find(key_section);
         if (it == array.end())
-            throw ML::Exception("key not found in array");
+            throw MLDB::Exception("key not found in array");
         return (*it).at(key);
     }
 
@@ -226,7 +226,7 @@ struct judy_multi_array_base<Key, Data, Extractor, MaxLevel, MaxLevel> {
         unsigned long key_section = Extractor().template get<MaxLevel-1>(key);
         auto it = array.find(key_section);
         if (it == array.end())
-            throw ML::Exception("at(): key not found");
+            throw MLDB::Exception("at(): key not found");
         return *it;
     }
 

--- a/ml/jml/label.h
+++ b/ml/jml/label.h
@@ -1,14 +1,12 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* label.h                                                         -*- C++ -*-
    Jeremy Barnes, 18 May 2010
    Copyright (c) 2010 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Label class.
 */
 
-#ifndef __jml__boosting__label_h__
-#define __jml__boosting__label_h__
+#pragma once
 
 #include "mldb/compiler/compiler.h"
 #include "mldb/jml/db/persistent_fwd.h"
@@ -53,8 +51,8 @@ struct Label {
         if (label_ & 0x80000000)
             return label_ & ((1 << lab) & 0x3fffffff);
         else if (label_ & 0x40000000)
-            throw Exception("Training_Data::Label::is_label(): "
-                            "label sets not done yet");
+            throw MLDB::Exception("Training_Data::Label::is_label(): "
+                                  "label sets not done yet");
         else return (label_ == lab);
     }
     
@@ -69,5 +67,3 @@ struct Label {
 
 
 } // namespace ML
-
-#endif /* __jml__boosting__label_h__ */

--- a/ml/jml/null_feature_space.cc
+++ b/ml/jml/null_feature_space.cc
@@ -45,13 +45,13 @@ std::string Null_Feature_Space::print(const Feature & feature) const
 }
 
 bool Null_Feature_Space::
-parse(Parse_Context & context, Feature & feature) const
+parse(ParseContext & context, Feature & feature) const
 {
     throw Exception("Null_Feature_Space::parse() not implemented");
 }
 
 void Null_Feature_Space::
-expect(Parse_Context & context, Feature & feature) const
+expect(ParseContext & context, Feature & feature) const
 {
     throw Exception("Null_Feature_Space::expect() not implemented");
 }

--- a/ml/jml/null_feature_space.h
+++ b/ml/jml/null_feature_space.h
@@ -46,8 +46,8 @@ public:
 
     /* Methods to deal with features. */
     virtual std::string print(const Feature & feature) const;
-    virtual bool parse(Parse_Context & context, Feature & feature) const;
-    virtual void expect(Parse_Context & context, Feature & feature) const;
+    virtual bool parse(ParseContext & context, Feature & feature) const;
+    virtual void expect(ParseContext & context, Feature & feature) const;
     virtual void serialize(DB::Store_Writer & store,
                            const Feature & feature) const;
     virtual void reconstitute(DB::Store_Reader & store,

--- a/ml/jml/probabilizer.cc
+++ b/ml/jml/probabilizer.cc
@@ -36,7 +36,7 @@ using std::sqrt;
 namespace ML {
 
 namespace {
-Env_Option<bool> debug("DEBUG_PROBABILIZER", false);
+EnvOption<bool> debug("DEBUG_PROBABILIZER", false);
 }
 
 

--- a/ml/jml/registry.h
+++ b/ml/jml/registry.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* registry.h                                                      -*- C++ -*-
    Jeremy Barnes, 20 June 2003
    Copyright (c) 2003 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Contains the functions to register polymorphic heirarchies of objects
    that can all be serialized and reconstituted in one big happy family.
@@ -20,6 +19,8 @@
 #undef VERSION
 
 namespace ML {
+
+using namespace MLDB;
 
 /* Factory class.  Note that it is expected that this will be specialised
    for the particular type of base, to hold the arguments that it is expected

--- a/ml/jml/sparse_features.cc
+++ b/ml/jml/sparse_features.cc
@@ -83,13 +83,13 @@ print(const ML::Feature & feature) const
 }
 
 bool Sparse_Feature_Space::
-parse(Parse_Context & context, ML::Feature & feature) const
+parse(ParseContext & context, ML::Feature & feature) const
 {
     throw Exception("unimplemented");
 }
 
 void Sparse_Feature_Space::
-expect(Parse_Context & context, ML::Feature & feature) const
+expect(ParseContext & context, ML::Feature & feature) const
 {
     throw Exception("unimplemented");
 }
@@ -227,7 +227,7 @@ Sparse_Training_Data::~Sparse_Training_Data()
 
 void
 Sparse_Training_Data::
-expect_feature(Parse_Context & c, Mutable_Feature_Set & features,
+expect_feature(ParseContext & c, Mutable_Feature_Set & features,
                Sparse_Feature_Space & feature_space,
                bool & guessed_wrong)
 {
@@ -306,7 +306,7 @@ expect_feature(Parse_Context & c, Mutable_Feature_Set & features,
 
 namespace {
 
-bool match_label(Parse_Context & c, Mutable_Feature_Set & features,
+bool match_label(ParseContext & c, Mutable_Feature_Set & features,
                  Sparse_Feature_Space & feature_space)
 {
     /* If the first part is numeric and doesn't include a ":", we assume that
@@ -358,7 +358,7 @@ init(const std::vector<std::string> & filenames,
             /* We load the training data from the file. */
             File_Read_Buffer file(filename);
             
-            Parse_Context c(filename, file.start(), file.end());
+            ParseContext c(filename, file.start(), file.end());
             
             /* Skip over the header. */
             c.skip_line();

--- a/ml/jml/sparse_features.h
+++ b/ml/jml/sparse_features.h
@@ -45,8 +45,8 @@ public:
     /** Methods to do with the features. */
     virtual Feature_Info info(const ML::Feature & feature) const;
     virtual std::string print(const ML::Feature & feature) const;
-    virtual bool parse(Parse_Context & context, ML::Feature & feature) const;
-    virtual void expect(Parse_Context & context, ML::Feature & feature) const;
+    virtual bool parse(ParseContext & context, ML::Feature & feature) const;
+    virtual void expect(ParseContext & context, ML::Feature & feature) const;
     virtual void serialize(DB::Store_Writer & store,
                            const ML::Feature & feature) const;
     virtual void reconstitute(DB::Store_Reader & store,
@@ -159,7 +159,7 @@ public:
     virtual Sparse_Training_Data * make_type() const;
 
 private:
-    void expect_feature(Parse_Context & c, Mutable_Feature_Set & features,
+    void expect_feature(ParseContext & c, Mutable_Feature_Set & features,
                         Sparse_Feature_Space & feature_space,
                         bool & guessed_wrong);
 

--- a/ml/jml/split.h
+++ b/ml/jml/split.h
@@ -19,6 +19,8 @@
 
 namespace ML {
 
+using namespace MLDB;
+
 class Feature_Space;
 class Feature_Set;
 class Feature_Info;

--- a/ml/jml/stump.cc
+++ b/ml/jml/stump.cc
@@ -38,7 +38,7 @@ double t_train_stump = 0.0;
 
 namespace {
 
-Env_Option<bool> profile("PROFILE_BOOSTED_STUMPS", false);
+EnvOption<bool> profile("PROFILE_BOOSTED_STUMPS", false);
 
 struct Stats {
     ~Stats()

--- a/ml/jml/stump_training_bin.h
+++ b/ml/jml/stump_training_bin.h
@@ -31,7 +31,7 @@ namespace ML {
 
 extern double non_missing_ticks;
 extern size_t non_missing_calls;
-
+using namespace MLDB;
 
 /*****************************************************************************/
 /* W_BINSYM                                                                  */

--- a/ml/jml/testing/feature_info_test.cc
+++ b/ml/jml/testing/feature_info_test.cc
@@ -32,7 +32,7 @@ using boost::unit_test::test_suite;
 BOOST_AUTO_TEST_CASE( test_glz_classifier_test )
 {
     string toParse = "k=CATEGORICAL/c=2,Male,Female/o=OPTIONAL";
-    ML::Parse_Context context(toParse, toParse.c_str(), toParse.length());
+    ParseContext context(toParse, toParse.c_str(), toParse.length());
     Mutable_Feature_Info info;
     info.parse(context);
 

--- a/ml/jml/testing/weighted_training_test.cc
+++ b/ml/jml/testing/weighted_training_test.cc
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE( weighted_training_test )
 
     vector<string> probabilizer = {"-p 3", "-p 1 -Q 1"};
     for(int probIdx=0; probIdx<probabilizer.size(); probIdx++) {
-        cout << ML::format(" ----------------------- TESTING WITH PROBABILIZER IN MODE %s (%s) "
+        cout << MLDB::format(" ----------------------- TESTING WITH PROBABILIZER IN MODE %s (%s) "
                 "-----------------------", probabilizer[probIdx], (probIdx == 0 ? "off" : "on")) << endl;
 
         // weights: LABEL, ExampleId

--- a/ml/jml/training_data.cc
+++ b/ml/jml/training_data.cc
@@ -121,22 +121,22 @@ initFiltered(const Training_Data & other,
                 cerr << "different info " << endl;
                 cerr << entry1.print_info() << endl;
                 cerr << entry2.print_info() << endl;
-                throw ML::Exception("different info");
+                throw MLDB::Exception("different info");
             }
 
             if (entry1.examples != entry2.examples) {
                 cerr << "different examples" << endl;
-                throw ML::Exception("different examples");
+                throw MLDB::Exception("different examples");
             }
         
             if (entry1.values != entry2.values) {
                 cerr << "different values" << endl;
-                throw ML::Exception("different values");
+                throw MLDB::Exception("different values");
             }
 
             if (entry1.example_count != entry2.example_count) {
                 cerr << "different example count" << endl;
-                throw ML::Exception("different example count");
+                throw MLDB::Exception("different example count");
             }
         }
     }    

--- a/ml/jml/training_index.cc
+++ b/ml/jml/training_index.cc
@@ -271,7 +271,7 @@ joint(const Feature & target, const Feature & independent,
 
     //if (!getItl()->index.count(target)) {
     //    cerr << "target = " << target << endl;
-    //    throw ML::Exception("Dataset index of %zd features doesn't include target",
+    //    throw MLDB::Exception("Dataset index of %zd features doesn't include target",
     //                        getItl()->index.size());
     //}
 
@@ -290,7 +290,7 @@ joint(const Feature & target, const Feature & independent,
         return Joint_Index(values, buckets, labels, examples, counts, divisors,
                            0, bucket_splits);
         
-        throw ML::Exception("Dataset index of %zd features doesn't include independent",
+        throw MLDB::Exception("Dataset index of %zd features doesn't include independent",
                             getItl()->index.size());
     }
 

--- a/ml/jml/training_index_iterators.cc
+++ b/ml/jml/training_index_iterators.cc
@@ -13,6 +13,7 @@
 #include "mldb/jml/utils/string_functions.h"
 
 using namespace std;
+using namespace MLDB;
 
 namespace ML {
 

--- a/ml/jml/training_params.h
+++ b/ml/jml/training_params.h
@@ -76,7 +76,7 @@ struct Training_Params : public std::map<std::string, boost::any> {
     {
         std::map<std::string, boost::any>::const_iterator loc = find(key);
         if (loc == end())
-            throw ML::Exception("key \"" + key + "\" not found in "
+            throw MLDB::Exception("key \"" + key + "\" not found in "
                                     "context object");
         try {
             return boost::any_cast<Obj>(loc->second);

--- a/ml/jml/weighted_training.cc
+++ b/ml/jml/weighted_training.cc
@@ -321,7 +321,7 @@ parse_weight_spec(const Feature_Space & fs,
     vector<Weight_Spec> result;
 
     if (weight_spec != "") {
-        Parse_Context context("weight-spec option",
+        ParseContext context("weight-spec option",
                               &*weight_spec.begin(), &*weight_spec.end());
 
         while (context) {

--- a/ml/kmeans.cc
+++ b/ml/kmeans.cc
@@ -27,9 +27,9 @@ train(const std::vector<distribution<float>> & points,
     using namespace std;
 
     if (nbClusters < 2)
-        throw ML::Exception("kmeans training requires at least 2 clusters");
+        throw MLDB::Exception("kmeans training requires at least 2 clusters");
     if (points.size() == 0)
-        throw ML::Exception("kmeans training requires at least 1 datapoint");
+        throw MLDB::Exception("kmeans training requires at least 1 datapoint");
 
     boost::mt19937 rng;
     rng.seed(randomSeed);
@@ -123,7 +123,7 @@ train(const std::vector<distribution<float>> & points,
 
 #if KMEANS_DEBUG
         auto printDebug = [&] (const string & step, int iter) {
-            filter_ostream stream(ML::format("kmeans_debug_%i_%s.csv", iter, step));
+            filter_ostream stream(MLDB::format("kmeans_debug_%i_%s.csv", iter, step));
             stream << "x,y,group,type\n";
 
             for (int i=0; i < clusters.size(); ++i) {
@@ -209,7 +209,7 @@ assign(const distribution<float> & point) const
 {
     using namespace std;
     if (clusters.size() == 0)
-        throw ML::Exception("Did you train your kmeans?");
+        throw MLDB::Exception("Did you train your kmeans?");
 
     float distMin = INFINITY;
     int best_cluster = -1;
@@ -223,7 +223,7 @@ assign(const distribution<float> & point) const
     // Those are points with infinty distance or nan distance maybe
     // Let's put them in cluster 0
     if (best_cluster == -1) {
-        cerr << ML::format("something went wrong when assigning this vector with norm [%f]",
+        cerr << MLDB::format("something went wrong when assigning this vector with norm [%f]",
                point.two_norm()) << endl;
         best_cluster = 0;
     }
@@ -253,7 +253,7 @@ reconstitute(ML::DB::Store_Reader & store)
     std::string name;
     store >> name;
     if (name != "kmeans")
-        throw ML::Exception("invalid name when loading a KMeans object");
+        throw MLDB::Exception("invalid name when loading a KMeans object");
     std::string metricTag;
     store >> metricTag;
     if (metricTag != metric->tag()) {
@@ -261,13 +261,13 @@ reconstitute(ML::DB::Store_Reader & store)
             metric.reset(new KMeansCosineMetric());
         else if (metricTag == "EuclideanMetric")
             metric.reset(new KMeansEuclideanMetric());
-        else throw ML::Exception("unknown metric tag: tag = %s, current = %s",
+        else throw MLDB::Exception("unknown metric tag: tag = %s, current = %s",
                             metricTag.c_str(), metric->tag().c_str());
     }
     int version;
     store >> version;
     if (version != 0)
-        throw ML::Exception("invalid KMeans version");
+        throw MLDB::Exception("invalid KMeans version");
     int nbClusters;
     store >> nbClusters;
     clusters.clear();

--- a/ml/neural/layer_stack.h
+++ b/ml/neural/layer_stack.h
@@ -1,15 +1,13 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* layer_stack.h                                                   -*- C++ -*-
    Jeremy Barnes, 4 November 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Stack of neural network layers where each one feeds its output as in input
    into the next.
 */
 
-#ifndef __jml__neural__layer_stack_h__
-#define __jml__neural__layer_stack_h__
+#pragma once
 
 #include "layer.h"
 #include <boost/type_traits/is_base_of.hpp>
@@ -17,6 +15,8 @@
 
 
 namespace ML {
+
+using namespace MLDB;
 
 /// Tag structure to force a deep copy
 struct Deep_Copy_Tag {
@@ -309,6 +309,3 @@ JML_IMPL_SERIALIZE_RECONSTITUTE_TEMPLATE(class LayerT, Layer_Stack<LayerT>);
 
 
 } // namespace ML
-
-
-#endif /* __jml__neural__layer_stack_h__ */

--- a/ml/neural/loss_function.h
+++ b/ml/neural/loss_function.h
@@ -1,19 +1,18 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* loss_function.h                                                 -*- C++ -*-
    Jeremy Barnes, 9 November 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Loss functions for discriminative training.
 */
 
-#ifndef __jml__neural__loss_function_h__
-#define __jml__neural__loss_function_h__
+#pragma once
 
 #include "mldb/jml/stats/distribution.h"
 
 namespace ML {
 
+using namespace MLDB;
 
 /*****************************************************************************/
 /* LOSS_FUNCTION_TYPE                                                        */
@@ -103,5 +102,3 @@ struct MSE_Loss {
 // ...
 
 } // namespace ML
-
-#endif /* __jml__neural__loss_function_h__ */

--- a/ml/neural/parameters.h
+++ b/ml/neural/parameters.h
@@ -21,6 +21,7 @@
 
 namespace ML {
 
+using namespace MLDB;
 
 class Layer;
 class Parameters;

--- a/ml/neural/perceptron.cc
+++ b/ml/neural/perceptron.cc
@@ -38,7 +38,7 @@ namespace ML {
 
 namespace {
 
-Env_Option<bool> profile("PROFILE_PERCEPTRON", false);
+EnvOption<bool> profile("PROFILE_PERCEPTRON", false);
 
 double t_predict = 0.0, t_accuracy = 0.0, t_decorrelate = 0.0;
 
@@ -167,7 +167,7 @@ std::vector<int>
 Perceptron::
 parse_architecture(const std::string & arch)
 {
-    Parse_Context context(arch, &arch[0], &arch[0] + arch.size());
+    ParseContext context(arch, &arch[0], &arch[0] + arch.size());
 
     vector<int> result;
     while (context) {

--- a/ml/neural/perceptron.h
+++ b/ml/neural/perceptron.h
@@ -1,9 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* perceptron.h                                                    -*- C++ -*-
    Jeremy Barnes, 16 June 2003
    Copyright (c) 2003 Jeremy Barnes.  All rights reserved.
-   $Source$
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    The multi layer perceptron algorithm, implemented as a classifier.
 */
@@ -20,6 +18,7 @@
 
 namespace ML {
 
+using namespace MLDB;
 
 class Label;
 class Thread_Context;

--- a/ml/neural/perceptron_defs.cc
+++ b/ml/neural/perceptron_defs.cc
@@ -13,6 +13,7 @@
 #include "mldb/jml/db/persistent.h"
 
 using namespace std;
+using namespace MLDB;
 
 namespace ML {
 

--- a/ml/neural/perceptron_generator.cc
+++ b/ml/neural/perceptron_generator.cc
@@ -38,7 +38,7 @@ namespace ML {
 
 namespace {
 
-Env_Option<bool> profile("PROFILE_PERCEPTRON", false);
+EnvOption<bool> profile("PROFILE_PERCEPTRON", false);
 
 double t_train = 0.0, t_decorrelate = 0.0;
 double t_cholesky = 0.0, t_qr = 0.0, t_gs = 0.0, t_mean = 0.0, t_covar = 0.0;

--- a/ml/neural/testing/dense_layer_test.cc
+++ b/ml/neural/testing/dense_layer_test.cc
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE( test_dense_layer_none )
     input[0] = numeric_limits<float>::quiet_NaN();
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(layer.apply(input), ML::Exception);
+        BOOST_CHECK_THROW(layer.apply(input), MLDB::Exception);
     }
 
     // Check that the wrong size throws an exception
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE( test_dense_layer_none )
     input[0] = 1.0;
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(layer.apply(input), ML::Exception);
+        BOOST_CHECK_THROW(layer.apply(input), MLDB::Exception);
     }
 
     input.pop_back();

--- a/ml/neural/testing/layer_stack_test.cc
+++ b/ml/neural/testing/layer_stack_test.cc
@@ -126,8 +126,8 @@ BOOST_AUTO_TEST_CASE( test_one_dense_layer_stack )
     input[0] = numeric_limits<float>::quiet_NaN();
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(layers.apply(input), ML::Exception);
-        BOOST_CHECK_THROW(layersb.apply(input), ML::Exception);
+        BOOST_CHECK_THROW(layers.apply(input), MLDB::Exception);
+        BOOST_CHECK_THROW(layersb.apply(input), MLDB::Exception);
     }
         
     // Check that the wrong size throws an exception
@@ -136,8 +136,8 @@ BOOST_AUTO_TEST_CASE( test_one_dense_layer_stack )
 
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(layers.apply(input), ML::Exception);
-        BOOST_CHECK_THROW(layersb.apply(input), ML::Exception);
+        BOOST_CHECK_THROW(layers.apply(input), MLDB::Exception);
+        BOOST_CHECK_THROW(layersb.apply(input), MLDB::Exception);
     }
 
     input.pop_back();

--- a/ml/neural/testing/twoway_layer_test.cc
+++ b/ml/neural/testing/twoway_layer_test.cc
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE( test_dense_layer_none )
     input[0] = numeric_limits<float>::quiet_NaN();
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(layer.apply(input), ML::Exception);
+        BOOST_CHECK_THROW(layer.apply(input), MLDB::Exception);
     }
 
     // Check that the wrong size throws an exception
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE( test_dense_layer_none )
     input[0] = 1.0;
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(layer.apply(input), ML::Exception);
+        BOOST_CHECK_THROW(layer.apply(input), MLDB::Exception);
     }
 
     input.pop_back();

--- a/ml/neural/transfer_function.h
+++ b/ml/neural/transfer_function.h
@@ -1,14 +1,12 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* transfer_function.h                                             -*- C++ -*-
    Jeremy Barnes, 2 November 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
    Definition of transfer functions.
 */
 
-#ifndef __jml__neural__transfer_function_h__
-#define __jml__neural__transfer_function_h__
+#pragma once
 
 #include "perceptron_defs.h"
 #include "mldb/jml/stats/distribution.h"
@@ -18,6 +16,7 @@
 
 namespace ML {
 
+using namespace MLDB;
 
 /*****************************************************************************/
 /* RANGE_TYPE                                                                */
@@ -282,7 +281,4 @@ create_transfer_function(const Transfer_Function_Type & function);
 std::shared_ptr<Transfer_Function>
 create_transfer_function(const std::string & name);
 
-
 } // namespace ML
-
-#endif /* __jml__neural__transfer_function_h__ */

--- a/ml/neural/twoway_layer.cc
+++ b/ml/neural/twoway_layer.cc
@@ -817,7 +817,7 @@ rbprop(const F * inputs,
 
     for (unsigned i = 0;  i < ni;  ++i) {
 
-        if (!isnan(noisy_input[i])) {
+        if (!std::isnan(noisy_input[i])) {
             
             F W_updates_row[no];
             

--- a/ml/pipeline_execution_context.h
+++ b/ml/pipeline_execution_context.h
@@ -30,9 +30,9 @@ struct PipelineExecutionContext: public ML::PredictionContext {
     }
 
     void setFeatures(const std::string & name,
-                     const ML::distribution<float> & feats)
+                     const distribution<float> & feats)
     {
-        set<ML::distribution<float> >(name, feats);
+        set<distribution<float> >(name, feats);
     }
 
     template<typename T>
@@ -40,19 +40,19 @@ struct PipelineExecutionContext: public ML::PredictionContext {
     {
         auto it = entries.find(name);
         if (it == entries.end())
-            throw ML::Exception("couldn't find required entry " + name);
+            throw MLDB::Exception("couldn't find required entry " + name);
         try {
             return boost::any_cast<T>(it->second);
         } catch (const boost::bad_any_cast & exc) {
-            throw ML::Exception("attempt to access feature " + name + " as "
-                                + ML::type_name<T>() + " but it is recorded as "
-                                + ML::demangle(it->second.type().name()));
+            throw MLDB::Exception("attempt to access feature " + name + " as "
+                                + MLDB::type_name<T>() + " but it is recorded as "
+                                + demangle(it->second.type().name()));
         }
     }
 
-    ML::distribution<float> getFeatures(const std::string & name) const
+    distribution<float> getFeatures(const std::string & name) const
     {
-        return get<ML::distribution<float> >(name);
+        return get<distribution<float> >(name);
     }
 };
 

--- a/ml/prediction_accumulator.cc
+++ b/ml/prediction_accumulator.cc
@@ -162,7 +162,7 @@ Prediction_Accumulator::assertValidBucketConfig(
     }
 
     // If we have given invalid options
-    throw ML::Exception(ML::format("Invalid bucket_config size. Should be 3; %d.",
+    throw MLDB::Exception(MLDB::format("Invalid bucket_config size. Should be 3; %d.",
             (int)bC_vec.size()));
 }
 
@@ -171,7 +171,7 @@ computeGroupCalibration(const string & calibrateToGroup,
         const std::pair<int, int> & calibrateCountsRef)
 {
     if(calibrateToGroup == "")
-        throw ML::Exception("Need to provide a group to calibrate to");
+        throw MLDB::Exception("Need to provide a group to calibrate to");
 
     // find uid weighted total for each group
     map<string, pair<unsigned, float>> groupCounts;
@@ -203,13 +203,13 @@ computeGroupCalibration(const string & calibrateToGroup,
     }
 
     float normaliseToCxR = target_group_CxR;
-    cerr << ML::format(" target group weight:%0.1f  CxR:%0.4f%% (%s)",
+    cerr << MLDB::format(" target group weight:%0.1f  CxR:%0.4f%% (%s)",
             target_group_weight, target_group_CxR*100, calibrateToGroup) << endl;
     if(target_group_weight < 100) {
         // prefer using the calibrateCountsRef CxR over the weighted average
         // of all other groups if possible
         if(calibrateCountsRef.first >= 50000 && calibrateCountsRef.second >= 2) {
-            cerr << ML::format(" > Using provided CxR to average to. Counts: %d/%d",
+            cerr << MLDB::format(" > Using provided CxR to average to. Counts: %d/%d",
                     calibrateCountsRef.second, calibrateCountsRef.first) << endl;
             float refCxR = calibrateCountsRef.second / (float) calibrateCountsRef.first;
 
@@ -229,7 +229,7 @@ computeGroupCalibration(const string & calibrateToGroup,
             float impsAccum = 0;
             for(auto itt = groupCounts.begin(); itt != groupCounts.end(); itt++) {
                 float cxr = itt->second.second / float(itt->second.first);
-                cerr << ML::format("   %s: base CxR: %0.4f%%.  imps:%d",
+                cerr << MLDB::format("   %s: base CxR: %0.4f%%.  imps:%d",
                         itt->first, cxr * 100, itt->second.first) << endl;
                 if(itt->first == calibrateToGroup) continue;
                 CxRaccum += cxr * itt->second.first;
@@ -242,7 +242,7 @@ computeGroupCalibration(const string & calibrateToGroup,
         }
     }
     cerr << "           normaliseToCxR: " <<
-        ML::format("%0.4f%%", normaliseToCxR*100) << endl;
+        MLDB::format("%0.4f%%", normaliseToCxR*100) << endl;
 
     // calculate the calibration ratio for each group
     cerr << "  -- Calibration for each group -- " << endl;
@@ -254,7 +254,7 @@ computeGroupCalibration(const string & calibrateToGroup,
             float groupCxR = git->second.second / float(git->second.first);
             groupCalibration[git->first] = groupCxR / normaliseToCxR;
 
-            cerr << ML::format("%s : GrpCxR:%0.4f%%    NormRatio:%0.4f",
+            cerr << MLDB::format("%s : GrpCxR:%0.4f%%    NormRatio:%0.4f",
                     git->first, groupCxR*100, groupCxR / normaliseToCxR) << endl;
         }
     }
@@ -285,7 +285,7 @@ getUidWeight(const Id & uid, const string & groupId) const
 
     auto uid_it = uid_counts.find(uid);
     if(uid_it == uid_counts.end()) {
-        throw ML::Exception("unknown uid should not be possible!");
+        throw MLDB::Exception("unknown uid should not be possible!");
     }
 
     return 1.0 / uid_it->second / groupCalib;
@@ -317,13 +317,13 @@ getSortedPreds(const string & calibrateToGroup,
         float weighted_act_rate = num_weighted_pos / (pos.size() + neg.size());
         float unweighted_act_rate = (float)pos.size() / (pos.size() + neg.size());
 
-        cerr << ML::format("Weighted action rate:   %0.4f%%",
+        cerr << MLDB::format("Weighted action rate:   %0.4f%%",
                 weighted_act_rate * 100) << endl;
-        cerr << ML::format("Unweighted action rate: %0.4f%%",
+        cerr << MLDB::format("Unweighted action rate: %0.4f%%",
                 unweighted_act_rate * 100) << endl;
-        cerr << ML::format("Num unweighted pos:     %d", pos.size()) << endl;
-        cerr << ML::format("Num sum weighted pos:   %0.4f", num_weighted_pos) << endl;
-        cerr << ML::format("Num elements:           %d", pos.size() + neg.size()) << endl;
+        cerr << MLDB::format("Num unweighted pos:     %d", pos.size()) << endl;
+        cerr << MLDB::format("Num sum weighted pos:   %0.4f", num_weighted_pos) << endl;
+        cerr << MLDB::format("Num elements:           %d", pos.size() + neg.size()) << endl;
         cerr << endl;
     }
 
@@ -360,7 +360,7 @@ dumpClassHistogram(const string& out_path,
 
     // Figure out filename of histogram
     //boost::filesystem::path dir(outfolder);
-    //string modelfn = ML::format("chist-%s.js", modelname.c_str());
+    //string modelfn = MLDB::format("chist-%s.js", modelname.c_str());
     //boost::filesystem::path file(modelfn);
     //boost::filesystem::path full_path = dir / file;
     cout << "  Writing histogram to: " << out_path << endl;
@@ -404,7 +404,7 @@ getBucketsForClass(const vector<pair<float, float>> & preds,
     int idx = 0;
 
     if (bC.initial_bucket == bC.max_bucket)
-        throw ML::Exception("The first and last buckets are equal.");
+        throw MLDB::Exception("The first and last buckets are equal.");
 
     float lowerBound = bC.initial_bucket - bC.bucket_increment;
     if(preds[idx].first < lowerBound) {
@@ -443,7 +443,7 @@ ScoredStats Prediction_Accumulator::
 getScoredStats(bool weightByClass) const
 {
     if (predictionsAccum.size()==0)
-        throw ML::Exception("Cannot get ScoredStats with empty PredAccum.");
+        throw MLDB::Exception("Cannot get ScoredStats with empty PredAccum.");
 
     double weights[2];
     if(weightByClass) {
@@ -470,7 +470,7 @@ Prediction_Accumulator::getCTRBuckets(size_t num_buckets,
         std::pair<int, int> calibrateCountsRef)
 {
     if (predictionsAccum.size()==0)
-        throw ML::Exception("Cannot compute CTR buckets with empty PredAccum.");
+        throw MLDB::Exception("Cannot compute CTR buckets with empty PredAccum.");
 
     // Get bucket freqs
     vector<float> values(predictionsAccum.size());
@@ -539,7 +539,7 @@ Prediction_Accumulator::getCTRBuckets(size_t num_buckets,
         }
 
         if(unique) {
-            cerr << ML::format(" WARNING!!!! When calling getCTRBuckets, "
+            cerr << MLDB::format(" WARNING!!!! When calling getCTRBuckets, "
                     "prediction accumulator contains %d times the unique "
                     "value of %0.6f", predictionsAccum.size(), val) << endl;
         }

--- a/ml/prediction_accumulator.h
+++ b/ml/prediction_accumulator.h
@@ -98,10 +98,10 @@ protected:
         std::vector<std::pair<float, float>> neg;
         std::vector<std::pair<float, float>> pos;
 
-        static ML::distribution<float> getDistFor(
+        static distribution<float> getDistFor(
                 const std::vector<std::pair<float, float>> & preds)
         {
-            ML::distribution<float> tp(preds.size());
+            distribution<float> tp(preds.size());
             for(int i=0; i<preds.size(); i++)
                 tp[i] = preds[i].first;
             return tp;

--- a/ml/randomforest.h
+++ b/ml/randomforest.h
@@ -597,7 +597,7 @@ struct PartitionData {
         size_t rightRows = splits.second.rows.size();
 
         if (leftRows == 0 || rightRows == 0)
-            throw ML::Exception("Invalid split in random forest");
+            throw MLDB::Exception("Invalid split in random forest");
 
         ThreadPool tp;
         // Put the smallest one on the thread pool, so that we have the highest

--- a/ml/scorer.cc
+++ b/ml/scorer.cc
@@ -34,7 +34,7 @@ test(const DataPartition & partition) const
 
     Date before = Date::now();
 
-    typedef ML::Spinlock Lock;
+    typedef Spinlock Lock;
     Lock lock;
 
     auto onExample = [&] (bool label, const boost::any & user, double weight,

--- a/ml/separation_stats.cc
+++ b/ml/separation_stats.cc
@@ -155,7 +155,7 @@ atPercentile(float percentile) const
             cerr << "i = " << i << endl;
             cerr << "prev = " << stats[i - 1].toJson() << endl;
             cerr << "ours = " << stats[i].toJson() << endl;
-            throw ML::Exception("really not sorted on input");
+            throw MLDB::Exception("really not sorted on input");
         }
     }
 
@@ -287,9 +287,9 @@ ScoredStats::
 add(const ScoredStats & other)
 {
     if (!isSorted)
-        throw ML::Exception("attempt to add to non-sorted separation stats");
+        throw MLDB::Exception("attempt to add to non-sorted separation stats");
     if (!other.isSorted)
-        throw ML::Exception("attempt to add non-sorted separation stats");
+        throw MLDB::Exception("attempt to add non-sorted separation stats");
 
     size_t split = entries.size();
     entries.insert(entries.end(), other.entries.begin(), other.entries.end());
@@ -306,24 +306,24 @@ ScoredStats::
 dumpRocCurveJs(std::ostream & stream) const
 {
     if (stats.empty())
-        throw ML::Exception("can't dump ROC curve without calling calculate()");
+        throw MLDB::Exception("can't dump ROC curve without calling calculate()");
 
     stream << "this.data = {" << endl;
-    stream << ML::format("  \"aroc\": %8.05f , ", auc) << endl;
+    stream << MLDB::format("  \"aroc\": %8.05f , ", auc) << endl;
     stream << "  \"model\":{";
     for(unsigned i = 0;  i < stats.size();  ++i) {
         const BinaryStats & x = stats[i];
-        stream << ML::format("\n  \"%8.05f\": { ", x.threshold);
-        stream << ML::format("\n  tpr : %8.05f,", x.recall());
-        stream << ML::format("\n  accuracy : %8.05f,", x.accuracy());
-        stream << ML::format("\n  precision : %8.05f,", x.precision());
-        stream << ML::format("\n  fscore : %8.05f,", x.f());
-        stream << ML::format("\n  fpr : %8.05f,", x.falsePositiveRate());
-        stream << ML::format("\n  tp : %8.05f,", x.truePositives());
-        stream << ML::format("\n  fp : %8.05f,", x.falsePositives());
-        stream << ML::format("\n  fn : %8.05f,", x.falseNegatives());
-        stream << ML::format("\n  tn : %8.05f,", x.trueNegatives());
-        stream << ML::format("}");
+        stream << MLDB::format("\n  \"%8.05f\": { ", x.threshold);
+        stream << MLDB::format("\n  tpr : %8.05f,", x.recall());
+        stream << MLDB::format("\n  accuracy : %8.05f,", x.accuracy());
+        stream << MLDB::format("\n  precision : %8.05f,", x.precision());
+        stream << MLDB::format("\n  fscore : %8.05f,", x.f());
+        stream << MLDB::format("\n  fpr : %8.05f,", x.falsePositiveRate());
+        stream << MLDB::format("\n  tp : %8.05f,", x.truePositives());
+        stream << MLDB::format("\n  fp : %8.05f,", x.falsePositives());
+        stream << MLDB::format("\n  fn : %8.05f,", x.falseNegatives());
+        stream << MLDB::format("\n  tn : %8.05f,", x.trueNegatives());
+        stream << MLDB::format("}");
         stream << ",";
     }
     stream << "\n}";
@@ -343,12 +343,12 @@ ScoredStats::
 getRocCurveJson() const
 {
     if (stats.empty())
-        throw ML::Exception("can't dump ROC curve without calling calculate()");
+        throw MLDB::Exception("can't dump ROC curve without calling calculate()");
 
     Json::Value modelJs;
     for(unsigned i = 0;  i < stats.size();  ++i) {
         const BinaryStats & x = stats[i];
-        modelJs[ML::format("%8.05f", x.threshold)] = x.toJson();
+        modelJs[MLDB::format("%8.05f", x.threshold)] = x.toJson();
     }
 
     Json::Value js;

--- a/ml/svd_utils.cc
+++ b/ml/svd_utils.cc
@@ -458,7 +458,7 @@ intersectionCount(const uint16_t * it1, const uint16_t * end1,
         : intersectionCountBasic(it1, end1, it2, end2);
 }
 
-ML::Env_Option<int> SVD_OPTIMIZED_INTERSECTION("SVD_OPTIMIZED_INTERSECTION", 3);
+EnvOption<int> SVD_OPTIMIZED_INTERSECTION("SVD_OPTIMIZED_INTERSECTION", 3);
 
 int useOptimizedIntersection = SVD_OPTIMIZED_INTERSECTION;
 
@@ -504,7 +504,7 @@ calcOverlap(const Bucket & other, SvdSpace space) const
                     result += ei.counts.at(it1 - begin1) * ej.counts.at(it2 - begin2);
                     break;
                 default:
-                    throw ML::Exception("unknown space");
+                    throw MLDB::Exception("unknown space");
                 }
 
                 ++it1;

--- a/ml/tsne/quadtree.cc
+++ b/ml/tsne/quadtree.cc
@@ -47,7 +47,7 @@ serialize(DB::Store_Writer & store) const
         ExcAssertEqual(child.size(), maxs.size());
         return;
     }
-    throw ML::Exception("Unknown quadtree node size");
+    throw MLDB::Exception("Unknown quadtree node size");
 }
 
 QuadtreeNode::
@@ -55,11 +55,11 @@ QuadtreeNode(DB::Store_Reader & store, int version)
     : diag(0.0), type(EMPTY), numChildren(0), recipNumChildren{0, 0}
 {
     if (version != 0)
-        throw ML::Exception("Unknown quadtree node version");
+        throw MLDB::Exception("Unknown quadtree node version");
 
     DB::compact_size_t type(store);
     if (type == 0) {
-        throw ML::Exception("Reconstituting an empty quadtree node");
+        throw MLDB::Exception("Reconstituting an empty quadtree node");
     }
     else if (type == 1) {
         type = NODE;
@@ -88,7 +88,7 @@ QuadtreeNode(DB::Store_Reader & store, int version)
         mins = maxs = center = centerOfMass = child;
 
     }
-    else throw ML::Exception("Unknown quadtree node type");
+    else throw MLDB::Exception("Unknown quadtree node type");
 
     center.resize(mins.size());
     for (unsigned i = 0;  i < mins.size();  ++i) {
@@ -104,7 +104,7 @@ QuadtreeNode(DB::Store_Reader & store, int version)
             cerr << "child = " << child << endl;
             cerr << "center = " << center << endl;
 
-            backtrace();
+            MLDB::backtrace();
         }
         
         center[i] = 0.5 * (mins[i] + maxs[i]);
@@ -125,10 +125,10 @@ Quadtree(DB::Store_Reader & store)
     std::string canary;
     store >> canary;
     if (canary != "QTREE")
-        throw ML::Exception("Unknown quadtree canary");
+        throw MLDB::Exception("Unknown quadtree canary");
     DB::compact_size_t version(store);
     if (version != 0)
-        throw ML::Exception("Unknown quadtree version");
+        throw MLDB::Exception("Unknown quadtree version");
 
     DB::compact_size_t indicator(store);
     if (indicator == 0)
@@ -136,7 +136,7 @@ Quadtree(DB::Store_Reader & store)
     else if (indicator == 1) {
         root.reset(new QuadtreeNode(store, version));
     }
-    else throw ML::Exception("Unknown quadtree indicator");
+    else throw MLDB::Exception("Unknown quadtree indicator");
 }
 
 void

--- a/ml/tsne/quadtree.h
+++ b/ml/tsne/quadtree.h
@@ -112,7 +112,7 @@ struct QuadtreeNode {
                 cerr << "point = " << point << endl;
                 cerr << "mins " << mins << endl;
                 cerr << "maxs " << maxs << endl;
-                throw ML::Exception("point is not within cell");
+                throw MLDB::Exception("point is not within cell");
             }
         }
 

--- a/ml/tsne/testing/tsne_algorithm_test.cc
+++ b/ml/tsne/testing/tsne_algorithm_test.cc
@@ -45,7 +45,7 @@ X sqr(X x)
 void calcRep(const QuadtreeNode & node,
              int depth,
              bool inside,
-             const ML::distribution<float> & y,
+             const distribution<float> & y,
              double * FrepZ,
              double & exampleZ,
              int & nodesTouched,
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE( test_small )
     string input_file = "mldb/tsne/testing/mnist2500_X_min.txt.gz";
 
     filter_istream stream(input_file);
-    Parse_Context context(input_file, stream);
+    ParseContext context(input_file, stream);
 
     int nd = 784;
     int nx = 100;
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE( test_vantage_point_tree )
     string input_file = "mldb/tsne/testing/mnist2500_X_min.txt.gz";
 
     filter_istream stream(input_file);
-    Parse_Context context(input_file, stream);
+    ParseContext context(input_file, stream);
 
     int nd = 784;
     int nx = 2500;
@@ -427,7 +427,7 @@ BOOST_AUTO_TEST_CASE( test_small_approx )
     string input_file = "mldb/tsne/testing/mnist2500_X_min.txt.gz";
 
     filter_istream stream(input_file);
-    Parse_Context context(input_file, stream);
+    ParseContext context(input_file, stream);
 
     int nd = 784;
     int nx = 100;
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE( test_distance_to_probability_big )
     string input_file = "mldb/tsne/testing/mnist2500_X_min.txt.gz";
 
     filter_istream stream(input_file);
-    Parse_Context context(input_file, stream);
+    ParseContext context(input_file, stream);
 
     int nd = 784;
     int nx = 2500;

--- a/ml/tsne/tsne.h
+++ b/ml/tsne/tsne.h
@@ -175,7 +175,7 @@ tsne(const boost::multi_array<float, 2> & probs,
 
 struct TsneSparseProbs {
     std::vector<int> indexes;
-    ML::distribution<float> probs;
+    distribution<float> probs;
 };
 
 /** Sparse and approximate Barnes-Hut-SNE version of tSNE.
@@ -216,7 +216,7 @@ struct PythagDistFromCoords {
     PythagDistFromCoords(const boost::multi_array<float, 2> & coords);
 
     const boost::multi_array<float, 2> & coords;
-    ML::distribution<float> sum_dist;
+    distribution<float> sum_dist;
     int nx;
     int nd;
 
@@ -322,21 +322,21 @@ sparseProbsFromCoords(const std::function<float (int)> & dist,
     The calculation is much simpler since we only have one point that can
     move at a time, rather than the whole lot of them.
 */
-ML::distribution<float>
-retsne(const ML::distribution<float> & probs,
+distribution<float>
+retsne(const distribution<float> & probs,
        const boost::multi_array<float, 2> & prevOutput,
        const TSNE_Params & params = TSNE_Params());
 
 
-ML::distribution<float>
+distribution<float>
 retsneApproxFromSparse(const TsneSparseProbs & neighbours,
                        const boost::multi_array<float, 2> & prevOutput,
                        const Quadtree & qtree,
                        const TSNE_Params & params);
 
 
-ML::distribution<float>
-retsneApproxFromCoords(const ML::distribution<float> & coords,
+distribution<float>
+retsneApproxFromCoords(const distribution<float> & coords,
                        const boost::multi_array<float, 2> & coreCoords,
                        const boost::multi_array<float, 2> & prevOutput,
                        const Quadtree & qtree,

--- a/ml/tsne/vantage_point_tree.h
+++ b/ml/tsne/vantage_point_tree.h
@@ -104,7 +104,7 @@ struct VantagePointTreeT {
                                       int depth)
             {
                 // Calculate distances to all children
-                ML::distribution<float> distances(items2.size());
+                distribution<float> distances(items2.size());
 
                 for (unsigned i = 0;  i < items2.size();  ++i) {
                     distances[i] = distance(pivot, items2[i]);
@@ -118,7 +118,7 @@ struct VantagePointTreeT {
 
     static VantagePointTreeT *
     createParallel(const std::vector<Item> & objectsToInsert_,
-                   const std::function<ML::distribution<float> (Item, const std::vector<Item> &, int)> & distance,
+                   const std::function<distribution<float> (Item, const std::vector<Item> &, int)> & distance,
                    int depth = 0)
     {
         using namespace std;
@@ -157,7 +157,7 @@ struct VantagePointTreeT {
             Item pivot = objectsToInsert[0];
 
             // Calculate distances to all children
-            ML::distribution<float> distances
+            distribution<float> distances
                 = distance(pivot, objectsToInsert, depth);
 
             ExcAssertEqual(distances.size(), objectsToInsert.size());

--- a/ml/value_descriptions.cc
+++ b/ml/value_descriptions.cc
@@ -96,7 +96,7 @@ struct DenseFeatureSpaceDescription
 
     virtual void parseJsonTyped(ML::Dense_Feature_Space * val, JsonParsingContext & context) const
     {
-        throw ML::Exception("Can't round-trip a dense feature space through JSON");
+        throw MLDB::Exception("Can't round-trip a dense feature space through JSON");
     }
 
     virtual void printJson(const void * val, JsonPrintingContext & context) const
@@ -173,7 +173,7 @@ struct FeatureInfoDescription
 
     virtual void parseJsonTyped(ML::Feature_Info * val, JsonParsingContext & context) const
     {
-        throw ML::Exception("Can't round-trip a feature info through JSON");
+        throw MLDB::Exception("Can't round-trip a feature info through JSON");
     }
 
     virtual void printJson(const void * val, JsonPrintingContext & context) const
@@ -236,7 +236,7 @@ struct JmlConfigurationDescription
         Json::Value json = context.expectJson();
 
         if (!json.isObject())
-            throw ML::Exception("Expected JSON object for configuration");
+            throw MLDB::Exception("Expected JSON object for configuration");
 
         insertInto(result, "", json);
 
@@ -246,7 +246,7 @@ struct JmlConfigurationDescription
     static Json::Value & getPath(const std::string & key, Json::Value & val)
     {
         if (key.empty())
-            throw ML::Exception("can't lookup empty key");
+            throw MLDB::Exception("can't lookup empty key");
 
         auto pos = key.find('.');
         if (pos == string::npos)
@@ -312,7 +312,7 @@ ClassifierImplDescription::
 parseJsonTyped(std::shared_ptr<ML::Classifier_Impl>  * val,
                MLDB::JsonParsingContext & context) const
 {
-    throw ML::Exception("Can't parse classifiers");
+    throw MLDB::Exception("Can't parse classifiers");
 }
 
 template<typename T>
@@ -345,7 +345,7 @@ printJsonTyped(const std::shared_ptr<Classifier_Impl>  * val,
     if (tryType<ML::Boosted_Stumps>(val, "BoostedStumps", context)) return;
 
     Json::Value result;
-    result["type"] = ML::type_name(**val);
+    result["type"] = MLDB::type_name(**val);
     result["model"] = (*val)->print();
     context.writeJson(result);
 }
@@ -374,7 +374,7 @@ struct FeatureDescription
     virtual void parseJsonTyped(ML::Feature * val,
                                 MLDB::JsonParsingContext & context) const
     {
-        throw ML::Exception("Can't parse classifiers");
+        throw MLDB::Exception("Can't parse classifiers");
     }
 
     virtual void printJsonTyped(const ML::Feature * val,
@@ -397,7 +397,7 @@ struct SplitDescription
     virtual void parseJsonTyped(ML::Split * val,
                                 MLDB::JsonParsingContext & context) const
     {
-        throw ML::Exception("Can't parse classifiers");
+        throw MLDB::Exception("Can't parse classifiers");
     }
 
     virtual void printJsonTyped(const ML::Split * val,
@@ -427,7 +427,7 @@ struct TreePtrDescription
     virtual void parseJsonTyped(ML::Tree::Ptr * val,
                                 MLDB::JsonParsingContext & context) const
     {
-        throw ML::Exception("Can't parse classifiers");
+        throw MLDB::Exception("Can't parse classifiers");
     }
 
     virtual void printJsonTyped(const ML::Tree::Ptr * val,
@@ -603,7 +603,7 @@ std::string keyToString(const Split & split)
 
 Split stringToKey(const std::string & str, Split * = 0)
 {
-    throw ML::Exception("stringToKey(): to implement");
+    throw MLDB::Exception("stringToKey(): to implement");
 }
 
 BoostedStumpsDescription::

--- a/mongodb/mongo_import.cc
+++ b/mongodb/mongo_import.cc
@@ -200,7 +200,7 @@ struct MongoImportProcedure: public Procedure {
                     try {
                         processor(*output.get(), doc);
                     }
-                    catch (const ML::Exception & exc) {
+                    catch (const MLDB::Exception & exc) {
                         ++ errors;
                         if (errors <= 100) {
                             logger->error() << exc.what();

--- a/mongodb/mongo_query.cc
+++ b/mongodb/mongo_query.cc
@@ -164,7 +164,7 @@ struct MongoQueryFunction: Function {
                 return std::move(row);
             }
             else {
-                throw ML::Exception("Unknown outputType");
+                throw MLDB::Exception("Unknown outputType");
             }
         }
 

--- a/mongodb/mongo_temporary_server.cc
+++ b/mongodb/mongo_temporary_server.cc
@@ -34,7 +34,7 @@ MongoTemporaryServer(const string & uniquePath, const int portNum)
             string cwd(secure_getenv("PWD"));
             tmpDir = "." + tmpDir.substr(cwd.size());
         }
-        uniquePath_ = ML::format("%s/mongo-temporary-server-%d-%d",
+        uniquePath_ = MLDB::format("%s/mongo-temporary-server-%d-%d",
                                  tmpDir, getpid(), index);
         cerr << ("starting mongo temporary server under unique path "
                  + uniquePath_ + "\n");
@@ -57,7 +57,7 @@ MongoTemporaryServer(const string & uniquePath, const int portNum)
             freePort = 0;
         }
         if (freePort == 0) {
-            throw ML::Exception("Failed to find free port");
+            throw MLDB::Exception("Failed to find free port");
         }
         this->portNum = freePort;
     }
@@ -81,7 +81,7 @@ testConnection()
     // 3.  Connect to the server to make sure it works
     int sock = ::socket(AF_UNIX, SOCK_STREAM, 0);
     if (sock == -1) {
-        throw ML::Exception(errno, "socket");
+        throw MLDB::Exception(errno, "socket");
     }
 
     sockaddr_un addr;
@@ -103,7 +103,7 @@ testConnection()
             }
             else if (res == -1) {
                 if (errno != ECONNREFUSED && errno != ENOENT) {
-                    throw ML::Exception(errno, "connect");
+                    throw MLDB::Exception(errno, "connect");
                 }
             }
         }
@@ -111,7 +111,7 @@ testConnection()
     }
 
     if (!connected) {
-        throw ML::Exception("mongod didn't start up in 10 seconds");
+        throw MLDB::Exception("mongod didn't start up in 10 seconds");
     }
     ::close(sock);
 }
@@ -122,7 +122,7 @@ start()
 {
     // Check the unique path
     if (uniquePath_.empty() || uniquePath_ == "." || uniquePath_ == "..") {
-        throw ML::Exception("unacceptable unique path");
+        throw MLDB::Exception("unacceptable unique path");
     }
 
     // 1.  Create the directory
@@ -132,15 +132,15 @@ start()
     int res = ::stat(uniquePath_.c_str(), &stats);
     if (res == -1) {
         if (errno != EEXIST && errno != ENOENT) {
-            throw ML::Exception(errno, "unhandled exception");
+            throw MLDB::Exception(errno, "unhandled exception");
         }
     } else if (res == 0) {
-        throw ML::Exception("unique path " + uniquePath_ + " already exists");
+        throw MLDB::Exception("unique path " + uniquePath_ + " already exists");
     }
 
     cerr << "creating directory " << uniquePath_ << endl;
     if (!fs::create_directories(fs::path(uniquePath_))) {
-        throw ML::Exception("could not create unique path " + uniquePath_);
+        throw MLDB::Exception("could not create unique path " + uniquePath_);
     }
 
     socketPrefix_ = uniquePath_ + "/mongo-socket";
@@ -148,13 +148,13 @@ start()
     int UNIX_PATH_MAX=108;
 
     if (socketPrefix_.size() >= UNIX_PATH_MAX) {
-        throw ML::Exception("unix socket path is too long");
+        throw MLDB::Exception("unix socket path is too long");
     }
 
     // Create unix socket directory
     fs::path unixdir(socketPrefix_);
     if (!fs::create_directory(unixdir)) {
-        throw ML::Exception(errno,
+        throw MLDB::Exception(errno,
                             "couldn't create unix socket directory for Mongo");
     }
     auto onStdOut = [&] (string && message) {

--- a/plugins/accuracy.cc
+++ b/plugins/accuracy.cc
@@ -157,7 +157,7 @@ runBoolean(AccuracyConfig & runAccuracyConf,
                   });
 
     if (!gotStuff) {
-        throw ML::Exception(NO_DATA_ERR_MSG);
+        throw MLDB::Exception(NO_DATA_ERR_MSG);
     }
 
     //stats.sort();
@@ -335,7 +335,7 @@ runCategorical(AccuracyConfig & runAccuracyConf,
             });
 
     if (!gotStuff) {
-        throw ML::Exception(NO_DATA_ERR_MSG);
+        throw MLDB::Exception(NO_DATA_ERR_MSG);
     }
     // Create per-class statistics
     Json::Value results;
@@ -420,7 +420,7 @@ runCategorical(AccuracyConfig & runAccuracyConf,
     // in the labels
     if (weighted_stats["precision"].asDouble() == 0
         && nb_predicted_no_label > 0) {
-        throw ML::Exception(ML::format("Weighted precision is 0 and %i"
+        throw MLDB::Exception(MLDB::format("Weighted precision is 0 and %i"
                 "labels were predicted but not in true labels! "
                 "Are the columns of the predicted labels named properly?",
                 nb_predicted_no_label));
@@ -468,7 +468,7 @@ runRegression(AccuracyConfig & runAccuracyConf,
 
         double mse_sum;
         double totalWeight;
-        ML::distribution<double> absolute_percentage;
+        distribution<double> absolute_percentage;
         vector<pair<double, double>> labelsWeights;
     };
 
@@ -528,7 +528,7 @@ runRegression(AccuracyConfig & runAccuracyConf,
                   });
 
     if(totalWeight == 0) {
-        throw ML::Exception(NO_DATA_ERR_MSG);
+        throw MLDB::Exception(NO_DATA_ERR_MSG);
     }
 
     std::mutex mergeAccumsLock;
@@ -567,7 +567,7 @@ runRegression(AccuracyConfig & runAccuracyConf,
     else                            r_squared = 1 - (mse_sum / totalSumSquares);
 
     // prepare absolute_percentage distribution
-    ML::distribution<double> absolute_percentage;
+    distribution<double> absolute_percentage;
 
     parallelMergeSortRecursive(accum.threads, 0, accum.threads.size(),
                                [] (const std::shared_ptr<ThreadStats> & t)
@@ -657,7 +657,7 @@ run(const ProcedureRunConfig & run,
     if(runAccuracyConf.mode == CM_REGRESSION)
         return runRegression(runAccuracyConf, boundQuery, output);
 
-    throw ML::Exception("Classification mode '%d' not implemented", runAccuracyConf.mode);
+    throw MLDB::Exception("Classification mode '%d' not implemented", runAccuracyConf.mode);
 }
 
 namespace {

--- a/plugins/bucketize_procedure.cc
+++ b/plugins/bucketize_procedure.cc
@@ -74,22 +74,22 @@ BucketizeProcedureConfigDescription()
         auto last = make_pair(-1.0, -1.0);
         for (const auto & range: ranges) {
             if (range.first < 0) {
-                throw ML::Exception(
+                throw MLDB::Exception(
                     "Invalid percentileBucket [%f, %f]: lower bound must be "
                     "greater or equal to 0", range.first, range.second);
             }
             if (range.second > 100) {
-                throw ML::Exception(
+                throw MLDB::Exception(
                     "Invalid percentileBucket [%f, %f]: higher bound must be "
                     "lower or equal to 1", range.first, range.second);
             }
             if (range.first >= range.second) {
-                throw ML::Exception(
+                throw MLDB::Exception(
                     "Invalid percentileBucket [%f, %f]: higher bound must  "
                     "be greater than lower bound", range.first, range.second);
             }
             if (range.first < last.second) {
-                throw ML::Exception(
+                throw MLDB::Exception(
                     "Invalid percentileBucket: [%f, %f] is overlapping with "
                     "[%f, %f]", last.first, last.second, range.first,
                     range.second);

--- a/plugins/classifier.cc
+++ b/plugins/classifier.cc
@@ -269,7 +269,7 @@ run(const ProcedureRunConfig & run,
 
     DEBUG_MSG(logger) << "knownInputColumns are " << jsonEncode(knownInputColumns);
 
-    ML::Timer timer;
+    Timer timer;
 
     // TODO: it's not the feature space itself, but indeed the output of
     // the select expression that's important...
@@ -433,7 +433,7 @@ run(const ProcedureRunConfig & run,
                         (KEEP_HTTP_CODE,
                          "Error processing row '" + row.rowName.toUtf8String()
                          + "' column '" + std::get<0>(c).toUtf8String()
-                         + "': " + ML::getExceptionString(),
+                         + "': " + getExceptionString(),
                          "rowName", row.rowName,
                          "columns", row.columns);
                 }
@@ -577,12 +577,12 @@ run(const ProcedureRunConfig & run,
         throw HttpReturnException(400, "Unknown classifier mode");
     }
 
-    std::vector<ML::distribution<float>> labelWeights(num_weight_labels);
+    std::vector<distribution<float>> labelWeights(num_weight_labels);
     for(int i=0; i<num_weight_labels; i++) {
         labelWeights[i].resize(nx);
     }
 
-    ML::distribution<float> exampleWeights(nx);
+    distribution<float> exampleWeights(nx);
 
     for (unsigned i = 0;  i < nx;  ++i) {
         float label  = fvs[i].label();
@@ -665,12 +665,12 @@ run(const ProcedureRunConfig & run,
     ML::Thread_Context threadContext;
     threadContext.seed(randomSeed);
 
-    ML::distribution<float> weights;
+    distribution<float> weights;
     if(runProcConf.mode == CM_REGRESSION) {
         weights = exampleWeights;
     }
     else {
-        ML::distribution<float> factor_accum(exampleWeights.size(), 0);
+        distribution<float> factor_accum(exampleWeights.size(), 0);
         for(int lbl=0; lbl<num_weight_labels; lbl++) {
             double factor = pow(labelWeights[lbl].total(), -equalizationFactor);
 
@@ -698,7 +698,7 @@ run(const ProcedureRunConfig & run,
         JML_CATCH_ALL {
             rethrowHttpException(400, "Error saving classifier to '"
                                  + runProcConf.modelFileUrl.toString() + "': "
-                                 + ML::getExceptionString(),
+                                 + getExceptionString(),
                                  "url", runProcConf.modelFileUrl);
         }
         INFO_MSG(logger) << "Saved classifier to " << runProcConf.modelFileUrl;
@@ -961,7 +961,7 @@ apply(const FunctionApplier & applier_,
     }
     else {
         if(!fset) {
-            throw ML::Exception("Feature_Set is null! Are you giving "
+            throw MLDB::Exception("Feature_Set is null! Are you giving "
                                 "only null features to the classifier function?");
         }
         
@@ -1120,7 +1120,7 @@ apply(const FunctionApplier & applier,
     std::tie(dense, fset, ts) = getFeatureSet(context, false /* attempt to optimize */);
 
     if (fset->features.empty()) {
-        throw ML::Exception("The specified features couldn't be found in the "
+        throw MLDB::Exception("The specified features couldn't be found in the "
                             "classifier. At least one non-null feature column "
                             "must be provided.");
     }
@@ -1191,7 +1191,7 @@ void jmlclassifierMacro(MacroContext & context,
         context.writeHtml("<table><tr><th>Parameter</th><th>Range</th>"
                           "<th>Default</th><th>Description</th></tr>");
         for (auto & o: generator->options())
-            context.writeHtml(ML::format(
+            context.writeHtml(MLDB::format(
                                          "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>",
                                          o.name.c_str(), o.range.c_str(), o.value.c_str(), o.doc.c_str()
                                          ));

--- a/plugins/continuous_dataset.cc
+++ b/plugins/continuous_dataset.cc
@@ -68,7 +68,7 @@ struct ContinuousDataset::Itl {
             metadataDataset = obtainDataset(server, config.metadataDataset);
         } JML_CATCH_ALL {
             rethrowHttpException(-1, "Error initializing continuous dataset in "
-                                 "metadata initialization: " + ML::getExceptionString(),
+                                 "metadata initialization: " + getExceptionString(),
                                  "continuousDatasetConfig", config);
         }
         
@@ -77,7 +77,7 @@ struct ContinuousDataset::Itl {
         } JML_CATCH_ALL {
             rethrowHttpException(-1, "Error initializing continuous dataset in "
                                  "createStorageDataset initialization: "
-                                 + ML::getExceptionString(),
+                                 + getExceptionString(),
                                  "continuousDatasetConfig", config);
         }
         
@@ -86,7 +86,7 @@ struct ContinuousDataset::Itl {
         } JML_CATCH_ALL {
             rethrowHttpException(-1, "Error initializing continuous dataset in "
                                  "saveStorageDataset procedure initialization: "
-                                 + ML::getExceptionString(),
+                                 + getExceptionString(),
                                  "continuousDatasetConfig", config);
         }
         
@@ -546,7 +546,7 @@ ContinuousWindowDataset(MldbServer * owner,
         metadataDataset = obtainDataset(server, config.metadataDataset);
     } JML_CATCH_ALL {
         rethrowHttpException(-1, "Error initializing continuous window dataset in "
-                             "metadata initialization: " + ML::getExceptionString(),
+                             "metadata initialization: " + getExceptionString(),
                              "continuousDatasetConfig", config);
     }
 
@@ -558,7 +558,7 @@ ContinuousWindowDataset(MldbServer * owner,
         toLoadConfig = getDatasetConfig(config.datasetFilter, config.from, config.to);
     } JML_CATCH_ALL {
         rethrowHttpException(-1, "Error initializing continuous window dataset in "
-                             "metadata query: " + ML::getExceptionString(),
+                             "metadata query: " + getExceptionString(),
                              "continuousDatasetConfig", config);
     }
 
@@ -569,7 +569,7 @@ ContinuousWindowDataset(MldbServer * owner,
         setUnderlying(underlying);
     } JML_CATCH_ALL {
         rethrowHttpException(-1, "Error initializing continuous window dataset in "
-                             "metadata query: " + ML::getExceptionString(),
+                             "metadata query: " + getExceptionString(),
                              "continuousDatasetConfig", config);
     }
 }

--- a/plugins/csv_export_procedure.cc
+++ b/plugins/csv_export_procedure.cc
@@ -68,10 +68,10 @@ CsvExportProcedureConfigDescription()
                           JsonParsingContext & context)
     {
         if (cfg->delimiter.size() != 1) {
-            throw ML::Exception("delimiter must be 1 char long.");
+            throw MLDB::Exception("delimiter must be 1 char long.");
         }
         if (cfg->quoteChar.size() != 1) {
-            throw ML::Exception("Quotechar must be 1 char long.");
+            throw MLDB::Exception("Quotechar must be 1 char long.");
         }
         MustContainFrom()(cfg->exportData, CsvExportProcedureConfig::name);
     };
@@ -147,7 +147,7 @@ run(const ProcedureRunConfig & run,
                         if(runProcConf.skipDuplicateCells)
                             return false;
 
-                        throw ML::Exception(Utf8String("CSV export does not work over "
+                        throw MLDB::Exception(Utf8String("CSV export does not work over "
                                 "cells having multiple values, at row '" + row.rowName.toUtf8String() +
                                 "' for column '" + seekColumn.toUtf8String() + "'").utf8String());
                     }

--- a/plugins/dataset_feature_space.cc
+++ b/plugins/dataset_feature_space.cc
@@ -143,7 +143,7 @@ encodeFeatureValue(ColumnHash column, const CellValue & value) const
         
     auto it = columnInfo.find(column);
     if (it == columnInfo.end()) {
-        throw ML::Exception("Encoding unknown column");
+        throw MLDB::Exception("Encoding unknown column");
     }
 
     return encodeValue(value, it->second.columnName, it->second.info);
@@ -159,7 +159,7 @@ encodeFeature(ColumnHash column, const CellValue & value,
         
     auto it = columnInfo.find(column);
     if (it == columnInfo.end()) {
-        throw ML::Exception("Encoding unknown column");
+        throw MLDB::Exception("Encoding unknown column");
     }
 
     fset.emplace_back(getFeature(column),
@@ -172,11 +172,11 @@ DatasetFeatureSpace::
 getFeatureBucket(ColumnHash column, const CellValue & value) const
 {
     if (value.empty())
-        throw ML::Exception("Encoding empty value");
+        throw MLDB::Exception("Encoding empty value");
         
     auto it = columnInfo.find(column);
     if (it == columnInfo.end()) {
-        throw ML::Exception("Encoding unknown column");
+        throw MLDB::Exception("Encoding unknown column");
     }
 
     if (it->second.info.type() == ML::CATEGORICAL
@@ -233,7 +233,7 @@ encodeValue(const CellValue & value,
         return val;
     }
     if (!value.isNumeric()) {
-        throw ML::Exception("Value for column '"
+        throw MLDB::Exception("Value for column '"
                             + columnName.toUtf8String().rawString() + 
                             "' was numeric in training, but is now " +
                             jsonEncodeStr(value));
@@ -257,7 +257,7 @@ info(const ML::Feature & feature) const
     // Look up the feature info we just extracted
     auto it = columnInfo.find(getHash(feature));
     if (it == columnInfo.end())
-        throw ML::Exception("feature " + feature.print() + " not found");
+        throw MLDB::Exception("feature " + feature.print() + " not found");
     return it->second.info;
 }
 
@@ -317,7 +317,7 @@ getValue(const ML::Feature & feature, float value) const
     auto it = columnInfo.find(column);
 
     if (it == columnInfo.end())
-        throw ML::Exception("Couldn't find column");
+        throw MLDB::Exception("Couldn't find column");
 
     return getValueFromInfo(it->second.info, value);
 }
@@ -353,7 +353,7 @@ print(const ML::Feature & feature) const
         
     auto it = columnInfo.find(getHash(feature));
     if (it == columnInfo.end()) {
-        throw ML::Exception("Couldn't find feature in dataset");
+        throw MLDB::Exception("Couldn't find feature in dataset");
     }
     return it->second.columnName.toUtf8String().rawString();
 }
@@ -399,7 +399,7 @@ serialize(ML::DB::Store_Writer & store, const ML::Feature & feature,
 {
     auto it = columnInfo.find(getHash(feature));
     if (it == columnInfo.end())
-        throw ML::Exception("Couldn't find feature in dataset");
+        throw MLDB::Exception("Couldn't find feature in dataset");
 
     if (it->second.info.categorical()) {
         store << it->second.info.categorical()->print(value);
@@ -415,7 +415,7 @@ reconstitute(ML::DB::Store_Reader & store,
 {
     auto it = columnInfo.find(getHash(feature));
     if (it == columnInfo.end())
-        throw ML::Exception("Couldn't find feature in dataset");
+        throw MLDB::Exception("Couldn't find feature in dataset");
 
     if (it->second.info.categorical()) {
         string val;
@@ -453,7 +453,7 @@ reconstitute(ML::DB::Store_Reader & store)
     char version;
     store >> version;
     if (version > 2)
-        throw ML::Exception("unexpected version of DatasetFeatureSpace");
+        throw MLDB::Exception("unexpected version of DatasetFeatureSpace");
     ML::DB::compact_size_t numFeatures(store);
 
     if (version > 1)

--- a/plugins/dist_table_procedure.cc
+++ b/plugins/dist_table_procedure.cc
@@ -125,7 +125,7 @@ getStat(DISTTABLE_STATISTICS stat) const
         case DT_LAST:   return last;
         case DT_SUM:    return sum;
         default:
-            throw ML::Exception("Unknown DistTable_Stat");
+            throw MLDB::Exception("Unknown DistTable_Stat");
     }
 }
 
@@ -203,7 +203,7 @@ reconstitute(ML::DB::Store_Reader & store)
                                   "table model");
     }
     if(version!=REQUIRED_V) {
-        throw HttpReturnException(400, ML::format(
+        throw HttpReturnException(400, MLDB::format(
                     "invalid DistTable version! exptected %d, got %d",
                     REQUIRED_V, version));
     }
@@ -342,7 +342,7 @@ run(const ProcedureRunConfig & run,
                           DistTable(ColumnPath("words"), outcome_names)));
     }
     else {
-        throw ML::Exception("unsupported dist table mode");
+        throw MLDB::Exception("unsupported dist table mode");
     }
 
     auto onProgress2 = [&] (const Json::Value & progress)
@@ -355,7 +355,7 @@ run(const ProcedureRunConfig & run,
     std::shared_ptr<Dataset> output;
     if(runProcConf.output) {
         if(runProcConf.mode == DT_MODE_BAG_OF_WORDS)
-            throw ML::Exception("Cannot use outputDataset when mode=bagOfWords");
+            throw MLDB::Exception("Cannot use outputDataset when mode=bagOfWords");
 
         PolyConfigT<Dataset> outputDataset = *runProcConf.output;
         if (outputDataset.type.empty())
@@ -376,7 +376,7 @@ run(const ProcedureRunConfig & run,
 
             if (num_req++ % 5000 == 0) {
                 double secs = Date::now().secondsSinceEpoch() - start.secondsSinceEpoch();
-                string message = ML::format("done %d. %0.4f/sec", num_req, num_req / secs);
+                string message = MLDB::format("done %d. %0.4f/sec", num_req, num_req / secs);
                 Json::Value progress;
                 progress["message"] = message; 
                 onProgress(progress);
@@ -453,7 +453,7 @@ run(const ProcedureRunConfig & run,
                 }
             }
             else {
-                throw ML::Exception("Unknown distTable mode");
+                throw MLDB::Exception("Unknown distTable mode");
             }
 
             return true;
@@ -579,13 +579,13 @@ DistTableFunction(MldbServer * owner,
     ML::DB::Store_Reader store(stream);
     store >> version;
     if(version != REQUIRED_VERSION)
-        throw ML::Exception("Wrong DistTable map version");
+        throw MLDB::Exception("Wrong DistTable map version");
 
     store >> i_mode;
     mode = (DistTableMode)i_mode;
 
     if(mode != DT_MODE_BAG_OF_WORDS && mode != DT_MODE_FIXED_COLUMNS)
-        throw ML::Exception("Unsupported DistTable mode");
+        throw MLDB::Exception("Unsupported DistTable mode");
 
     store >> distTablesMap;
 
@@ -654,7 +654,7 @@ increment(const vector<pair<Utf8String, Utf8String>> & keys,
         Path pKey(key.first);
         auto table_it = distTablesMap.find(pKey);
         if(table_it == distTablesMap.end())
-            throw ML::Exception("Unknown dist table '"+
+            throw MLDB::Exception("Unknown dist table '"+
                         key.first.utf8String()+"'");
 
         //for(double outcome : outcomes)

--- a/plugins/dist_table_procedure.h
+++ b/plugins/dist_table_procedure.h
@@ -45,7 +45,7 @@ inline DISTTABLE_STATISTICS parseDistTableStatistic(const Utf8String & st)
     if(st == "last")  return DT_LAST;
     if(st == "count") return DT_COUNT;
     if(st == "sum")   return DT_SUM;
-    throw ML::Exception("Unknown distribution table statistic");
+    throw MLDB::Exception("Unknown distribution table statistic");
 }
 
 inline std::string print(DISTTABLE_STATISTICS stat)
@@ -59,7 +59,7 @@ inline std::string print(DISTTABLE_STATISTICS stat)
         case DT_LAST:   return "last";
         case DT_SUM:    return "sum";
         default:
-            throw ML::Exception("Unknown DistTable_Stat");
+            throw MLDB::Exception("Unknown DistTable_Stat");
     }
 }
 

--- a/plugins/docker_plugin.cc
+++ b/plugins/docker_plugin.cc
@@ -124,7 +124,7 @@ start()
 
     std::string path
         = "tmp/plugin-"
-        + ML::format("%08x", jsonHash(jsonEncode(config)))
+        + MLDB::format("%08x", jsonHash(jsonEncode(config)))
         + ".so";
 
     {
@@ -141,7 +141,7 @@ start()
     if (!handle) {
         char * error = dlerror();
         ExcAssert(error);
-        throw ML::Exception("couldn't load plugin %s: %s",
+        throw MLDB::Exception("couldn't load plugin %s: %s",
                             path.c_str(), error);
     }
 
@@ -152,7 +152,7 @@ start()
     auto registerPlugin =  (RegisterFnType) dlsym(handle, "mldbPluginEnter");
     
     if (!registerPlugin)
-        throw ML::Exception("plugin library doesn't expose mldb_plugin_enter: %s",
+        throw MLDB::Exception("plugin library doesn't expose mldb_plugin_enter: %s",
                             dlerror());
     
     std::shared_ptr<Plugin> plugin(registerPlugin(server));

--- a/plugins/em.cc
+++ b/plugins/em.cc
@@ -152,10 +152,10 @@ run(const ProcedureRunConfig & run,
     auto rows = embeddingOutput.first;
     std::vector<KnownColumn> & vars = embeddingOutput.second;
 
-    std::vector<ML::distribution<double> > vecs;
+    std::vector<distribution<double> > vecs;
 
     for (unsigned i = 0;  i < rows.size();  ++i) {
-        vecs.emplace_back(ML::distribution<double>(std::get<2>(rows[i]).begin(),
+        vecs.emplace_back(distribution<double>(std::get<2>(rows[i]).begin(),
                                                    std::get<2>(rows[i]).end()));
     }
 
@@ -235,10 +235,10 @@ run(const ProcedureRunConfig & run,
             auto flatmatrix = tovector(cluster.covarianceMatrix);
 
             for (unsigned j = 0;  j < flatmatrix.size();  ++j) {
-                cols.emplace_back(ColumnPath(ML::format("c%02d", j)), flatmatrix[j], applyDate);
+                cols.emplace_back(ColumnPath(MLDB::format("c%02d", j)), flatmatrix[j], applyDate);
             }
 
-            centroids->recordRow(RowPath(ML::format("%i", i)), cols);
+            centroids->recordRow(RowPath(MLDB::format("%i", i)), cols);
         }
 
         centroids->commit();
@@ -278,7 +278,7 @@ EMFunctionConfigDescription()
                          JsonParsingContext & context) {
         // this includes empty url
         if(!cfg->modelFileUrl.valid()) {
-            throw ML::Exception("modelFileUrl \"" + cfg->modelFileUrl.toString()
+            throw MLDB::Exception("modelFileUrl \"" + cfg->modelFileUrl.toString()
                                 + "\" is not valid");
         }
     };
@@ -365,7 +365,7 @@ applyT(const ApplierT & applier_, EMInput input_) const
     const auto * downcast
             = dynamic_cast<const EMFunctionApplier *>(&applier_);
 
-    ML::distribution<double> input = downcast->extract(input_.embedding);
+    distribution<double> input = downcast->extract(input_.embedding);
     Date ts = input_.embedding.getEffectiveTimestamp();
 
     int bestCluster = impl->em.assign(input);

--- a/plugins/embedding.cc
+++ b/plugins/embedding.cc
@@ -129,14 +129,14 @@ struct EmbeddingDatasetRepr {
     }
 
     struct Row {
-        Row(RowPath rowName, ML::distribution<float> coords, Date timestamp)
+        Row(RowPath rowName, distribution<float> coords, Date timestamp)
             : rowName(std::move(rowName)), coords(std::move(coords)),
               timestamp(timestamp)
         {
         }
 
         RowPath rowName;
-        ML::distribution<float> coords;
+        distribution<float> coords;
         Date timestamp;
 
         void serialize(ML::DB::Store_Writer & store) const
@@ -161,7 +161,7 @@ struct EmbeddingDatasetRepr {
         return result;
     }
 
-    float dist(unsigned row1, const ML::distribution<float> & row2) const
+    float dist(unsigned row1, const distribution<float> & row2) const
     {
         ExcAssertLess(row1, rows.size());
         ExcAssertEqual(row2.size(), columns.size());
@@ -196,10 +196,10 @@ struct EmbeddingDatasetRepr {
     
     std::vector<ColumnPath> columnNames;
     std::vector<std::vector<float> > columns;
-    ML::Lightweight_Hash<ColumnHash, int> columnIndex;
+    Lightweight_Hash<ColumnHash, int> columnIndex;
 
     std::vector<Row> rows;
-    ML::Lightweight_Hash<uint64_t, int> rowIndex;
+    Lightweight_Hash<uint64_t, int> rowIndex;
     
     std::unique_ptr<ML::VantagePointTreeT<int> > vpTree;
     std::unique_ptr<DistanceMetric> distance;
@@ -259,7 +259,7 @@ struct EmbeddingDataset::Itl
     GcLock lock;
     RcuProtected<EmbeddingDatasetRepr> committed;
 
-    //typedef ML::Spinlock Mutex;
+    //typedef Spinlock Mutex;
     typedef std::mutex Mutex;
     Mutex mutex;
     std::atomic<EmbeddingDatasetRepr *> uncommitted;
@@ -643,7 +643,7 @@ struct EmbeddingDataset::Itl
             uint64_t rowHash = EmbeddingDatasetRepr::getRowHashForIndex(rowName);
 
             const auto & vec = std::get<1>(r);
-            ML::distribution<float> embedding(vec.begin(), vec.end());
+            distribution<float> embedding(vec.begin(), vec.end());
             Date ts = std::get<2>(r);
 
             int index = (*uncommitted).rows.size();
@@ -699,7 +699,7 @@ struct EmbeddingDataset::Itl
         auto repr = committed();
 
         uint64_t rowHash = EmbeddingDatasetRepr::getRowHashForIndex(rowName);
-        ML::distribution<float> embedding;
+        distribution<float> embedding;
         Date latestDate = Date::negativeInfinity();
 
         // Do it here before we acquire the lock in the case that it's initalized
@@ -830,7 +830,7 @@ struct EmbeddingDataset::Itl
 
         // Create the vantage point tree
         cerr << "creating vantage point tree" << endl;
-        ML::Timer timer;
+        Timer timer;
         
         std::vector<int> items;
         for (unsigned i = 0;  i < (*uncommitted).rows.size();  ++i) {
@@ -840,11 +840,11 @@ struct EmbeddingDataset::Itl
         // Function used to build the VP tree, that scans all of the items in
         // parallel.
         auto dist = [&] (int item, const std::vector<int> & items, int depth)
-            -> ML::distribution<float>
+            -> distribution<float>
             {
                 ExcAssertLessEqual(depth, 100);  // 2^100 items is enough
 
-                ML::distribution<float> result(items.size());
+                distribution<float> result(items.size());
 
                 auto doItem = [&] (int n)
                 {
@@ -886,7 +886,7 @@ struct EmbeddingDataset::Itl
     }
 
     vector<tuple<RowPath, RowHash, float> >
-    getNeighbors(const ML::distribution<float> & coord,
+    getNeighbors(const distribution<float> & coord,
                  int numNeighbors,
                  double maxDistance)
     {
@@ -901,7 +901,7 @@ struct EmbeddingDataset::Itl
             return result;
         };
 
-        //ML::Timer timer;
+        //Timer timer;
 
         auto neighbors = repr->vpTree->search(dist, numNeighbors, maxDistance);
 
@@ -1071,7 +1071,7 @@ overrideFunction(const Utf8String & tableName,
 
 vector<tuple<RowPath, RowHash, float> >
 EmbeddingDataset::
-getNeighbors(const ML::distribution<float> & coord, int numNeighbors, double maxDistance) const
+getNeighbors(const distribution<float> & coord, int numNeighbors, double maxDistance) const
 {
     return itl->getNeighbors(coord, numNeighbors, maxDistance);
 }
@@ -1232,7 +1232,7 @@ applyT(const ApplierT & applier_, NearestNeighborsInput input) const
             ->getNeighbors(embedding.cast<float>(), numNeighbors, maxDistance);
     }
     else {
-        throw ML::Exception("Input row must be either a row name or an embedding");
+        throw MLDB::Exception("Input row must be either a row name or an embedding");
     }
 
     std::vector<CellValue> neighborsOut;
@@ -1324,7 +1324,7 @@ bindT(SqlBindingScope & outerContext, const std::shared_ptr<RowValueInfo> & inpu
             (400, "A dataset of type embedding needs to be provided for "
              "the nearest.neighbors function; the provided dataset '"
              + functionConfig.dataset->surface + "' is of type '"
-             + ML::type_name(*boundDataset.dataset) + "'");
+             + MLDB::type_name(*boundDataset.dataset) + "'");
     }
  
     return std::move(result);

--- a/plugins/embedding.h
+++ b/plugins/embedding.h
@@ -75,7 +75,7 @@ struct EmbeddingDataset: public Dataset {
     getKnownColumnInfos(const std::vector<ColumnPath> & columnNames) const;
     
     std::vector<std::tuple<RowPath, RowHash, float> >
-    getNeighbors(const ML::distribution<float> & coord, int numNeighbors,
+    getNeighbors(const distribution<float> & coord, int numNeighbors,
                  double maxDistance) const;
     
     std::vector<std::tuple<RowPath, RowHash, float> >

--- a/plugins/experiment_procedure.cc
+++ b/plugins/experiment_procedure.cc
@@ -221,7 +221,7 @@ accumStats(const Json::Value & js, const string & path) {
             }
             else {
                 outputStatsAccum.insert(make_pair(currPath,
-                            ML::distribution<double>{js[key].asDouble()}));
+                            distribution<double>{js[key].asDouble()}));
             }
         }
     }
@@ -250,7 +250,7 @@ generateStatistics(const Json::Value & js,
         else if(js[key].isNumeric()) {
             auto it = outputStatsAccum.find(currPath);
             if(it == outputStatsAccum.end()) {
-                throw ML::Exception("Unable to find statistics '"+currPath+"' in results map");
+                throw MLDB::Exception("Unable to find statistics '"+currPath+"' in results map");
             }
 
             Json::Value stats;
@@ -316,16 +316,16 @@ run(const ProcedureRunConfig & run,
     Json::Value test_eval_results(Json::ValueType::arrayValue);
 
     if(!runProcConf.inputData.stm) {
-        throw ML::Exception("Training data must be specified.");
+        throw MLDB::Exception("Training data must be specified.");
     }
 
     // validation
     if(runProcConf.datasetFolds.size() > 0 && runProcConf.kfold != 0) {
-        throw ML::Exception("The datasetFolds and kfold parameters "
+        throw MLDB::Exception("The datasetFolds and kfold parameters "
                 "cannot be specified at the same time.");
     }
     else if(runProcConf.kfold == 1) {
-        throw ML::Exception("When using the kfold parameter, it must be >= 2.");
+        throw MLDB::Exception("When using the kfold parameter, it must be >= 2.");
     }
 
     // default behaviour if nothing is defined
@@ -348,7 +348,7 @@ run(const ProcedureRunConfig & run,
     // generate dataset_splits if using the kfold helper parameter
     if(runProcConf.kfold >= 2) {
         if(runProcConf.testingDataOverride) {
-            throw ML::Exception("Should not use a k-fold cross-validation if testing "
+            throw MLDB::Exception("Should not use a k-fold cross-validation if testing "
                 "dataset is specified.");
         }
 
@@ -356,8 +356,8 @@ run(const ProcedureRunConfig & run,
             //train and test
             runProcConf.datasetFolds.push_back(
                 DatasetFoldConfig(
-                    SqlExpression::parse(ML::format("rowHash() %% %d != %d", runProcConf.kfold, k)),
-                    SqlExpression::parse(ML::format("rowHash() %% %d = %d",  runProcConf.kfold, k))));
+                    SqlExpression::parse(MLDB::format("rowHash() %% %d != %d", runProcConf.kfold, k)),
+                    SqlExpression::parse(MLDB::format("rowHash() %% %d = %d",  runProcConf.kfold, k))));
         }
     }
 
@@ -376,7 +376,7 @@ run(const ProcedureRunConfig & run,
 
         string baseUrl = runProcConf.modelFileUrlPattern.toString();
         ML::replace_all(baseUrl, "$runid",
-                        ML::format("%s-%d", runProcConf.experimentName, (int)progress));
+                        MLDB::format("%s-%d", runProcConf.experimentName, (int)progress));
         clsProcConf.modelFileUrl = Url(baseUrl);
         clsProcConf.configuration = runProcConf.configuration;
         clsProcConf.configurationFile = runProcConf.configurationFile;
@@ -385,7 +385,7 @@ run(const ProcedureRunConfig & run,
         clsProcConf.mode = runProcConf.mode;
 
 
-        clsProcConf.functionName = ML::format("%s_scorer_%d", runProcConf.experimentName, (int)progress);
+        clsProcConf.functionName = MLDB::format("%s_scorer_%d", runProcConf.experimentName, (int)progress);
 
         if(progress == 0) {
             PolyConfig clsProcPC;
@@ -399,7 +399,7 @@ run(const ProcedureRunConfig & run,
         }
 
         if(!clsProcedure) {
-            throw ML::Exception("Was unable to create classifier.train procedure");
+            throw MLDB::Exception("Was unable to create classifier.train procedure");
         }
 
         // create run configuration
@@ -440,7 +440,7 @@ run(const ProcedureRunConfig & run,
         if     (runProcConf.mode == CM_BOOLEAN ||
                 runProcConf.mode == CM_REGRESSION)  scoreExpr = "\"%s\"({%s})[score] as score";
         else if(runProcConf.mode == CM_CATEGORICAL) scoreExpr = "\"%s\"({%s})[scores] as score";
-        else throw ML::Exception("Classifier mode %d not implemented", runProcConf.mode);
+        else throw MLDB::Exception("Classifier mode %d not implemented", runProcConf.mode);
 
 
         // this lambda actually runs the accuracy procedure for the given config
@@ -452,16 +452,16 @@ run(const ProcedureRunConfig & run,
             if (!weight)
                 weight = SqlRowExpression::parse("1.0 as weight");
 
-            auto score = SqlRowExpression::parse(ML::format(scoreExpr.c_str(),
+            auto score = SqlRowExpression::parse(MLDB::format(scoreExpr.c_str(),
                                                             clsProcConf.functionName.utf8String(),
                                                             features->surface.utf8String()));
 
             accuracyConf.testingData.stm->select = SelectExpression({features, label, weight, score});
 
-            ML::Timer timer;
+            Timer timer;
 
             if(!accuracyProc)
-                throw ML::Exception("Was unable to create accuracy procedure");
+                throw MLDB::Exception("Was unable to create accuracy procedure");
 
             ProcedureRunConfig accuracyProcRunConf;
             accuracyProcRunConf.id = "run_"+to_string(progress);
@@ -486,7 +486,7 @@ run(const ProcedureRunConfig & run,
 
                 if(runProcConf.outputAccuracyDataset && onTestSet) {
                     PolyConfigT<Dataset> outputPC;
-                    outputPC.id = ML::format("%s_results_%d", runProcConf.experimentName, 
+                    outputPC.id = MLDB::format("%s_results_%d", runProcConf.experimentName, 
                                                               (int)progress);
                     outputPC.type = "tabular";
 
@@ -497,7 +497,7 @@ run(const ProcedureRunConfig & run,
                         server->handleRequest(connection, request);
 
                         if(connection.responseCode != 204) {
-                            throw ML::Exception("HTTP error "+std::to_string(connection.responseCode)+
+                            throw MLDB::Exception("HTTP error "+std::to_string(connection.responseCode)+
                                 " when trying to DELETE dataset '"+outputPC.id.utf8String()+"'");
                         }
                     }
@@ -579,7 +579,7 @@ run(const ProcedureRunConfig & run,
             RestRequest request("DELETE", resource, RestParams(), "{}");
             server->handleRequest(connection, request);
             if(connection.responseCode != 204) {
-                throw ML::Exception(ML::format("Unable to delete resource '%s'. "
+                throw MLDB::Exception(MLDB::format("Unable to delete resource '%s'. "
                             "Response code %d", resource, connection.responseCode));
             }
         }

--- a/plugins/experiment_procedure.h
+++ b/plugins/experiment_procedure.h
@@ -131,7 +131,7 @@ struct JsStatsStatsGenerator {
                             const std::string & path) const;
 
     Json::Value lastObj;
-    std::map<std::string, ML::distribution<double>> outputStatsAccum;
+    std::map<std::string, distribution<double>> outputStatsAccum;
 };
 
 

--- a/plugins/external_python_procedure.cc
+++ b/plugins/external_python_procedure.cc
@@ -83,9 +83,9 @@ run(const ProcedureRunConfig & run,
     auto stderr_sink = make_shared<OStreamInputSink>(output_stderr.get());
 
     if(!pluginRes)
-        throw ML::Exception("ScriptRessource not loaded");
+        throw MLDB::Exception("ScriptRessource not loaded");
     if(!pluginRes->packageElementExists(MAIN))
-        throw ML::Exception("Main script element does not exist");
+        throw MLDB::Exception("Main script element does not exist");
 
     // TODO fix this. MLDB-874
     string python_executable;

--- a/plugins/feature_generators.cc
+++ b/plugins/feature_generators.cc
@@ -82,7 +82,7 @@ HashedColumnFeatureGenerator(MldbServer * owner,
     functionConfig = config.params.convert<HashedColumnFeatureGeneratorConfig>();
 
     for(int i=0; i<numBuckets(); i++) {
-        outputColumns.emplace_back(ColumnPath(ML::format("hashColumn%d", i)),
+        outputColumns.emplace_back(ColumnPath(MLDB::format("hashColumn%d", i)),
                                    std::make_shared<Float32ValueInfo>(),
                                    COLUMN_IS_DENSE);
     }
@@ -97,9 +97,9 @@ FeatureGeneratorOutput
 HashedColumnFeatureGenerator::
 call(FeatureGeneratorInput input) const
 {
-    ML::distribution<float> result(numBuckets());
+    distribution<float> result(numBuckets());
 
-    ML::Lightweight_Hash_Set<uint64_t> doneHashes;
+    Lightweight_Hash_Set<uint64_t> doneHashes;
 
     Date ts = Date::negativeInfinity();
 
@@ -118,7 +118,7 @@ call(FeatureGeneratorInput input) const
             hash = sipHash(defaultSeedStable.u64, str.rawData(), str.rawLength());
         }
         else {
-            throw ML::Exception("Unsupported hashing mode");
+            throw MLDB::Exception("Unsupported hashing mode");
         }
 
         if (!doneHashes.insert(hash).second)
@@ -144,7 +144,7 @@ call(FeatureGeneratorInput input) const
     ExpressionValue foResult;
     RowValue rowVal;
     for(int i=0; i<result.size(); i++) {
-        rowVal.push_back(make_tuple(ColumnPath(ML::format("hashColumn%d", i)),
+        rowVal.push_back(make_tuple(ColumnPath(MLDB::format("hashColumn%d", i)),
                                     CellValue(result[i]), ts));
     }
 

--- a/plugins/fetcher.cc
+++ b/plugins/fetcher.cc
@@ -117,7 +117,7 @@ struct FetcherFunction: public ValueFunctionT<FetcherArgs, FetcherOutput> {
         }
         JML_CATCH_ALL {
             result.content = ExpressionValue::null(Date::notADate());
-            result.error = ExpressionValue(ML::getExceptionString(), Date::now());
+            result.error = ExpressionValue(getExceptionString(), Date::now());
         }
         return result;
     }

--- a/plugins/for_each_line.cc
+++ b/plugins/for_each_line.cc
@@ -107,7 +107,7 @@ readStream(std::istream & stream,
 
                 double elapsed = now.secondsSince(start);
                 double instElapsed = now.secondsSince(lastCheck);
-                cerr << ML::format("doing %.3fMlines/second total, %.3f instantaneous",
+                cerr << MLDB::format("doing %.3fMlines/second total, %.3f instantaneous",
                                    done / elapsed / 1000000.0,
                                    1000000 / instElapsed / 1000000.0)
                      << endl;

--- a/plugins/importtext_procedure.cc
+++ b/plugins/importtext_procedure.cc
@@ -117,7 +117,7 @@ ImportTextConfigDescription::ImportTextConfigDescription()
     onPostValidate = [] (ImportTextConfig * config,
                          JsonParsingContext & context) {
         if (!config->headers.empty() && config->autoGenerateHeaders) {
-            throw ML::Exception("autoGenerateHeaders cannot be true if "
+            throw MLDB::Exception("autoGenerateHeaders cannot be true if "
                                 "headers is defined.");
         }
     };
@@ -280,7 +280,7 @@ struct SqlCsvScope: public SqlExpressionMldbScope {
                     {
                         auto & row = scope.as<RowScope>();
                         if(!row.rowName) {
-                            throw ML::Exception("rowHash() not available in this scope");
+                            throw MLDB::Exception("rowHash() not available in this scope");
                         }
                         return ExpressionValue(row.rowName->hash(), fileTimestamp);
                     },
@@ -453,7 +453,7 @@ parseFixedWidthCsvRow(const char * & line,
             // Parse differently based upon encoding
             switch (encoding) {
             case ASCII:
-            throw ML::Exception("non-ASCII character in ASCII text file");
+            throw MLDB::Exception("non-ASCII character in ASCII text file");
             case LATIN1:
             return CellValue(Utf8String::fromLatin1(string(start, len)));
             case UTF8:
@@ -672,7 +672,7 @@ struct ImportTextProcedureWorkInstance
     }
 
     vector<ColumnPath> knownColumnNames;
-    ML::Lightweight_Hash<ColumnHash, int> columnIndex; //To check for duplicates column names
+    Lightweight_Hash<ColumnHash, int> columnIndex; //To check for duplicates column names
     int64_t lineOffset;
     // Column names in the CSV file.  This is distinct from the
     // output column names that will be created once parsing has
@@ -785,12 +785,12 @@ struct ImportTextProcedureWorkInstance
                     }
 
                     try {
-                        ML::Parse_Context pcontext(filename,
+                        ParseContext pcontext(filename,
                                                header.c_str(), header.length(), 1, 0);
-                        fields = ML::expect_csv_row(pcontext, -1, separator);
+                        fields = expect_csv_row(pcontext, -1, separator);
                         break;
                     }
-                    catch (ML::FileFinishInsideQuote & exp) {
+                    catch (FileFinishInsideQuote & exp) {
                         if(config.allowMultiLines) {
                             prevHeader.assign(std::move(header));
                             continue;
@@ -838,7 +838,7 @@ struct ImportTextProcedureWorkInstance
         }
 
         // Early check for duplicate column names in input
-        ML::Lightweight_Hash<ColumnHash, int> inputColumnIndex;
+        Lightweight_Hash<ColumnHash, int> inputColumnIndex;
         for (unsigned i = 0;  i < inputColumnNames.size();  ++i) {
             const ColumnPath & c = inputColumnNames[i];
             ColumnHash ch(c);
@@ -928,7 +928,7 @@ struct ImportTextProcedureWorkInstance
         std::atomic<uint64_t> numSkipped(0);
         std::atomic<uint64_t> totalLinesProcessed(0);
 
-        ML::Timer timer;
+        Timer timer;
 
         auto handleError = [&](const std::string & message,
                                int64_t lineNumber,

--- a/plugins/json_importer.cc
+++ b/plugins/json_importer.cc
@@ -235,7 +235,7 @@ struct JSONImporter: public Procedure {
                                       onProgress, true);
 
         if(!outputDataset) {
-            throw ML::Exception("Unable to obtain output dataset");
+            throw MLDB::Exception("Unable to obtain output dataset");
         }
 
         Date zeroTs;
@@ -250,7 +250,7 @@ struct JSONImporter: public Procedure {
 
         Date timestamp = stream.info().lastModified;
 
-        ML::Timer timer;
+        Timer timer;
 
         // Skip those up to the offset
         for (size_t i = 0;  stream && i < config.offset;  ++i, ++lineOffset) {

--- a/plugins/kmeans.cc
+++ b/plugins/kmeans.cc
@@ -110,7 +110,7 @@ ML::KMeansMetric * makeMetric(MetricSpace metric)
         return new ML::KMeansCosineMetric();
         break;
     default:
-        throw ML::Exception("Unknown kmeans metric type");
+        throw MLDB::Exception("Unknown kmeans metric type");
     }
 }
 
@@ -178,10 +178,10 @@ run(const ProcedureRunConfig & run,
         columnNames.push_back(v.columnName);
     }
 
-    std::vector<ML::distribution<float> > vecs;
+    std::vector<distribution<float> > vecs;
 
     for (unsigned i = 0;  i < rows.size();  ++i) {
-        vecs.emplace_back(ML::distribution<float>(std::get<2>(rows[i]).begin(),
+        vecs.emplace_back(distribution<float>(std::get<2>(rows[i]).begin(),
                                                   std::get<2>(rows[i]).end()));
     }
 
@@ -260,7 +260,7 @@ run(const ProcedureRunConfig & run,
                 cols.emplace_back(columnNames[j], cluster.centroid[j], applyDate);
             }
 
-            centroids->recordRow(RowPath(ML::format("%i", i)), cols);
+            centroids->recordRow(RowPath(MLDB::format("%i", i)), cols);
         }
 
         centroids->commit();
@@ -301,7 +301,7 @@ KmeansFunctionConfigDescription()
                          JsonParsingContext & context) {
         // this includes empty url
         if(!cfg->modelFileUrl.valid()) {
-            throw ML::Exception("modelFileUrl \"" + cfg->modelFileUrl.toString()
+            throw MLDB::Exception("modelFileUrl \"" + cfg->modelFileUrl.toString()
                                 + "\" is not valid");
         }
     };

--- a/plugins/lang/js/js_common.cc
+++ b/plugins/lang/js/js_common.cc
@@ -484,7 +484,7 @@ ScriptException convertException(const v8::TryCatch & trycatch,
     using namespace v8;
 
     if (!trycatch.HasCaught())
-        throw ML::Exception("function didn't return but no result");
+        throw MLDB::Exception("function didn't return but no result");
     
     Handle<Value> exception = trycatch.Exception();
     String::Utf8Value exception_str(exception);
@@ -518,7 +518,7 @@ ScriptException convertException(const v8::TryCatch & trycatch,
         if (endColumn + 4 <= sourceLine.length())
             sourceLine.replace(endColumn + 4, 0, "]]]]");
 
-        where = ML::format("file '%s', line %d, column %d, source '%s': %s",
+        where = MLDB::format("file '%s', line %d, column %d, source '%s': %s",
                            scriptUri.rawData(),
                            line, column,
                            sourceLine.rawData(),
@@ -612,7 +612,7 @@ wrap(v8::Handle<v8::Object> handle, JsPluginContext * context)
     ExcAssert(js_object_.IsEmpty());
 
     if (handle->InternalFieldCount() == 0) {
-        throw ML::Exception("InternalFieldCount is zero; are you forgetting "
+        throw MLDB::Exception("InternalFieldCount is zero; are you forgetting "
                             "to use 'new'?");
     }
 
@@ -703,7 +703,7 @@ JsContextScope::
 current()
 {
     if (!jsContextStack || jsContextStack->empty())
-        throw ML::Exception("attempt to retrieve JS context stack with nothing on it");
+        throw MLDB::Exception("attempt to retrieve JS context stack with nothing on it");
     return jsContextStack->back();
 }
 
@@ -721,7 +721,7 @@ JsContextScope::
 exit(JsPluginContext * context)
 {
     if (current() != context)
-        throw ML::Exception("JS context stack consistency error");
+        throw MLDB::Exception("JS context stack consistency error");
     jsContextStack->pop_back();
 }
 
@@ -774,7 +774,7 @@ from_js(const JSValue & val, const RestParams *)
         for (int i=0; i<arrPtr->Length(); ++i) {
             auto arrPtr2 = v8::Array::Cast(*arrPtr->Get(i));
             if(arrPtr2->Length() != 2) {
-                throw ML::Exception("invalid length for pair extraction");
+                throw MLDB::Exception("invalid length for pair extraction");
             }
             
             Json::Value param = fromJsForRestParams(arrPtr2->Get(1));
@@ -814,7 +814,7 @@ from_js(const JSValue & val, const RestParams *)
 
         return result;
     }
-    else throw ML::Exception("couldn't convert JS value '%s' to REST parameters",
+    else throw MLDB::Exception("couldn't convert JS value '%s' to REST parameters",
                              cstr(val).c_str());
 }
 

--- a/plugins/lang/js/js_common.h
+++ b/plugins/lang/js/js_common.h
@@ -102,9 +102,9 @@ ExpressionValue from_js_ref(const JS::JSValue & value, ExpressionValue * = 0);
 ScriptException convertException(const v8::TryCatch & trycatch,
                                  const Utf8String & context);
 
-struct JsException: public ML::Exception {
+struct JsException: public MLDB::Exception {
     JsException(const ScriptException & exc)
-        : ML::Exception(exc.where.rawString()), rep(exc)
+        : MLDB::Exception(exc.where.rawString()), rep(exc)
     {
     }
 

--- a/plugins/lang/js/js_function.cc
+++ b/plugins/lang/js/js_function.cc
@@ -48,7 +48,7 @@ struct JsFunctionThreadData {
 
 struct JsFunctionData {
     MldbServer * server;
-    ML::ThreadSpecificInstanceInfo<JsFunctionThreadData, void> threadInfo;
+    ThreadSpecificInstanceInfo<JsFunctionThreadData, void> threadInfo;
     Utf8String scriptSource;
     std::string filenameForErrorMessages;
     std::vector<std::string> params;

--- a/plugins/lang/js/js_loader.cc
+++ b/plugins/lang/js/js_loader.cc
@@ -158,7 +158,7 @@ struct JsPluginJS {
     {
         try {
             if (args.Length() < 1)
-                throw ML::Exception("Need a handler");
+                throw MLDB::Exception("Need a handler");
 
             JsPluginContext * itl = getShared(args.This());
 
@@ -221,7 +221,7 @@ struct JsPluginJS {
     {
         try {
             if (args.Length() < 1)
-                throw ML::Exception("Need a handler");
+                throw MLDB::Exception("Need a handler");
 
             JsPluginContext * itl = getShared(args.This());
 
@@ -230,7 +230,7 @@ struct JsPluginJS {
 
             fs::path fullDir(fs::path(itl->pluginResource->getPluginDir().string()) / fs::path(dir));
             if(!fs::exists(fullDir)) {
-                throw ML::Exception("Cannot serve static folder for path that does "
+                throw MLDB::Exception("Cannot serve static folder for path that does "
                         "not exist: " + fullDir.string());
             }
 
@@ -248,7 +248,7 @@ struct JsPluginJS {
     {
         try {
             if (args.Length() < 1)
-                throw ML::Exception("Need a handler");
+                throw MLDB::Exception("Need a handler");
 
             JsPluginContext * itl = getShared(args.This());
 
@@ -277,7 +277,7 @@ struct JsPluginJS {
     {
         try {
             if (args.Length() < 1)
-                throw ML::Exception("Need a handler");
+                throw MLDB::Exception("Need a handler");
 
             JsPluginContext * itl = getShared(args.This());
 

--- a/plugins/lang/js/js_utils.cc
+++ b/plugins/lang/js/js_utils.cc
@@ -21,13 +21,10 @@ using namespace std;
 using namespace v8;
 using namespace ML;
 
-namespace ML {
-
-__thread BacktraceInfo * current_backtrace = nullptr;
-
-} // namespace ML
 
 namespace MLDB {
+
+__thread BacktraceInfo * current_backtrace = nullptr;
 
 namespace JS {
 
@@ -56,12 +53,12 @@ injectBacktrace(v8::Handle<v8::Value> value)
 {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
     if (value.IsEmpty())
-        throw ML::Exception("no object passed for backtrace injection");
+        throw MLDB::Exception("no object passed for backtrace injection");
 
     auto obj = value.As<v8::Object>();
 
     if (obj.IsEmpty())
-        throw ML::Exception("can't inject backtrace");
+        throw MLDB::Exception("can't inject backtrace");
 
     v8::Handle<v8::Value> jsStack
         = obj->Get(v8::String::NewFromUtf8(isolate, "stack"));
@@ -71,18 +68,18 @@ injectBacktrace(v8::Handle<v8::Value> value)
     // Frames to skip:
     // at [C++] ML::backtrace(int)
     // at [C++] MLDB::JS::injectBacktrace(v8::Handle<v8::Value>)
-    // at [C++] MLDB::JS::mapException(ML::Exception const&)
+    // at [C++] MLDB::JS::mapException(MLDB::Exception const&)
     // at [C++] MLDB::JS::translateCurrentException()
     int num_frames_to_skip = 4;
 
-    vector<ML::BacktraceFrame> backtrace;
+    vector<BacktraceFrame> backtrace;
     if (current_backtrace && abi::__cxa_current_exception_type()) {
         // Skip:
-        backtrace = ML::backtrace(*current_backtrace, num_frames_to_skip);
+        backtrace = MLDB::backtrace(*current_backtrace, num_frames_to_skip);
         delete current_backtrace;
         current_backtrace = 0;
     }
-    else backtrace = ML::backtrace(num_frames_to_skip);
+    else backtrace = MLDB::backtrace(num_frames_to_skip);
 
     v8::Handle<v8::Array> nativeStack
         (v8::Array::New(isolate, backtrace.size() + jsStackElements.size()));
@@ -113,10 +110,10 @@ mapException(const std::exception & exc)
 }
 
 v8::Handle<Value>
-mapException(const ML::Exception & exc)
+mapException(const MLDB::Exception & exc)
 {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
-    //cerr << "mapping ML::Exception " << exc.what() << endl;
+    //cerr << "mapping MLDB::Exception " << exc.what() << endl;
 
     return isolate->ThrowException
         (injectBacktrace
@@ -133,7 +130,7 @@ mapException(const HttpReturnException & exc)
     auto obj = error.As<v8::Object>();
 
     if (obj.IsEmpty())
-        throw ML::Exception("can't inject backtrace");
+        throw MLDB::Exception("can't inject backtrace");
     
     obj->Set(v8::String::NewFromUtf8(isolate, "httpCode"),
              v8::Integer::New(isolate, exc.httpCode));
@@ -151,7 +148,7 @@ translateCurrentException()
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
 
     if (!std::current_exception()) {
-        throw ML::Exception("no exception");
+        throw MLDB::Exception("no exception");
     }
 
     try {
@@ -163,7 +160,7 @@ translateCurrentException()
     catch (const HttpReturnException & ex) {
         return mapException(ex);
     }
-    catch(const ML::Exception& ex) {
+    catch(const MLDB::Exception& ex) {
         return mapException(ex);
     }
     catch(const std::exception& ex) {
@@ -182,14 +179,14 @@ ValuePromise getArg(const JSArgs & args, int argnum,
                     const std::string & name)
 {
     if (args.Length() <= argnum)
-        throw ML::Exception("argument %d (%s) must be present",
+        throw MLDB::Exception("argument %d (%s) must be present",
                             argnum, name.c_str());
 
     ValuePromise arg;
     arg.value  = args[argnum];
 
     if (arg.value->IsUndefined() || arg.value->IsNull())
-        throw ML::Exception("argument %d (%s) was %s",
+        throw MLDB::Exception("argument %d (%s) was %s",
                             argnum, name.c_str(), cstr(arg.value).c_str());
 
     arg.argnum = argnum;
@@ -217,7 +214,7 @@ from_js(const JSValue & val, v8::Persistent<v8::Function> *)
         //cerr << "fn = " << cstr(fn) << endl;
         //cerr << "fn.IsEmpty() = " << fn.IsEmpty() << endl;
         //cerr << "val->IsFunction() = " << val->IsFunction() << endl;
-        throw ML::Exception("expected a function; instead we got " + cstr(val));
+        throw MLDB::Exception("expected a function; instead we got " + cstr(val));
     }
     
     return v8::Persistent<v8::Function>(isolate, fn);
@@ -232,7 +229,7 @@ from_js(const JSValue & val, v8::Local<v8::Function> *)
         //cerr << "fn = " << cstr(fn) << endl;
         //cerr << "fn.IsEmpty() = " << fn.IsEmpty() << endl;
         //cerr << "val->IsFunction() = " << val->IsFunction() << endl;
-        throw ML::Exception("expected a function; instead we got " + cstr(val));
+        throw MLDB::Exception("expected a function; instead we got " + cstr(val));
     }
 
     return fn;
@@ -243,7 +240,7 @@ from_js(const JSValue & val, v8::Handle<v8::Array> *)
 {
     auto arr = val.As<v8::Array>();
     if (arr.IsEmpty() || !arr->IsArray())
-        throw ML::Exception("expected an array; instead we got " + cstr(val));
+        throw MLDB::Exception("expected an array; instead we got " + cstr(val));
 
     return arr;
 }
@@ -262,21 +259,21 @@ getFunction(const std::string & script_source)
     Handle<Script> script = Script::Compile(source);
 
     if (script.IsEmpty() && tc.HasCaught())
-        throw ML::Exception("got exception compiling: "
+        throw MLDB::Exception("got exception compiling: "
                             + JS::cstr(tc.Exception()));
     if (script.IsEmpty())
-        throw ML::Exception("compilation returned nothing");
+        throw MLDB::Exception("compilation returned nothing");
     
     // Run the script to get the result (which should be a function)
     Handle<Value> result = script->Run();
 
     if (result.IsEmpty() && tc.HasCaught())
-        throw ML::Exception("got exception compiling: "
+        throw MLDB::Exception("got exception compiling: "
                             + JS::cstr(tc.Exception()));
     if (result.IsEmpty())
-        throw ML::Exception("compilation returned nothing");
+        throw MLDB::Exception("compilation returned nothing");
     if (!result->IsFunction())
-        throw ML::Exception("result of script isn't a function");
+        throw MLDB::Exception("result of script isn't a function");
     
     auto fnresult = result.As<v8::Function>();
 

--- a/plugins/lang/js/js_utils.h
+++ b/plugins/lang/js/js_utils.h
@@ -92,9 +92,9 @@ v8::Handle<v8::Value> injectBacktrace(v8::Handle<v8::Value> value);
         return;                                                 \
     }
 
-/** Convert a ML::Exception into a Javascript exception. */
+/** Convert a MLDB::Exception into a Javascript exception. */
 v8::Handle<v8::Value>
-mapException(const ML::Exception & exc);
+mapException(const MLDB::Exception & exc);
 
 /** Convert a std::exception into a Javascript exception. */
 v8::Handle<v8::Value>
@@ -108,10 +108,10 @@ toObject(v8::Handle<v8::Value> handle)
 {
     ExcAssert(!handle.IsEmpty());
     if (!handle->IsObject())
-        throw ML::Exception("value " + cstr(handle) + " is not an object");
+        throw MLDB::Exception("value " + cstr(handle) + " is not an object");
     v8::Handle<v8::Object> object = handle->ToObject();
     if (object.IsEmpty())
-        throw ML::Exception("value " + cstr(handle) + " is not an object");
+        throw MLDB::Exception("value " + cstr(handle) + " is not an object");
     return object;
 }
 
@@ -123,10 +123,10 @@ toArray(v8::Handle<v8::Value> handle)
 {
     ExcAssert(!handle.IsEmpty());
     if (!handle->IsArray())
-        throw ML::Exception("value " + cstr(handle) + " is not an array");
+        throw MLDB::Exception("value " + cstr(handle) + " is not an array");
     auto array = handle.As<v8::Array>();
     if (array.IsEmpty())
-        throw ML::Exception("value " + cstr(handle) + " is not an array");
+        throw MLDB::Exception("value " + cstr(handle) + " is not an array");
     return array;
 }
 
@@ -195,7 +195,7 @@ std::map<std::string, T>
 from_js(const JSValue & val, const std::map<std::string, T> * = 0)
 {
     if(!val->IsObject()) {
-        throw ML::Exception("invalid JSValue for map extraction");
+        throw MLDB::Exception("invalid JSValue for map extraction");
     }
     
     std::map<std::string, T> result;
@@ -237,7 +237,7 @@ std::map<Utf8String, T>
 from_js(const JSValue & val, const std::map<Utf8String, T> * = 0)
 {
     if(!val->IsObject()) {
-        throw ML::Exception("invalid JSValue for map extraction");
+        throw MLDB::Exception("invalid JSValue for map extraction");
     }
     
     std::map<Utf8String, T> result;
@@ -291,7 +291,7 @@ std::map<K, V, H>
 from_js(const JSValue & val, const std::map<K, V, H> * = 0)
 {
     if(!val->IsObject()) {
-        throw ML::Exception("invalid JSValue for map extraction");
+        throw MLDB::Exception("invalid JSValue for map extraction");
     }
     
     std::map<K, V, H> result;
@@ -342,12 +342,12 @@ std::pair<T,V>
 from_js(const JSValue & val, const std::pair<T,V> * = 0)
 {
     if(!val->IsArray()) {
-        throw ML::Exception("invalid JSValue for pair extraction");
+        throw MLDB::Exception("invalid JSValue for pair extraction");
     }
 
     auto arrPtr = v8::Array::Cast(*val);
     if(arrPtr->Length() != 2) {
-        throw ML::Exception("invalid length for pair extraction");
+        throw MLDB::Exception("invalid length for pair extraction");
     }
 
     return std::make_pair(from_js(JSValue(arrPtr->Get(0)),(T *) 0),
@@ -408,7 +408,7 @@ std::tuple<Args...>
 from_js(const JSValue & val, const std::tuple<Args...> * v = 0)
 {
     if (!val->IsArray())
-        throw ML::Exception("invalid JSValue for tuple extraction");
+        throw MLDB::Exception("invalid JSValue for tuple extraction");
 
     auto arrPtr = v8::Array::Cast(*val);
 
@@ -478,7 +478,7 @@ std::vector<T>
 from_js(const JSValue & val, const std::vector<T> * = 0)
 {
     if(!val->IsArray()) {
-        throw ML::Exception("invalid JSValue for vector extraction");
+        throw MLDB::Exception("invalid JSValue for vector extraction");
     }
 
     std::vector<T> result;
@@ -495,7 +495,7 @@ std::set<T>
 from_js(const JSValue & val, const std::set<T> * = 0)
 {
     if(!val->IsArray()) {
-        throw ML::Exception("invalid JSValue for set extraction");
+        throw MLDB::Exception("invalid JSValue for set extraction");
     }
 
     std::set<T> result;
@@ -581,16 +581,16 @@ struct ValuePromise {
             return from_js(this->value, (T *)0);
         } catch (const std::exception & exc) {
             if (argnum == -1)
-                throw ML::Exception("value \"%s\" could not be "
+                throw MLDB::Exception("value \"%s\" could not be "
                                     "converted to a %s: %s",
                                     cstr(this->value).c_str(),
-                                    ML::type_name<T>().c_str(),
+                                    MLDB::type_name<T>().c_str(),
                                     exc.what());
-            throw ML::Exception("argument %d (%s): value \"%s\" could not be "
+            throw MLDB::Exception("argument %d (%s): value \"%s\" could not be "
                                 "converted to a %s: %s",
                                 this->argnum, this->name.c_str(),
                                 cstr(this->value).c_str(),
-                                ML::type_name<T>().c_str(),
+                                MLDB::type_name<T>().c_str(),
                                 exc.what());
         }
     }
@@ -602,16 +602,16 @@ struct ValuePromise {
             return from_js_ref(this->value, (T *)0);
         } catch (const std::exception & exc) {
             if (argnum == -1)
-                throw ML::Exception("value \"%s\" could not be "
+                throw MLDB::Exception("value \"%s\" could not be "
                                     "converted to a %s: %s",
                                     cstr(this->value).c_str(),
-                                    ML::type_name<T>().c_str(),
+                                    MLDB::type_name<T>().c_str(),
                                     exc.what());
-            throw ML::Exception("argument %d (%s): value \"%s\" could not be "
+            throw MLDB::Exception("argument %d (%s): value \"%s\" could not be "
                                 "converted to a %s: %s",
                                 this->argnum, this->name.c_str(),
                                 cstr(this->value).c_str(),
-                                ML::type_name<T>().c_str(),
+                                MLDB::type_name<T>().c_str(),
                                 exc.what());
         }
     }

--- a/plugins/lang/js/js_value.cc
+++ b/plugins/lang/js/js_value.cc
@@ -210,7 +210,7 @@ void to_js(JSValue & jsval, const Json::Value & value)
         jsval = v8::Null(isolate);
         break;
     default:
-        throw ML::Exception("Can't convert from JsonCpp to JSValue");
+        throw MLDB::Exception("Can't convert from JsonCpp to JSValue");
         break;
     }
 }
@@ -237,7 +237,7 @@ int64_t check_to_int2(const JSValue & val)
 
     if (dval > std::numeric_limits<uint64_t>::max()
         || dval < std::numeric_limits<uint64_t>::min())
-        throw ML::Exception("Cannot fit " + cstr(val) + " into an integer");
+        throw MLDB::Exception("Cannot fit " + cstr(val) + " into an integer");
         
     v8::Local<v8::Number> num;
 
@@ -311,7 +311,7 @@ T check_to_int(const JSValue & val)
     T result2 = result1;
     if (result1 != result2)
         throw Exception("value " + cstr(val) + " does not fit in type "
-                        + ML::type_name<T>());
+                        + MLDB::type_name<T>());
     return result2;
 }
 
@@ -369,7 +369,7 @@ double from_js(const JSValue & val, double *)
             string s = ML::lowercase(cstr(val));
             if (s == "nan" || s == "-nan")
                 return result;
-            throw ML::Exception("string value \"%s\" is not converible to "
+            throw MLDB::Exception("string value \"%s\" is not converible to "
                                 "floating point",
                                 s.c_str());
         }
@@ -394,7 +394,7 @@ std::string from_js(const JSValue & val, std::string *)
 Json::Value from_js(const JSValue & val, Json::Value *)
 {
     if (val.IsEmpty())
-        throw ML::Exception("empty val");
+        throw MLDB::Exception("empty val");
 
     //cerr << cstr(val) << endl;
 
@@ -458,14 +458,14 @@ Json::Value from_js(const JSValue & val, Json::Value *)
     }
     if (val->IsNull() || val->IsUndefined())
         return Json::Value();
-    throw ML::Exception("can't convert from JSValue %s to Json::Value",
+    throw MLDB::Exception("can't convert from JSValue %s to Json::Value",
                         cstr(val).c_str());
 }
 
 Date from_js(const JSValue & val, Date *)
 {
     if(!v8::Date::Cast(*val)->IsDate())
-        throw ML::Exception("Couldn't convert from " + cstr(val) + " to MLDB::Date");
+        throw MLDB::Exception("Couldn't convert from " + cstr(val) + " to MLDB::Date");
     return Date::fromSecondsSinceEpoch(v8::Date::Cast(*val)->NumberValue()
                                        / 1000.0);
 }

--- a/plugins/lang/js/mldb_js.cc
+++ b/plugins/lang/js/mldb_js.cc
@@ -95,7 +95,7 @@ struct StreamJS::Methods {
 
             string nextLine;
             if(!getline(*stream, nextLine))
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
 
             while (!nextLine.empty() && nextLine[nextLine.size() - 1] == '\r')
                 nextLine.erase(nextLine.size() - 1);
@@ -130,7 +130,7 @@ struct StreamJS::Methods {
             stream->read(&byte, 1);
 
             if (stream->gcount() < 1)
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
             
             args.GetReturnValue().Set(JS::toJS(u));
         } HANDLE_JS_EXCEPTIONS(args);
@@ -148,7 +148,7 @@ struct StreamJS::Methods {
             stream->read(&byte, 1);
 
             if (stream->gcount() < 1)
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
             
             args.GetReturnValue().Set(JS::toJS(i));
         } HANDLE_JS_EXCEPTIONS(args);
@@ -166,7 +166,7 @@ struct StreamJS::Methods {
             stream->read(bytes, 4);
 
             if (stream->gcount() < 4)
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
             
             args.GetReturnValue().Set(JS::toJS(u));
         } HANDLE_JS_EXCEPTIONS(args);
@@ -184,7 +184,7 @@ struct StreamJS::Methods {
             stream->read(bytes, 4);
 
             if (stream->gcount() < 4)
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
             
             uint32_t u
                 = ubytes[3]
@@ -209,7 +209,7 @@ struct StreamJS::Methods {
             stream->read(bytes, 4);
 
             if (stream->gcount() < 4)
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
             
             args.GetReturnValue().Set(JS::toJS(u));
         } HANDLE_JS_EXCEPTIONS(args);
@@ -227,7 +227,7 @@ struct StreamJS::Methods {
             stream->read(bytes, 4);
 
             if (stream->gcount() < 4)
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
             
             int32_t u
                 = ubytes[3]
@@ -251,7 +251,7 @@ struct StreamJS::Methods {
             stream->read(bytes, 2);
 
             if (stream->gcount() < 2)
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
             
             args.GetReturnValue().Set(JS::toJS(u));
         } HANDLE_JS_EXCEPTIONS(args);
@@ -269,7 +269,7 @@ struct StreamJS::Methods {
             stream->read(bytes, 2);
 
             if (stream->gcount() < 2)
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
             
             uint16_t u
                 = ubytes[1] << 0
@@ -292,7 +292,7 @@ struct StreamJS::Methods {
             stream->read(bytes, 2);
 
             if (stream->gcount() < 2)
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
             
             args.GetReturnValue().Set(JS::toJS(u));
         } HANDLE_JS_EXCEPTIONS(args);
@@ -310,7 +310,7 @@ struct StreamJS::Methods {
             stream->read(bytes, 2);
 
             if (stream->gcount() < 2)
-                throw ML::Exception("End of file");
+                throw MLDB::Exception("End of file");
             
             int16_t u
                 = ubytes[1] << 0
@@ -331,7 +331,7 @@ struct StreamJS::Methods {
             std::vector<unsigned char> bytes;
 
             if (numBytes == -1) {
-                throw ML::Exception("no unlimited bytes");
+                throw MLDB::Exception("no unlimited bytes");
             }
             else {
                 bytes.resize(numBytes);
@@ -1031,7 +1031,7 @@ struct MldbJS::Methods {
                             args.GetReturnValue().Set(scope.Escape(CellValueJS::create(val, context)));
                         }
                         else {
-                            throw ML::Exception("Unknown object field for interval: '%s'.  Accepted are months, days, seconds or interval by itself");
+                            throw MLDB::Exception("Unknown object field for interval: '%s'.  Accepted are months, days, seconds or interval by itself");
                         }
                     }
                 }
@@ -1121,7 +1121,7 @@ struct MldbJS::Methods {
             else if (valLc == "sometimes") {
                 level = OptimizedPath::SOMETIMES;
             }
-            else throw ML::Exception("Couldn't parse path optimization level '"
+            else throw MLDB::Exception("Couldn't parse path optimization level '"
                                      + val + "': accepted are 'always', 'never' "
                                      "and 'sometimes'");
 
@@ -1219,7 +1219,7 @@ MldbJS::
 New(const v8::FunctionCallbackInfo<v8::Value> & args)
 {
     try {
-        throw ML::Exception("can't create new JS plugins");
+        throw MLDB::Exception("can't create new JS plugins");
     } HANDLE_JS_EXCEPTIONS(args);
 }
 

--- a/plugins/lang/python/mldb_python_converters.h
+++ b/plugins/lang/python/mldb_python_converters.h
@@ -71,7 +71,7 @@ struct RestParamsConverter
                 else
                 { 
                     throw HttpReturnException(400,
-                            ML::format("Exception while parsing REST parameter at position: %d", i));
+                            MLDB::format("Exception while parsing REST parameter at position: %d", i));
                 }
             }
         }
@@ -115,7 +115,7 @@ struct CellValueConverter
             //std::cerr << "   recording val as STR: " << val << std::endl;
             new (storage) CellValue(Utf8String(val));
         } else {
-            throw ML::Exception("Unsupported value type for CellValue converter");
+            throw MLDB::Exception("Unsupported value type for CellValue converter");
         }
     }
 };
@@ -162,7 +162,7 @@ struct PathConverter
                 return PathElement(Utf8String(val));
             }
 
-            throw ML::Exception("Unsupported value type for Path converter");
+            throw MLDB::Exception("Unsupported value type for Path converter");
         };
 
         boost::python::extract<PyList> listExtract(obj_ptr);

--- a/plugins/lang/python/python_converters.cc
+++ b/plugins/lang/python/python_converters.cc
@@ -241,7 +241,7 @@ construct_recur(PyObject * pyObj)
         }
     }
     //else if(PyDateTime_Check(pyObj)) {
-    //    throw ML::Exception("do datetime!!");
+    //    throw MLDB::Exception("do datetime!!");
     //}
     else if(PyTuple_Check(pyObj)) {
         val = construct_lst<bp::tuple>(pyObj);
@@ -254,7 +254,7 @@ construct_recur(PyObject * pyObj)
         bp::list keys = pyDict.keys();
         for(int i = 0; i < len(keys); i++) {
             //                 if(!PyString_Check(keys[i]))
-            //                     throw ML::Exception("PyDict to JsVal only supports string keys");
+            //                     throw MLDB::Exception("PyDict to JsVal only supports string keys");
             std::string key = bp::extract<std::string>(keys[i]);
 
             bp::object obj = bp::object(pyDict[keys[i]]);
@@ -274,7 +274,7 @@ construct_recur(PyObject * pyObj)
         // not returned so needs to be garbage collected
         Py_DECREF(str_obj);
 
-        throw ML::Exception("Unknown type in PyDict to JsVal converter. "
+        throw MLDB::Exception("Unknown type in PyDict to JsVal converter. "
                             "Str representation: "+str_rep);
     }
 
@@ -328,7 +328,7 @@ convert_recur(const Json::Value & js)
         return dict;
     }
     else {
-        throw ML::Exception("Unknown type is JsVal to PyDict converter");
+        throw MLDB::Exception("Unknown type is JsVal to PyDict converter");
     }
 }
 

--- a/plugins/lang/python/python_converters.h
+++ b/plugins/lang/python/python_converters.h
@@ -340,7 +340,7 @@ struct StrConstructableIdFromPython
             }
             id = boost::python::extract<std::string>(obj_ptr)();
         } else {
-            throw ML::Exception("StrConstructableIdFromPython: "
+            throw MLDB::Exception("StrConstructableIdFromPython: "
                                 "Failed to convert value to id");
         }
 

--- a/plugins/lang/python/python_loader.cc
+++ b/plugins/lang/python/python_loader.cc
@@ -261,7 +261,7 @@ PythonPlugin(MldbServer * server,
                                        config.id, res), routeHandlingMutex));
     }
     catch(const std::exception & exc) {
-        throw HttpReturnException(400, ML::format("Exception opening plugin: %s", exc.what()));
+        throw HttpReturnException(400, MLDB::format("Exception opening plugin: %s", exc.what()));
     }
 
     addRouteSyncJsonReturn(itl->router, "/lastoutput", {"GET"},
@@ -353,7 +353,7 @@ addPluginPathToEnv(PythonSubinterpreter & pyControl) const
     PyList_Insert( sysPath, 0, pluginDirPy );
 
     // change working dir to script dir
-//     PyRun_SimpleString(ML::format("import os\nos.chdir(\"%s\")", pluginDir).c_str());
+//     PyRun_SimpleString(MLDB::format("import os\nos.chdir(\"%s\")", pluginDir).c_str());
 }
 
 ScriptOutput PythonPlugin::
@@ -506,7 +506,7 @@ handleTypeRoute(RestDirectory * server,
         }
         catch(const std::exception & exc) {
             conn.sendResponse(400,
-                          jsonEncodeStr(ML::format("Exception opening script: %s", exc.what())),
+                          jsonEncodeStr(MLDB::format("Exception opening script: %s", exc.what())),
                           "application/json");
         }
 
@@ -622,7 +622,7 @@ runPythonScript(std::shared_ptr<PythonContext> titl,
             return result;
         }
         else {
-            throw ML::Exception("Unknown element to run!!");
+            throw MLDB::Exception("Unknown element to run!!");
         }
     } catch (const boost::python::error_already_set & exc) {
         ScriptException pyexc = convertException(pyControl, exc, "Running PyRunner script");

--- a/plugins/lang/python/python_plugin_context.cc
+++ b/plugins/lang/python/python_plugin_context.cc
@@ -507,7 +507,7 @@ void PythonPluginContext::
 setStatusHandler(PyObject * callback)
 {
     if(!callback)
-        throw ML::Exception("Must specify handler function");
+        throw MLDB::Exception("Must specify handler function");
 
     auto localsPlugin = boost::python::object(boost::python::ptr(mldbContext));
     getStatus = [=] ()
@@ -520,13 +520,13 @@ void PythonPluginContext::
 serveStaticFolder(const std::string & route, const std::string & dir)
 {
     if(route.empty() || dir.empty()) {
-        throw ML::Exception("Route and static directory cannot be empty "
+        throw MLDB::Exception("Route and static directory cannot be empty "
                 "for serving static folder");
     }
 
     fs::path fullDir(fs::path(getPluginDirectory()) / fs::path(dir));
     if(!fs::exists(fullDir)) {
-        throw ML::Exception("Cannot serve static folder for path that does "
+        throw MLDB::Exception("Cannot serve static folder for path that does "
                 "not exist: " + fullDir.string());
     }
 
@@ -541,12 +541,12 @@ void PythonPluginContext::
 serveDocumentationFolder(const std::string & dir)
 {
     if(dir.empty()) {
-        throw ML::Exception("Documentation directory cannot be empty");
+        throw MLDB::Exception("Documentation directory cannot be empty");
     }
 
     fs::path fullDir(fs::path(getPluginDirectory()) / fs::path(dir));
     if(!fs::exists(fullDir)) {
-        throw ML::Exception("Cannot serve documentation folder for path that does "
+        throw MLDB::Exception("Cannot serve documentation folder for path that does "
                 "not exist: " + fullDir.string());
     }
 
@@ -604,11 +604,11 @@ PythonContext* MldbPythonContext::
 getPyContext()
 {
     if(script && plugin)
-        throw ML::Exception("Both script and plugin are defined!!");
+        throw MLDB::Exception("Both script and plugin are defined!!");
 
     if(script) return script.get();
     if(plugin) return plugin.get();
-    throw ML::Exception("Neither script or plugin is defined!");
+    throw MLDB::Exception("Neither script or plugin is defined!");
 }
     
 void MldbPythonContext::
@@ -629,7 +629,7 @@ getPlugin()
     if(plugin) {
         return plugin;
     }
-    throw ML::Exception("Cannot call the plugin object in this context");
+    throw MLDB::Exception("Cannot call the plugin object in this context");
 
 }
 
@@ -639,7 +639,7 @@ getScript()
     if(script)
         return script;
 
-    throw ML::Exception("Cannot call the script object in this context");
+    throw MLDB::Exception("Cannot call the script object in this context");
 }
 
 void MldbPythonContext::
@@ -658,7 +658,7 @@ setPathOptimizationLevel(const std::string & val)
     else if (valLc == "sometimes") {
         level = OptimizedPath::SOMETIMES;
     }
-    else throw ML::Exception("Couldn't parse path optimization level '"
+    else throw MLDB::Exception("Couldn't parse path optimization level '"
                              + val + "': accepted are 'always', 'never' "
                              "and 'sometimes'");
 

--- a/plugins/matrix.cc
+++ b/plugins/matrix.cc
@@ -181,7 +181,7 @@ extractFeaturesFromRows(const Dataset & dataset,
 
     auto select = SqlRowExpression::parseList("*");
 
-    ML::Timer timer;
+    Timer timer;
     cerr << "extracting values" << endl;
 
     // Get an index of ColumnHash to dense value
@@ -269,7 +269,7 @@ extractFeaturesFromRows(const Dataset & dataset,
     {
         static int n = 0;
         cerr << "saving buckets " << n << endl;
-        filter_ostream stream(ML::format("buckets-%d.json", n++));
+        filter_ostream stream(MLDB::format("buckets-%d.json", n++));
         stream << "numExamples = " << featureBuckets.numExamples << endl;
         for (unsigned i = 0;  i < featureBuckets.size();  ++i) {
             stream << "bucket " << i << endl;
@@ -291,7 +291,7 @@ ColumnIndexEntries
 invertFeatures(const ClassifiedColumns & columns,
                const FeatureBuckets & featureBuckets)
 {
-    ML::Timer timer;
+    Timer timer;
 
     int numContinuousColumns = columns.continuousColumns.size();
     int numSparseColumns = columns.sparseColumns.size();
@@ -394,7 +394,7 @@ calculateCorrelations(const ColumnIndexEntries & columnIndex,
     // - for two sparse: hamming distance
     //
 
-    ML::Timer timer;
+    Timer timer;
 
     int numColumns = std::min<int>(numBasisVectors, columnIndex.size());
 

--- a/plugins/matrix.h
+++ b/plugins/matrix.h
@@ -86,7 +86,7 @@ struct ExtractedRow {
     {
     }
 
-    ExtractedRow(ML::distribution<float> continuous,
+    ExtractedRow(distribution<float> continuous,
                  std::vector<std::pair<ColumnHash, CellValue> > sparse)
         : continuous(std::move(continuous)),
           sparse(std::move(sparse))
@@ -94,7 +94,7 @@ struct ExtractedRow {
     }
 
     RowHash rowHash;  /// To sort on
-    ML::distribution<float> continuous;
+    distribution<float> continuous;
     std::vector<std::pair<ColumnHash, CellValue> > sparse;
 };
 
@@ -311,7 +311,7 @@ struct ColumnIndexEntry: public ColumnSpec {
             }
         };
 
-        throw ML::Exception("Unknown ColumnType");
+        throw MLDB::Exception("Unknown ColumnType");
     }
 
     double correlationContinuousContinuous(const ColumnIndexEntry & other) const
@@ -319,7 +319,7 @@ struct ColumnIndexEntry: public ColumnSpec {
         double result = continuousValues.dotprod(other.continuousValues)
             / numExamples;
         if (!std::isfinite(result))
-            throw ML::Exception("non-finite correlation");
+            throw MLDB::Exception("non-finite correlation");
         //cerr << "column " << columnName << " and " << other.columnName
         //     << " have correlation " << result << endl;
         return result;
@@ -424,7 +424,7 @@ struct ColumnIndexEntry: public ColumnSpec {
     int numExamples;
     int numExamplesWithColumn;
 
-    ML::distribution<float> continuousValues;
+    distribution<float> continuousValues;
     std::vector<std::pair<int, float> > sparseValues;
     SvdColumnEntry discreteValues;
 };

--- a/plugins/melt_procedure.cc
+++ b/plugins/melt_procedure.cc
@@ -36,7 +36,7 @@ struct MeltFixSelect
     {
         if (!containsNamedSubSelect(query, "to_melt") ||
             !containsNamedSubSelect(query, "to_fix") )
-            throw ML::Exception("%s procedure expect a rows named 'to_melt' and 'to_fix'", name.c_str());
+            throw MLDB::Exception("%s procedure expect a rows named 'to_melt' and 'to_fix'", name.c_str());
     }
 };
 
@@ -130,7 +130,7 @@ run(const ProcedureRunConfig & run,
     }
 
     if(!outputDataset) {
-        throw ML::Exception("Unable to obtain output dataset");
+        throw MLDB::Exception("Unable to obtain output dataset");
     }
 
 

--- a/plugins/metric_space.cc
+++ b/plugins/metric_space.cc
@@ -64,7 +64,7 @@ create(MetricSpace space)
 
 void
 EuclideanDistanceMetric::
-addRow(int rowNum, const ML::distribution<float> & coords)
+addRow(int rowNum, const distribution<float> & coords)
 {
     //cerr << "addRow " << rowNum << endl;
     ExcAssertEqual(rowNum, sum_dist.size());
@@ -74,8 +74,8 @@ addRow(int rowNum, const ML::distribution<float> & coords)
 
 float
 EuclideanDistanceMetric::
-calc(const ML::distribution<float> & coords1,
-     const ML::distribution<float> & coords2)
+calc(const distribution<float> & coords1,
+     const distribution<float> & coords2)
 {
     return sqrt(ML::SIMD::vec_euclid(coords1.data(), coords2.data(), coords1.size()));
     return (coords2 - coords1).two_norm();
@@ -84,8 +84,8 @@ calc(const ML::distribution<float> & coords1,
 float
 EuclideanDistanceMetric::
 dist(int rowNum1, int rowNum2,
-     const ML::distribution<float> & coords1,
-     const ML::distribution<float> & coords2) const
+     const distribution<float> & coords1,
+     const distribution<float> & coords2) const
 {
     ExcAssertEqual(coords1.size(), coords2.size());
 
@@ -138,7 +138,7 @@ dist(int rowNum1, int rowNum2,
 
 void
 CosineDistanceMetric::
-addRow(int rowNum, const ML::distribution<float> & coords)
+addRow(int rowNum, const distribution<float> & coords)
 {
     ExcAssertEqual(rowNum, two_norm_recip.size());
     float twonorm = coords.two_norm();
@@ -172,8 +172,8 @@ addRow(int rowNum, const ML::distribution<float> & coords)
 
 float
 CosineDistanceMetric::
-calc(const ML::distribution<float> & coords1,
-     const ML::distribution<float> & coords2)
+calc(const distribution<float> & coords1,
+     const distribution<float> & coords2)
 {
     if ((coords1 == coords2).all())
         return 0.0;
@@ -202,8 +202,8 @@ calc(const ML::distribution<float> & coords1,
 float
 CosineDistanceMetric::
 dist(int rowNum1, int rowNum2,
-     const ML::distribution<float> & coords1,
-     const ML::distribution<float> & coords2) const
+     const distribution<float> & coords1,
+     const distribution<float> & coords2) const
 {
     ExcAssertEqual(coords1.size(), coords2.size());
 

--- a/plugins/metric_space.h
+++ b/plugins/metric_space.h
@@ -34,15 +34,15 @@ struct DistanceMetric {
     }
 
     /** Add a row, caching information about it. */
-    virtual void addRow(int rowNum, const ML::distribution<float> & coords) = 0;
+    virtual void addRow(int rowNum, const distribution<float> & coords) = 0;
 
     /** Calculate the distance between two rows.  If either of them have
         a known number, it is passed in rowNum, otherwise that rowNum
         will be -1.
     */
     virtual float dist(int rowNum1, int rowNum2,
-                       const ML::distribution<float> & coords1,
-                       const ML::distribution<float> & coords2) const = 0;
+                       const distribution<float> & coords1,
+                       const distribution<float> & coords2) const = 0;
 
     /** Factor for distance metric objects. */
     static DistanceMetric * create(MetricSpace space);
@@ -55,19 +55,19 @@ struct DistanceMetric {
 
 struct EuclideanDistanceMetric: public DistanceMetric {
 
-    void addRow(int rowNum, const ML::distribution<float> & coords);
+    void addRow(int rowNum, const distribution<float> & coords);
 
     float dist(int rowNum1, int rowNum2,
-               const ML::distribution<float> & coords1,
-               const ML::distribution<float> & coords2) const;
+               const distribution<float> & coords1,
+               const distribution<float> & coords2) const;
 
     /// Pre cached ||vec||^2 for each row, to allow optimization of the
     /// calculation.
     std::vector<double> sum_dist;
 
     /// Static method to perform the calculation, with no caching
-    static float calc(const ML::distribution<float> & coords1,
-                      const ML::distribution<float> & coords2);
+    static float calc(const distribution<float> & coords1,
+                      const distribution<float> & coords2);
 };
 
 
@@ -77,19 +77,19 @@ struct EuclideanDistanceMetric: public DistanceMetric {
 
 struct CosineDistanceMetric: public DistanceMetric {
 
-    void addRow(int rowNum, const ML::distribution<float> & coords);
+    void addRow(int rowNum, const distribution<float> & coords);
 
     float dist(int rowNum1, int rowNum2,
-               const ML::distribution<float> & coords1,
-               const ML::distribution<float> & coords2) const;
+               const distribution<float> & coords1,
+               const distribution<float> & coords2) const;
 
     /// Pre-cached reciprocal of the two norm of each vector, to allow
     /// optimization of the calculation.
     std::vector<double> two_norm_recip;
     
     /// Static method to perform the calculation, with no caching
-    static float calc(const ML::distribution<float> & coords1,
-                      const ML::distribution<float> & coords2);
+    static float calc(const distribution<float> & coords1,
+                      const distribution<float> & coords2);
 };
 
 

--- a/plugins/nlp.cc
+++ b/plugins/nlp.cc
@@ -65,7 +65,7 @@ ApplyStopWordsFunction(MldbServer * owner,
 
     auto it = stopwords.find(functionConfig.language);
     if(it == stopwords.end())
-        throw ML::Exception("Unsupported language: " + functionConfig.language);
+        throw MLDB::Exception("Unsupported language: " + functionConfig.language);
 
     selected_stopwords = &(it->second);
 }
@@ -135,7 +135,7 @@ StemmerFunction(MldbServer * owner,
     std::unique_ptr<sb_stemmer> stemmer(sb_stemmer_new(functionConfig.language.c_str(), "UTF_8"));
 
     if (!stemmer) {
-        throw ML::Exception(ML::format("language `%s' not available for stemming in "
+        throw MLDB::Exception(MLDB::format("language `%s' not available for stemming in "
                 "encoding `%s'", functionConfig.language, "utf8"));
     }
 }
@@ -162,7 +162,7 @@ call(Words input) const
                     (const unsigned char*)str.c_str(), str.size());
 
             if (stemmed == nullptr) {
-                throw ML::Exception("Out of memory when stemming");
+                throw MLDB::Exception("Out of memory when stemming");
             }
 
             // Cast the cell value as a double before we accumulate them
@@ -224,7 +224,7 @@ StemmerOnDocumentFunction(MldbServer * owner,
     std::unique_ptr<sb_stemmer> stemmer(sb_stemmer_new(functionConfig.language.c_str(), "UTF_8"));
 
     if (!stemmer) {
-        throw ML::Exception(ML::format("language `%s' not available for stemming in "
+        throw MLDB::Exception(MLDB::format("language `%s' not available for stemming in "
                 "encoding `%s'", functionConfig.language, "utf8"));
     }
 }
@@ -248,7 +248,7 @@ call(Document doc) const
                     (const unsigned char*)str.c_str(), str.size());
 
         if (stemmed == NULL) {
-            throw ML::Exception("Out of memory when stemming");
+            throw MLDB::Exception("Out of memory when stemming");
         }
 
         Utf8String out((const char*)stemmed);
@@ -262,7 +262,7 @@ call(Document doc) const
     };
 
     Utf8String text = doc.document.toUtf8String();
-    ML::Parse_Context pcontext(text.rawData(), text.rawData(), text.rawLength());
+    ParseContext pcontext(text.rawData(), text.rawData(), text.rawLength());
 
     tokenize_exec(onGram, pcontext, " ", "", 0);
 

--- a/plugins/permuter_procedure.cc
+++ b/plugins/permuter_procedure.cc
@@ -83,7 +83,7 @@ forEachPermutation(
                 flatten(js[key], newPath);
             }
             else {
-               throw ML::Exception("unsupported type!");
+               throw MLDB::Exception("unsupported type!");
             }
         }
     };
@@ -131,7 +131,7 @@ forEachPermutation(
             }
         }
         else {
-            throw ML::Exception("Invalid data type for permutation");
+            throw MLDB::Exception("Invalid data type for permutation");
         }
     };
 
@@ -161,12 +161,12 @@ run(const ProcedureRunConfig & run,
         // to string to do a replace_all to catch all the $permutation to replace
         // and then parsing that back to json...
         string strConf = permutedConfTmp.toString();
-        ML::replace_all(strConf, "$permutation", ML::format("permutation_%d", permutation_num));
+        ML::replace_all(strConf, "$permutation", MLDB::format("permutation_%d", permutation_num));
 
         Json::Value permutedConf;
         Json::Reader reader;
         if(!reader.parse(strConf, permutedConf))
-            throw ML::Exception("unable to reparse!");
+            throw MLDB::Exception("unable to reparse!");
 
 
 

--- a/plugins/pooling_function.cc
+++ b/plugins/pooling_function.cc
@@ -79,12 +79,12 @@ PoolingFunction(MldbServer * owner,
     string select_expr;
     for(auto agg : functionConfig.aggregators) {
         if(validAggs.find(agg) == validAggs.end())
-            throw ML::Exception("Unknown aggregator: " + agg.rawString());
+            throw MLDB::Exception("Unknown aggregator: " + agg.rawString());
 
         if(select_expr.size() > 0)
             select_expr += ",";
 
-        select_expr += ML::format("%s({*}) as %s", agg.rawData(), agg.rawData());
+        select_expr += MLDB::format("%s({*}) as %s", agg.rawData(), agg.rawData());
     }
     fnConfig.query.stm->select = SelectExpression::parseList(select_expr);
     fnConfig.query.stm->from = functionConfig.embeddingDataset;
@@ -148,7 +148,7 @@ applyT(const ApplierT & applier_, PoolingInput input) const
                                           "aggregator", agg);
             }
 
-            ML::distribution<double> dist
+            distribution<double> dist
                 = val.getEmbedding(columnNames.data(), columnNames.size());
             outputEmbedding.insert(outputEmbedding.end(),
                                    dist.begin(), dist.end());

--- a/plugins/probabilizer.cc
+++ b/plugins/probabilizer.cc
@@ -90,7 +90,7 @@ ProbabilizerConfigDescription()
 struct ProbabilizerRepr {
     std::string style;
     ML::Link_Function link;
-    ML::distribution<double> params;
+    distribution<double> params;
 };
 
 DEFINE_STRUCTURE_DESCRIPTION(ProbabilizerRepr);
@@ -199,8 +199,8 @@ run(const ProcedureRunConfig & run,
     /* Convert to the correct data structures. */
 
     boost::multi_array<double, 2> outputs(boost::extents[2][nx]);  // value, bias
-    ML::distribution<double> correct(nx, 0.0);
-    ML::distribution<double> weights(nx, 1.0);
+    distribution<double> correct(nx, 0.0);
+    distribution<double> weights(nx, 1.0);
 
     size_t numTrue = 0;
 
@@ -222,7 +222,7 @@ run(const ProcedureRunConfig & run,
     filter_ostream out("prob-in.txt");
 
     for (unsigned i = 0;  i < nx;  ++i) {
-        out << ML::format("%.15f %.16f %d\n",
+        out << MLDB::format("%.15f %.16f %d\n",
                           outputs[0][i],
                           outputs[1][i],
                           correct[i]);
@@ -246,7 +246,7 @@ run(const ProcedureRunConfig & run,
     auto link = runProcConf.link;
 
     ML::Ridge_Regressor regressor;
-    ML::distribution<double> probParams
+    distribution<double> probParams
         = ML::run_irls(correct, outputs, weights, link, regressor);
 
     cerr << "probParams = " << probParams << endl;

--- a/plugins/progress.cc
+++ b/plugins/progress.cc
@@ -20,7 +20,7 @@ nextStep(float endValue) {
     value = endValue;
     auto nextStep = _nextStep.lock();
     if (!nextStep) {
-        throw ML::Exception("No next step!");
+        throw MLDB::Exception("No next step!");
     }
     nextStep->started = Date::now();
     return nextStep;

--- a/plugins/randomforest_procedure.cc
+++ b/plugins/randomforest_procedure.cc
@@ -129,11 +129,11 @@ run(const ProcedureRunConfig & run,
     RandomForestProcedureConfig runProcConf =
         applyRunConfOverProcConf(procedureConfig, run);
 
-    ML::Timer timer;
+    Timer timer;
 
     // this includes being empty
     if(!runProcConf.modelFileUrl.valid()) {
-         throw ML::Exception("modelFileUrl is not valid");
+         throw MLDB::Exception("modelFileUrl is not valid");
     }
 
     checkWritability(runProcConf.modelFileUrl.toDecodedString(),
@@ -170,7 +170,7 @@ run(const ProcedureRunConfig & run,
     cerr << "label uses columns " << jsonEncode(colScope.requiredColumns)
          << endl;
 
-    ML::Timer labelsTimer;
+    Timer labelsTimer;
 
     std::vector<CellValue> labels(std::move(colScope.run({boundLabel})[0]));
 
@@ -241,7 +241,7 @@ run(const ProcedureRunConfig & run,
 
     auto doFeatureVectorSampling = [&] (int bag)
         {
-            ML::Timer bagTimer;
+            Timer bagTimer;
 
             boost::mt19937 rng(bag + 245);
             distribution<float> in_training(numRows);
@@ -280,7 +280,7 @@ run(const ProcedureRunConfig & run,
                         mydata.features[i].active = false;
                 }
 
-                ML::Timer timer;
+                Timer timer;
                 ML::Tree tree;
                 tree.root = mydata.train(0 /* depth */, runProcConf.maxDepth, tree);
                 cerr << "bag " << bag << " partition " << partitionNum << " took "

--- a/plugins/script_function.cc
+++ b/plugins/script_function.cc
@@ -55,7 +55,7 @@ ScriptFunction(MldbServer * owner,
         case PYTHON:        runner = "python";      break;
         case JAVASCRIPT:    runner = "javascript";  break;
         default:
-            throw ML::Exception("unknown script language");
+            throw MLDB::Exception("unknown script language");
     }
 
     LoadedPluginResource loadedResource(parseScriptLanguage(functionConfig.language),
@@ -111,12 +111,12 @@ apply(const FunctionApplier & applier,
     
     vector<tuple<PathElement, ExpressionValue>> vals;
     if(!result.isArray()) {
-        throw ML::Exception("Function should return array of arrays.");
+        throw MLDB::Exception("Function should return array of arrays.");
     }
 
     for(const Json::Value & elem : result) {
         if(!elem.isArray() || elem.size() != 3)
-            throw ML::Exception("elem should be array of size 3");
+            throw MLDB::Exception("elem should be array of size 3");
 
         vals.push_back(make_tuple(PathElement(elem[0].asString()),
                                   ExpressionValue(elem[1],

--- a/plugins/script_procedure.cc
+++ b/plugins/script_procedure.cc
@@ -71,7 +71,7 @@ run(const ProcedureRunConfig & run,
         case PYTHON:        runner = "python";      break;
         case JAVASCRIPT:    runner = "javascript";  break;
         default:
-            throw ML::Exception("unknown script language");
+            throw MLDB::Exception("unknown script language");
     }
 
     string resource = "/v1/types/plugins/" + runner + "/routes/run";

--- a/plugins/sparse_matrix_dataset.cc
+++ b/plugins/sparse_matrix_dataset.cc
@@ -263,7 +263,7 @@ struct SparseMatrixDataset::Itl
     void optimize()
     {
         //cerr << "optimize() on MutableSparseMatrixDataset" << endl;
-        //ML::Timer timer;
+        //Timer timer;
 
         std::unique_lock<RootLock> guard(rootLock);
         // We don't increment the epoch since logically it's exactly the same
@@ -1336,7 +1336,7 @@ struct MutableBaseData {
         // Only one balancing at a time
         std::unique_lock<std::mutex> guard(this->mutex);
 
-        ML::Timer timer;
+        Timer timer;
 
         // Get a reference to the data
         auto r = this->repr.load();

--- a/plugins/sql.cc
+++ b/plugins/sql.cc
@@ -59,7 +59,7 @@ Json::Value toJson(sqlite3_value * arg)
     case SQLITE_BLOB:
         return "<<BLOB>>";
     default:
-        throw ML::Exception("Unknown type for column");
+        throw MLDB::Exception("Unknown type for column");
     }
 }
 
@@ -78,13 +78,13 @@ CellValue toCell(sqlite3_value * arg)
         return string(bytes, bytes + len);
     }
     default:
-        throw ML::Exception("Unknown type for column");
+        throw MLDB::Exception("Unknown type for column");
     }
 }
 
 void dumpQueryArray(sqlite3pp::database & db, const std::string & queryStr)
 {
-    ML::Timer timer;
+    Timer timer;
     cerr << "dumping query " << queryStr << endl;
 
     sqlite3pp::query query(db, queryStr.c_str());
@@ -114,7 +114,7 @@ void dumpQueryArray(sqlite3pp::database & db, const std::string & queryStr)
                 record[j] = "<<BLOB>>";
                 break;
             default:
-                throw ML::Exception("Unknown type for column");
+                throw MLDB::Exception("Unknown type for column");
             }
         }
         
@@ -137,7 +137,7 @@ std::string sqlEscape(const std::string & val)
         if (c == '\'')
             ++numQuotes;
         if (c < ' ' || c >= 127)
-            throw ML::Exception("Non ASCII character in DB");
+            throw MLDB::Exception("Non ASCII character in DB");
     }
     if (numQuotes == 0)
         return val;
@@ -308,7 +308,7 @@ struct BehaviourModule {
             case SQLITE_INDEX_CONSTRAINT_MATCH:
                 constraintStr = "MATCHES";  break;
             default:
-                throw ML::Exception("unknown constraint type");
+                throw MLDB::Exception("unknown constraint type");
             }
 
             cerr << "constraintStr = " << constraintStr << endl;
@@ -417,7 +417,7 @@ struct BehaviourModule {
             knownValues[colName] = arg;
 
             if (op != "==")
-                throw ML::Exception("non-equality not implemented");
+                throw MLDB::Exception("non-equality not implemented");
 
             cerr << "Filtering on " << colName << " " << op << " " << arg
                  << endl;
@@ -517,7 +517,7 @@ struct BehaviourModule {
             case CellValue::UTF8_STRING:
                 return sqlite3_result_result_utf8(context, value.toUtf8String());
             default:
-                throw ML::Exception("unknown cell type");
+                throw MLDB::Exception("unknown cell type");
             }
         }
         }

--- a/plugins/sql_config_validator.h
+++ b/plugins/sql_config_validator.h
@@ -67,10 +67,10 @@ struct NoGroupByHaving
     {
         if (query.stm) {
             if (!query.stm->groupBy.empty()) {
-                throw ML::Exception(name + " does not support groupBy clause");
+                throw MLDB::Exception(name + " does not support groupBy clause");
             }
             else if (!query.stm->having->isConstantTrue()) {
-                throw ML::Exception(name + " does not support having clause");
+                throw MLDB::Exception(name + " does not support having clause");
             }
         }
     }
@@ -91,7 +91,7 @@ struct NoWhere
     {
         if (query.stm) {
             if (!query.stm->where->isConstantTrue()) {
-                throw ML::Exception(name + " does not support where");
+                throw MLDB::Exception(name + " does not support where");
             }
         }
     }
@@ -113,7 +113,7 @@ struct NoLimit
     {
         if (query.stm) {
             if (query.stm->limit != -1) {
-                throw ML::Exception(name + " does not support limit");
+                throw MLDB::Exception(name + " does not support limit");
             }
         }
     }
@@ -135,7 +135,7 @@ struct NoOffset
     {
         if (query.stm) {
             if (query.stm->offset > 0) {
-                throw ML::Exception(name + " does not support offset");
+                throw MLDB::Exception(name + " does not support offset");
             }
         }
     }
@@ -155,7 +155,7 @@ struct MustContainFrom
     void operator()(const InputQuery & query, const std::string & name) const
     {
         if (!query.stm || !query.stm->from || query.stm->from->surface.empty())
-            throw ML::Exception(name + " must contain a FROM clause");
+            throw MLDB::Exception(name + " must contain a FROM clause");
     }
 
     void operator()(const Optional<InputQuery> & query, const std::string & name) const
@@ -292,7 +292,7 @@ struct PlainColumnSelect
                     continue;
             }
 
-            throw ML::Exception(name +
+            throw MLDB::Exception(name +
                                 " only accepts wildcard and column names at " +
                                 clause->surface.rawString());
         }
@@ -336,7 +336,7 @@ struct FeaturesLabelSelect
     {
         if (!containsNamedSubSelect(query, "features") ||
             !containsNamedSubSelect(query, "label") )
-            throw ML::Exception(name + " expects a row named 'features' and a scalar named 'label'");
+            throw MLDB::Exception(name + " expects a row named 'features' and a scalar named 'label'");
     }
 
     void operator()(const Optional<InputQuery> & query, const std::string & name) const
@@ -355,7 +355,7 @@ struct ScoreLabelSelect
     {
         if (!containsNamedSubSelect(query, "score") ||
             !containsNamedSubSelect(query, "label") )
-            throw ML::Exception(name + " expects a scalar named 'score' and a scalar named 'label'");
+            throw MLDB::Exception(name + " expects a scalar named 'score' and a scalar named 'label'");
     }
 };
 
@@ -370,7 +370,7 @@ validateFunction()
     return [](ConfigType * cfg, JsonParsingContext & context) {
         if (!cfg->functionName.empty() &&
             !cfg->modelFileUrl.valid()) {
-                throw ML::Exception(std::string(ConfigType::name) + " requires a valid "
+                throw MLDB::Exception(std::string(ConfigType::name) + " requires a valid "
                                     "modelFileUrl when specifying a functionName. "
                                     "modelFileUrl '" + cfg->modelFileUrl.toString()
                                     + "' is invalid.");

--- a/plugins/sqlite_dataset.cc
+++ b/plugins/sqlite_dataset.cc
@@ -60,7 +60,7 @@ std::string sqlEscape(const std::string & val)
         if (c == '\'')
             ++numQuotes;
         if (c < ' ' || c >= 127)
-            throw ML::Exception("Non ASCII character in DB");
+            throw MLDB::Exception("Non ASCII character in DB");
     }
     if (numQuotes == 0)
         return val;
@@ -84,10 +84,10 @@ struct Init {
     {
         int res = sqlite3_config(SQLITE_CONFIG_MULTITHREAD);
         if (res != SQLITE_OK)
-            throw ML::Exception("Configuring multi threaded: %d", res);
+            throw MLDB::Exception("Configuring multi threaded: %d", res);
         res = sqlite3_config(SQLITE_CONFIG_MEMSTATUS, 0);
         if (res != SQLITE_OK)
-            throw ML::Exception("Configuring no memory status: %d", res);
+            throw MLDB::Exception("Configuring no memory status: %d", res);
     }
 } init;
 
@@ -607,7 +607,7 @@ struct SqliteSparseDataset::Itl
             {
                 int res = db->execute(command.c_str());
                 if (res != SQLITE_OK) {
-                    throw ML::Exception("Error setting up database: executing %s: %s",
+                    throw MLDB::Exception("Error setting up database: executing %s: %s",
                                         command.c_str(), db->error_msg());
                 }
             };
@@ -642,8 +642,8 @@ struct SqliteSparseDataset::Itl
     }
 
     // Protected by the write lock
-    ML::Lightweight_Hash<RowHash, int> rowNumCache;
-    ML::Lightweight_Hash<ColumnHash, int> colNumCache;
+    Lightweight_Hash<RowHash, int> rowNumCache;
+    Lightweight_Hash<ColumnHash, int> colNumCache;
 
     // Unfortunately...
     mutable std::mutex writeLock;
@@ -668,7 +668,7 @@ struct SqliteSparseDataset::Itl
             {
                 int res = connection.execute(command.c_str());
                 if (res != SQLITE_OK) {
-                    throw ML::Exception("Error setting up connection: executing %s: %s",
+                    throw MLDB::Exception("Error setting up connection: executing %s: %s",
                                         command.c_str(), connection.error_msg());
                 }
             };

--- a/plugins/stats_table_procedure.cc
+++ b/plugins/stats_table_procedure.cc
@@ -137,7 +137,7 @@ reconstitute(ML::DB::Store_Reader & store)
                                   "table model");
     }
     if(version!=REQUIRED_V) {
-        throw HttpReturnException(400, ML::format(
+        throw HttpReturnException(400, MLDB::format(
                     "invalid StatsTable version! exptected %d, got %d",
                     REQUIRED_V, version));
     }
@@ -253,7 +253,7 @@ run(const ProcedureRunConfig & run,
             MatrixNamedRow row = row_.flattenDestructive();
             if(num_req++ % 5000 == 0) {
                 double secs = Date::now().secondsSinceEpoch() - start.secondsSinceEpoch();
-                string message = ML::format("done %d. %0.4f/sec", num_req, num_req / secs);
+                string message = MLDB::format("done %d. %0.4f/sec", num_req, num_req / secs);
                 Json::Value progress;
                 progress["message"] = message;
                 onProgress(progress);
@@ -661,7 +661,7 @@ run(const ProcedureRunConfig & run,
         applyRunConfOverProcConf(procConfig, run);
 
     if(!runProcConf.functionName.empty() && runProcConf.functionOutcomeToUse.empty()) {
-        throw ML::Exception("The 'functionOutcomeToUse' parameter must be set when the "
+        throw MLDB::Exception("The 'functionOutcomeToUse' parameter must be set when the "
                 "'functionName' parameter is set.");
     }
 
@@ -690,7 +690,7 @@ run(const ProcedureRunConfig & run,
             MatrixNamedRow row = row_.flattenDestructive();
             if(num_req++ % 10000 == 0) {
                 double secs = Date::now().secondsSinceEpoch() - start.secondsSinceEpoch();
-                string message = ML::format("done %d. %0.4f/sec", num_req, num_req / secs);
+                string message = MLDB::format("done %d. %0.4f/sec", num_req, num_req / secs);
                 Json::Value progress;
                 progress["message"] = message;
                 onProgress2(progress);

--- a/plugins/summary_statistics_proc.cc
+++ b/plugins/summary_statistics_proc.cc
@@ -69,13 +69,13 @@ SummaryStatisticsProcedureConfigDescription()
             auto expr = dynamic_cast<NamedColumnExpression *>(clause.get());
             if (expr == nullptr) {
                 DEBUG_MSG(logger) << "Failed to cast " << clause->surface;
-                throw ML::Exception("%s is not a supported SELECT value "
+                throw MLDB::Exception("%s is not a supported SELECT value "
                                     "expression for summary.statistics",
                                     clause->surface.rawData());
             }
             if (expr->alias.empty()) {
                 DEBUG_MSG(logger) << "Empty alias " << clause->surface;
-                throw ML::Exception("%s is not a supported SELECT value "
+                throw MLDB::Exception("%s is not a supported SELECT value "
                                     "expression for summary.statistics",
                                     clause->surface.rawData());
             }
@@ -84,10 +84,10 @@ SummaryStatisticsProcedureConfigDescription()
                     "sum(" + expr->getChildren()[0]->surface + ") AS "
                     + expr->alias.toSimpleName());
             }
-            catch (const ML::Exception & exc) {
+            catch (const MLDB::Exception & exc) {
                 DEBUG_MSG(logger) << "Failed to parse within sum "
                                 << clause->surface;
-                throw ML::Exception("%s is not a supported SELECT value "
+                throw MLDB::Exception("%s is not a supported SELECT value "
                                     "expression for summary.statistics",
                                     clause->surface.rawData());
             }
@@ -240,7 +240,7 @@ struct NumericRowHandler {
                          -1, // limit
                          onProgress);
         }
-        catch (const ML::Exception & exc) {
+        catch (const MLDB::Exception & exc) {
             if (!isNumeric) {
                 // Categorical, the query doesn't work
                 return false;

--- a/plugins/svd.cc
+++ b/plugins/svd.cc
@@ -131,13 +131,13 @@ SvdColumnIndexEntryDescription()
 }
 
 /** Given the other column, project it onto the basis. */
-ML::distribution<float>
+distribution<float>
 SvdBasis::
 rightSingularVector(const ColumnIndexEntries & basisColumns,
                     const ColumnIndexEntry & column) const
 {
     // For each basis vector, calculate the overlap
-    ML::distribution<float> result(singularValues.size());
+    distribution<float> result(singularValues.size());
 
     for (unsigned i = 0;  i < columns.size();  ++i) {
         double overlap = column.correlation(basisColumns.at(i));
@@ -163,7 +163,7 @@ rightSingularVector(const ColumnIndexEntries & basisColumns,
     return result;
 }
 
-ML::distribution<float>
+distribution<float>
 SvdBasis::
 rightSingularVectorForColumn(ColumnHash col, const CellValue & value,
                              int maxValues,
@@ -176,7 +176,7 @@ rightSingularVectorForColumn(ColumnHash col, const CellValue & value,
     auto it = columnIndex.find(col);
     if (it == columnIndex.end()) {
         //cerr << "column not found in " << columnIndex.size() << " entries" << endl;
-        return ML::distribution<float>();
+        return distribution<float>();
     }
 
     // 2.  Look up the value of the cell
@@ -199,7 +199,7 @@ rightSingularVectorForColumn(ColumnHash col, const CellValue & value,
                     continue;
                 int columnNum = e.second;
                 auto & col = columns[columnNum];
-                ML::distribution<float> result = col.singularVector;
+                distribution<float> result = col.singularVector;
                 result.resize(maxValues);
 
                 //double oldd = d;
@@ -222,7 +222,7 @@ rightSingularVectorForColumn(ColumnHash col, const CellValue & value,
 
                 auto & col = columns[columnEntry.values.begin()->second];
 
-                ML::distribution<float> result = col.singularVector;
+                distribution<float> result = col.singularVector;
                 result.resize(maxValues);
 
                 //double oldd = d;
@@ -240,7 +240,7 @@ rightSingularVectorForColumn(ColumnHash col, const CellValue & value,
             // It's a value we haven't seen.  We can't really do anything but return
             // an empty vector
             if (acceptUnknownValues)
-                return ML::distribution<float>();
+                return distribution<float>();
 
             throw HttpReturnException(400);
 
@@ -251,12 +251,12 @@ rightSingularVectorForColumn(ColumnHash col, const CellValue & value,
                 cerr << "known value " << e.first << endl;
             }
 
-            throw ML::Exception("Numeric value not found");
+            throw MLDB::Exception("Numeric value not found");
 #endif
         }
 
         if (acceptUnknownValues)
-            return ML::distribution<float>();
+            return distribution<float>();
 
         Json::Value details;
         details["columnName"] = jsonEncode(it->second.columnName);
@@ -309,12 +309,12 @@ rightSingularVectorForColumn(ColumnHash col, const CellValue & value,
         throw HttpReturnException(400, message, details);
     }
 
-    ML::distribution<float> result = columns[it2->second].singularVector;
+    distribution<float> result = columns[it2->second].singularVector;
     result.resize(maxValues);
     return result;
 }
 
-std::pair<ML::distribution<float>, Date>
+std::pair<distribution<float>, Date>
 SvdBasis::
 leftSingularVector(const std::vector<std::tuple<ColumnPath, CellValue, Date> > & row,
                    int maxValues,
@@ -323,7 +323,7 @@ leftSingularVector(const std::vector<std::tuple<ColumnPath, CellValue, Date> > &
     return doLeftSingularVector(row, maxValues, acceptUnknownValues);
 }
 
-std::pair<ML::distribution<float>, Date>
+std::pair<distribution<float>, Date>
 SvdBasis::
 leftSingularVector(const std::vector<std::tuple<ColumnHash, CellValue, Date> > & row,
                    int maxValues,
@@ -333,7 +333,7 @@ leftSingularVector(const std::vector<std::tuple<ColumnHash, CellValue, Date> > &
 }
 
 template<typename Tuple>
-std::pair<ML::distribution<float>, Date>
+std::pair<distribution<float>, Date>
 SvdBasis::
 doLeftSingularVector(const std::vector<Tuple> & row,
                      int maxValues,
@@ -343,7 +343,7 @@ doLeftSingularVector(const std::vector<Tuple> & row,
         maxValues = singularValues.size();
 
     Date ts = modelTs;
-    ML::distribution<float> result(maxValues);
+    distribution<float> result(maxValues);
 
     for (auto & v: row) {
         ColumnHash column;
@@ -352,7 +352,7 @@ doLeftSingularVector(const std::vector<Tuple> & row,
 
         std::tie(column, value, columnTs) = v;
 
-        const ML::distribution<float> & rsv
+        const distribution<float> & rsv
             = rightSingularVectorForColumn(column, value, maxValues, acceptUnknownValues);
 
         // If it was excluded, it will have an empty vector calculated
@@ -413,7 +413,7 @@ calcSvdBasis(const ColumnCorrelations & correlations,
     static int n = 0;
     {
         cerr << "saving correlations " << n << endl;
-        filter_ostream stream(ML::format("correlations-%d.json", n++));
+        filter_ostream stream(MLDB::format("correlations-%d.json", n++));
         stream << jsonEncode(correlations.columns);
         for (unsigned i = 0;  i < correlations.correlations.shape()[0];  ++i) {
             for (unsigned j = 0;  j < correlations.correlations.shape()[1];  ++j) {
@@ -427,7 +427,7 @@ calcSvdBasis(const ColumnCorrelations & correlations,
 
     int ndims = correlations.columnCount();
 
-    ML::Timer timer;
+    Timer timer;
 
     //for (unsigned i = 0;  i < ndims;  ++i) {
     //    cerr << "correlation between " << 0 << " and "
@@ -507,7 +507,7 @@ calcSvdBasis(const ColumnCorrelations & correlations,
     for (unsigned i = 0;  i < ndims;  ++i) {
         //cerr << "i = " << i << "svdResult->Vt->value[i] = "
         //     << svdResult->Vt->value[i] << endl;
-        ML::distribution<float> & d = result.columns[i].singularVector;
+        distribution<float> & d = result.columns[i].singularVector;
         d.resize(numSingularValues);
         for (unsigned j = 0;  j < numSingularValues;  ++j)
             d[j] = svdResult->Vt->value[j][i];
@@ -560,7 +560,7 @@ calcRightSingular(const ClassifiedColumns & columns,
     //cerr << "projecting " << columns.sparseColumns.size()
     //     << " discrete columns onto basis" << endl;
 
-    ML::Timer timer;
+    Timer timer;
 
     std::atomic<int> numDone(0);
     std::mutex doneMutex;
@@ -853,7 +853,7 @@ run(const ProcedureRunConfig & run,
 
                 auto row = dataset->getMatrixView()->getRow(rows[rowNum]);
 
-                ML::distribution<float> embedding;
+                distribution<float> embedding;
                 Date ts;
 
                 std::tie(embedding, ts)
@@ -920,7 +920,7 @@ run(const ProcedureRunConfig & run,
 
 
             // In goes the values
-            ML::distribution<double> accum(numSingularValues);
+            distribution<double> accum(numSingularValues);
 
             for (unsigned i = 0;  i < entry.values.size();  ++i) {
                 float v = (entry.values[i] - means[i]) / stddevs[i];
@@ -933,7 +933,7 @@ run(const ProcedureRunConfig & run,
     for (auto & s: features) {
         for (const ExtractedRow & entry: s.second) {
             // In goes the values
-            ML::distribution<double> accum(numSingularValues);
+            distribution<double> accum(numSingularValues);
 
             for (unsigned i = 0;  i < entry.values.size();  ++i) {
                 float v = (entry.values[i] - means[i]) / stddevs[i];
@@ -945,7 +945,7 @@ run(const ProcedureRunConfig & run,
                 //cerr << "dense " << behs.getBehaviourId(beh) << endl;
                 auto it = discreteIndex.find(beh);
                 if (it == discreteIndex.end())
-                    throw ML::Exception("couldn't find dense beh index");
+                    throw MLDB::Exception("couldn't find dense beh index");
                 accum += singularVectors[featureNum + it->second];
             }
 
@@ -959,7 +959,7 @@ run(const ProcedureRunConfig & run,
             // We now have an approximation to V in accum.  Take it back to
             // a feature vector
 
-            ML::distribution<double> reconst(featureNum);
+            distribution<double> reconst(featureNum);
 
             for (unsigned i = 0;  i < featureNum;  ++i) {
                 for (unsigned j = 0;  j < numSingularValues;  ++j) {
@@ -972,7 +972,7 @@ run(const ProcedureRunConfig & run,
             cerr << "input: " << entry.values << endl;
             cerr << "reconst: " << reconst << endl;
 
-            ML::distribution<double> reconstDense(numDenseColumns);
+            distribution<double> reconstDense(numDenseColumns);
 
             for (unsigned i = 0;  i < numDenseColumns;  ++i) {
                 for (unsigned j = 0;  j < numSingularValues;  ++j) {
@@ -1084,7 +1084,7 @@ call(SvdInput input) const
     RowValue row;
     input.row.mergeToRowDestructive(row);
     
-    ML::distribution<float> embedding;
+    distribution<float> embedding;
     Date ts;
 
     std::tie(embedding, ts)

--- a/plugins/svd.h
+++ b/plugins/svd.h
@@ -55,7 +55,7 @@ struct SimpleSvdColumnEntry: public ColumnSpec {
         return *this;
     }
 
-    ML::distribution<float> singularVector;
+    distribution<float> singularVector;
 };
 
 DECLARE_STRUCTURE_DESCRIPTION(SimpleSvdColumnEntry);
@@ -69,38 +69,38 @@ DECLARE_STRUCTURE_DESCRIPTION(SvdColumnIndexEntry);
 
 struct SvdBasis {
     std::vector<SimpleSvdColumnEntry> columns;
-    ML::distribution<float> singularValues;
+    distribution<float> singularValues;
     std::map<ColumnHash, SvdColumnIndexEntry> columnIndex;
     Date modelTs;   ///< Timestamp up to which model incorporates data from
 
     size_t numSingularValues() const { return singularValues.size(); }
 
     /** Given the other column, project it onto the basis. */
-    ML::distribution<float>
+    distribution<float>
     rightSingularVector(const ColumnIndexEntries & basisColumns,
                         const ColumnIndexEntry & column) const;
 
     /** Given a particular column and its value, calculate the right
         singular value for that column.
     */
-    ML::distribution<float>
+    distribution<float>
     rightSingularVectorForColumn(ColumnHash col, const CellValue & value,
                                  int maxValues,
                                  bool acceptUnknownValues) const;
 
     /** Given the row, calculate its embedding. */
-    std::pair<ML::distribution<float>, Date>
+    std::pair<distribution<float>, Date>
     leftSingularVector(const std::vector<std::tuple<ColumnHash, CellValue, Date> > & row,
                        int maxValues,
                        bool acceptUnknownValues) const;
 
-    std::pair<ML::distribution<float>, Date>
+    std::pair<distribution<float>, Date>
     leftSingularVector(const std::vector<std::tuple<ColumnPath, CellValue, Date> > & row,
                        int maxValues,
                        bool acceptUnknownValues) const;
 
     template<typename Tuple>
-    std::pair<ML::distribution<float>, Date>
+    std::pair<distribution<float>, Date>
     doLeftSingularVector(const std::vector<Tuple> & row,
                          int maxValues,
                          bool acceptUnknownValues) const;

--- a/plugins/svm.cc
+++ b/plugins/svm.cc
@@ -330,7 +330,7 @@ run(const ProcedureRunConfig & run,
     auto model_tmp_name = plugin_working_dir.string() + std::string("svmmodeltemp_a.svm");
     try {
         if (svm_save_model(model_tmp_name.c_str(),model))
-            throw ML::Exception("");
+            throw MLDB::Exception("");
 
         makeUriDirectory(
             runProcConf.modelFileUrl.toDecodedString());

--- a/plugins/tabular_dataset.cc
+++ b/plugins/tabular_dataset.cc
@@ -238,11 +238,11 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
     int64_t rowCount;
 
     /// This indexes column names to their index, using new (fast) hash
-    ML::Lightweight_Hash<uint64_t, int> columnIndex;
+    Lightweight_Hash<uint64_t, int> columnIndex;
 
     /// Same index, but using the old (slow) hash.  Useful only for when
     /// we are forced to lookup on ColumnHash.
-    ML::Lightweight_Hash<ColumnHash, int> columnHashIndex;
+    Lightweight_Hash<ColumnHash, int> columnHashIndex;
 
     struct ColumnEntry {
         ColumnEntry()
@@ -267,7 +267,7 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
     std::vector<ColumnPath> fixedColumns;
 
     /// Index of just the fixed columns
-    ML::Lightweight_Hash<uint64_t, int> fixedColumnIndex;
+    Lightweight_Hash<uint64_t, int> fixedColumnIndex;
 
     /// List of all chunks in the dataset
     std::vector<TabularDatasetChunk> chunks;
@@ -342,7 +342,7 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
 
     /// Index from rowHash to (chunk, indexInChunk) when line number not used for rowName
     static constexpr size_t ROW_INDEX_SHARDS=32;
-    ML::Lightweight_Hash<RowHash, std::pair<int, int> > rowIndex
+    Lightweight_Hash<RowHash, std::pair<int, int> > rowIndex
         [ROW_INDEX_SHARDS];
     std::string filename;
     Date earliestTs, latestTs;
@@ -753,7 +753,7 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
 
         std::mutex rowIndexLock[ROW_INDEX_SHARDS];
 
-        ML::Timer rowIndexTimer;
+        Timer rowIndexTimer;
 
         auto indexChunk = [&] (int chunkNum)
             {
@@ -1207,7 +1207,7 @@ struct TabularDataset::TabularDataStore: public ColumnIndex, public MatrixView {
             vector<ColumnPath> columnNames;
 
             //The first recorded row will determine the columns
-            ML::Lightweight_Hash<uint64_t, int> inputColumnIndex;
+            Lightweight_Hash<uint64_t, int> inputColumnIndex;
             for (unsigned i = 0;  i < vals.size();  ++i) {
                 const ColumnPath & c = std::get<0>(vals[i]);
                 uint64_t ch(c.newHash());

--- a/plugins/tabular_dataset_column.h
+++ b/plugins/tabular_dataset_column.h
@@ -49,7 +49,7 @@ struct TabularDatasetColumn {
     void reserve(size_t sz);
 
     std::vector<CellValue> indexedVals;
-    ML::Lightweight_Hash<uint64_t, int> valueIndex;
+    Lightweight_Hash<uint64_t, int> valueIndex;
     CellValue lastValue;
     std::vector<std::pair<uint32_t, int> > sparseIndexes;
     int64_t minRowNumber;  ///< Including null values not in sparseIndexes

--- a/plugins/tfidf.cc
+++ b/plugins/tfidf.cc
@@ -54,12 +54,12 @@ reconstitute(ML::DB::Store_Reader & store,
     std::string name;
     store >> name;
     if (name != "tfidf")
-        throw ML::Exception("invalid name when loading a tf-idf object");
+        throw MLDB::Exception("invalid name when loading a tf-idf object");
 
     int version;
     store >> version;
     if (version != 0)
-        throw ML::Exception("invalid tf-idf version");
+        throw MLDB::Exception("invalid tf-idf version");
 
     uint64_t termCount = 0;
 
@@ -295,7 +295,7 @@ TfidfFunctionConfigDescription()
                          JsonParsingContext & context) {
         // this includes empty url
         if(!cfg->modelFileUrl.valid()) {
-            throw ML::Exception("modelFileUrl \"" + cfg->modelFileUrl.toString()
+            throw MLDB::Exception("modelFileUrl \"" + cfg->modelFileUrl.toString()
                                 + "\" is not valid");
         }
     };

--- a/plugins/tsne.cc
+++ b/plugins/tsne.cc
@@ -173,10 +173,10 @@ struct TsneItl {
         string tag;
         store >> tag;
         if (tag != "TSNE")
-            throw ML::Exception("Expected TSNE tag");
+            throw MLDB::Exception("Expected TSNE tag");
         compact_size_t version(store);
         if (version != 2)
-            throw ML::Exception("Unknown version for t-SNE");
+            throw MLDB::Exception("Unknown version for t-SNE");
 
         compact_size_t rows(store), dimsIn(store), dimsOut(store);
 
@@ -190,7 +190,7 @@ struct TsneItl {
         qtree.reset(new ML::Quadtree(store));
     }
 
-    ML::distribution<float> reembed(const ML::distribution<float> & v) const
+    distribution<float> reembed(const distribution<float> & v) const
     {
         return retsneApproxFromCoords(v, inputPath, outputPath,
                                       *qtree, *vpTree, params);
@@ -326,7 +326,7 @@ run(const ProcedureRunConfig & run,
     else {
         names.clear();
         for (unsigned i = 0; i < runProcConf.numOutputDimensions;  ++i)
-            names.push_back(ColumnPath(ML::format("dim%04d", i)));
+            names.push_back(ColumnPath(MLDB::format("dim%04d", i)));
     }
 
 
@@ -433,7 +433,7 @@ call(TsneInput input) const
     ExpressionValue storage;
     const ExpressionValue & inputVal = context.get("embedding", storage);
 
-    ML::distribution<float> input = inputVal.getEmbedding(itl->inputColumnNames.size());
+    distribution<float> input = inputVal.getEmbedding(itl->inputColumnNames.size());
 
     Date ts = Date::negativeInfinity();
     auto embedding = itl->reembed(input);

--- a/plugins/word2vec.cc
+++ b/plugins/word2vec.cc
@@ -99,7 +99,7 @@ struct Word2VecImporter: public Procedure {
 
         vector<ColumnPath> columnNames;
         for (unsigned i = 0;  i < numDims;  ++i) {
-            columnNames.emplace_back(ML::format("%06d", i));
+            columnNames.emplace_back(MLDB::format("%06d", i));
         }
 
         vector<tuple<RowPath, vector<float>, Date> > rows;

--- a/plugins/xlsx_importer.cc
+++ b/plugins/xlsx_importer.cc
@@ -782,12 +782,12 @@ struct XlsxImporter: public Procedure {
 
             if (output && !sheet.rows.empty()) {
                 int maxRowIndex = sheet.rows.back().index;
-                int indexLength = ML::format("%d", maxRowIndex).length();
+                int indexLength = MLDB::format("%d", maxRowIndex).length();
 
                 for (auto & row: sheet.rows) {
                     MatrixNamedRow outputRow;
                     outputRow.rowHash = outputRow.rowName
-                        = RowPath(sheetEntry.name + ML::format(":%0*d", indexLength, row.index));
+                        = RowPath(sheetEntry.name + MLDB::format(":%0*d", indexLength, row.index));
 
                     for (auto & col: row.columns) {
                         outputRow.columns.emplace_back(getColName(std::get<0>(col)),

--- a/rest/asio_peer_connection.cc
+++ b/rest/asio_peer_connection.cc
@@ -316,7 +316,7 @@ onReadLengthDone(boost::system::error_code err, size_t bytesDone,
     if (bytesDone != 8) {
         // This is a logic error; it should never happen.  It's OK to
         // crash the world.
-        throw ML::Exception("wrong number of length bytes read in packet");
+        throw MLDB::Exception("wrong number of length bytes read in packet");
     }
 
     //cerr << "itl->currentPacketLength = " << itl->currentPacketLength << endl;

--- a/rest/asio_peer_server.cc
+++ b/rest/asio_peer_server.cc
@@ -46,11 +46,11 @@ int bindAndReturnOpenTcpPort(boost::asio::ip::tcp::acceptor & acceptor,
     
     if (port == -1)
         // Throw is OK: this will happen in a synchronous context.
-        throw ML::Exception("no open TCP port '%s': %s",
+        throw MLDB::Exception("no open TCP port '%s': %s",
                             uri.c_str(),
                             strerror(errno));
     
-    uri = ML::format("tcp://%s:%d", host.c_str(), port);
+    uri = MLDB::format("tcp://%s:%d", host.c_str(), port);
 
     return port;
 }
@@ -132,7 +132,7 @@ struct AsioPeerServer::Impl {
 
         if (error) {
             // Throw is OK: synchronous context
-            throw ML::Exception("error resolving peer name " + info.uri + ": "
+            throw MLDB::Exception("error resolving peer name " + info.uri + ": "
                                 + error.message());
         }
     
@@ -147,14 +147,14 @@ struct AsioPeerServer::Impl {
 
         if (error) {
             // Throw is OK: synchronous context
-            throw ML::Exception("error connecting to " + info.uri + ": "
+            throw MLDB::Exception("error connecting to " + info.uri + ": "
                                 + error.message());
         }
     
         cerr << "connected to " << info.uri << endl;
 
         // Send our handshake over the new connection
-        string handshake = "APSv1000" + ML::format("%8zd", info.peerName.size())
+        string handshake = "APSv1000" + MLDB::format("%8zd", info.peerName.size())
             + info.peerName;
         boost::asio::write(*sock, boost::asio::buffer(handshake));
 

--- a/rest/collection_config_store.cc
+++ b/rest/collection_config_store.cc
@@ -47,7 +47,7 @@ S3CollectionConfigStore::
 init(const std::string & baseUri)
 {
     if (baseUri.empty())
-        throw ML::Exception("can't do empty uri");
+        throw MLDB::Exception("can't do empty uri");
 
     // Strip off a trailing slash
     if (baseUri[baseUri.size() - 1] == '/')

--- a/rest/etcd_client.cc
+++ b/rest/etcd_client.cc
@@ -155,7 +155,7 @@ createDir(const std::string & key,
             if (resp.code() != 201 && resp.code() != 200) {
                 cerr << "createDir returned wrong code: "
                      << resp << endl;
-                throw ML::Exception("createDir");
+                throw MLDB::Exception("createDir");
             }
 #endif
             return extractResponse(resp);
@@ -222,7 +222,7 @@ listDir(const std::string & key, bool recursive)
                 return response;
 
             if (!response.node)
-                throw ML::Exception("listDir didn't return node: %d %s",
+                throw MLDB::Exception("listDir didn't return node: %d %s",
                                     resp.code(), resp.body().c_str());
 
             return response;
@@ -311,7 +311,7 @@ watch(const std::string & key,
             return EtcdResponse();
         if (resp.errorCode()) {
             if (i == retries - 1)
-                throw ML::Exception(resp.errorMessage());
+                throw MLDB::Exception(resp.errorMessage());
             cerr << "retrying etcd operation" << endl;
             std::this_thread::sleep_for(std::chrono::milliseconds(
                 int(retryDelay * 1000)));

--- a/rest/etcd_client.h
+++ b/rest/etcd_client.h
@@ -83,7 +83,7 @@ struct EtcdClient {
                  std::string basePath = "")
     {
         if (uri.empty())
-            throw ML::Exception("URI is empty");
+            throw MLDB::Exception("URI is empty");
         if (uri[uri.size() - 1] == '/')
             uri = std::string(uri, 0, uri.size() - 1);
         proxy.init(uri);

--- a/rest/etcd_peer_discovery.cc
+++ b/rest/etcd_peer_discovery.cc
@@ -79,7 +79,7 @@ publish(PeerInfo info)
     LOG(logEtcd) << "set key res = " << jsonEncode(res) << endl;
 
     if (res.errorCode != 0) {
-        throw ML::Exception("peer name appears to be already used");
+        throw MLDB::Exception("peer name appears to be already used");
     }
 
     LOG(logEtcd) << jsonEncode(etcd.get("peers/" + ourInfo.serviceType + "/"
@@ -90,13 +90,13 @@ publish(PeerInfo info)
                           5.0 /* seconds */);
     
     if (res.errorCode != 0) {
-        throw ML::Exception("error refreshing peer directory");
+        throw MLDB::Exception("error refreshing peer directory");
     }
     
     res = etcd.set("peers/" + ourInfo.serviceType + "/" + ourInfo.peerName + "/p2p",
                    jsonEncodeStr(ourInfo));
     if (res.errorCode != 0)
-        throw ML::Exception("couldn't set our address");
+        throw MLDB::Exception("couldn't set our address");
 
     discoveryThread.reset
         (new std::thread([=] () { this->runDiscoveryThread(); }));
@@ -183,7 +183,7 @@ runDiscoveryThread()
                     v["host"] = hostname();
                     v["user"] = username();
                     v["uid"] = userid();
-                    v["addr"] = ML::format("%016p", this);
+                    v["addr"] = MLDB::format("%016p", this);
 
                     string myId = v.toString();
 

--- a/rest/http_rest_endpoint.cc
+++ b/rest/http_rest_endpoint.cc
@@ -78,7 +78,7 @@ bindTcpAddress(const std::string & address)
     string portPart(address, pos + 1);
 
     if (portPart.empty())
-        throw ML::Exception("invalid port " + portPart + " in address "
+        throw MLDB::Exception("invalid port " + portPart + " in address "
                             + address);
 
     if (portPart[portPart.size() - 1] == '+') {
@@ -88,7 +88,7 @@ bindTcpAddress(const std::string & address)
             return bindTcp(PortRange(port, last), hostPart);
         }
 
-        throw ML::Exception("invalid port " + to_string(port));
+        throw MLDB::Exception("invalid port " + to_string(port));
     }
 
     return bindTcp(boost::lexical_cast<int>(portPart), hostPart);

--- a/rest/http_rest_service.cc
+++ b/rest/http_rest_service.cc
@@ -30,7 +30,7 @@ HttpRestConnection::
 sendResponse(int responseCode, std::string response, std::string contentType)
 {
     if (responseSent_)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
     if (endpoint->logResponse)
         endpoint->logResponse(*this, responseCode, response,
@@ -53,7 +53,7 @@ sendResponse(int responseCode,
     //     << endl;
 
     if (responseSent_)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
     if (endpoint->logResponse)
         endpoint->logResponse(*this, responseCode, response.toString(),
@@ -72,7 +72,7 @@ sendErrorResponse(int responseCode, string error, string contentType)
     cerr << "sent error response " << responseCode << " " << error << endl;
 
     if (responseSent_)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
 
     if (endpoint->logResponse)
@@ -92,7 +92,7 @@ sendErrorResponse(int responseCode, const Json::Value & error)
     cerr << "sent error response " << responseCode << " " << error << endl;
     
     if (responseSent_)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
     
     if (endpoint->logResponse)
         endpoint->logResponse(*this, responseCode, error.toString(),
@@ -108,7 +108,7 @@ HttpRestConnection::
 sendRedirect(int responseCode, std::string location)
 {
     if (responseSent_)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
     
     if (endpoint->logResponse)
         endpoint->logResponse(*this, responseCode, location,
@@ -127,7 +127,7 @@ sendHttpResponse(int responseCode,
                  RestParams headers)
 {
     if (responseSent_)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
     if (endpoint->logResponse)
         endpoint->logResponse(*this, responseCode, response,
@@ -145,10 +145,10 @@ sendHttpResponseHeader(int responseCode,
                        RestParams headers_)
 {
     if (responseSent_)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
     if (!http)
-        throw ML::Exception("sendHttpResponseHeader only works on HTTP connections");
+        throw MLDB::Exception("sendHttpResponseHeader only works on HTTP connections");
 
     if (endpoint->logResponse)
         endpoint->logResponse(*this, responseCode, "", contentType);
@@ -183,7 +183,7 @@ sendPayload(std::string payload)
 {
     if (chunkedEncoding) {
         if (payload.empty()) {
-            throw ML::Exception("Can't send empty chunk over a chunked connection");
+            throw MLDB::Exception("Can't send empty chunk over a chunked connection");
         }
         http->sendHttpChunk(std::move(payload), HttpLegacySocketHandler::NEXT_CONTINUE);
     }
@@ -212,7 +212,7 @@ capture(std::function<void ()> onDisconnect)
 {
     ExcAssert(onDisconnect);
     if (this->http->onDisconnect)
-        throw ML::Exception("Connection has already been captured");
+        throw MLDB::Exception("Connection has already been captured");
     auto result = std::make_shared<HttpRestConnection>(std::move(*this));
     result->http->onDisconnect = std::move(onDisconnect);
     return result;
@@ -313,7 +313,7 @@ handleRequest(RestConnection & connection,
         onHandleRequest(connection, request);
     }
     else {
-        throw ML::Exception("need to override handleRequest or assign to "
+        throw MLDB::Exception("need to override handleRequest or assign to "
                             "onHandleRequest");
     }
 }
@@ -322,9 +322,9 @@ std::string
 HttpRestService::
 getHttpRequestId() const
 {
-    std::string s = Date::now().print(9) + ML::format("%d", random());
+    std::string s = Date::now().print(9) + MLDB::format("%d", random());
     uint64_t jobId = CityHash64(s.c_str(), s.size());
-    return ML::format("%016llx", jobId);
+    return MLDB::format("%016llx", jobId);
 }
 
 void
@@ -355,7 +355,7 @@ logToStream(std::ostream & stream)
             stream << "<-- ========================= finished request "
             << conn.requestId
             << " at " << now.print(9)
-            << ML::format(" (%.3fms)", conn.startDate.secondsUntil(now) * 1000)
+            << MLDB::format(" (%.3fms)", conn.startDate.secondsUntil(now) * 1000)
             << endl;
             stream << code << " " << contentType << " " << resp.length() << " bytes" << endl;;
                 

--- a/rest/in_process_rest_connection.cc
+++ b/rest/in_process_rest_connection.cc
@@ -137,13 +137,13 @@ isConnected() const
 std::shared_ptr<RestConnection> InProcessRestConnection::
 capture(std::function<void ()> onDisconnect)
 {
-    throw ML::Exception("Capturing not supported");
+    throw MLDB::Exception("Capturing not supported");
 }
 
 std::shared_ptr<RestConnection> InProcessRestConnection::
 captureInConnection(std::shared_ptr<void> toCapture)
 {
-    throw ML::Exception("Capturing not supported");
+    throw MLDB::Exception("Capturing not supported");
 }
 
 };

--- a/rest/link.cc
+++ b/rest/link.cc
@@ -77,7 +77,7 @@ waitUntilState(double waitTime, LinkState stateRequired)
             return;
         Date now = Date::now();
         if (now > limit)
-            throw ML::Exception("timed out waiting for link connection");
+            throw MLDB::Exception("timed out waiting for link connection");
 
         LinkState state;
         bool found;
@@ -88,7 +88,7 @@ waitUntilState(double waitTime, LinkState stateRequired)
             if (state == stateRequired)
                 return;
             if (state == LS_ERROR)
-                throw ML::Exception("link in error state");
+                throw MLDB::Exception("link in error state");
         }
     }
 }

--- a/rest/peer_connection.cc
+++ b/rest/peer_connection.cc
@@ -96,7 +96,7 @@ void
 MirrorPeerConnection::
 stopReading()
 {
-    throw ML::Exception("MirrorPeerConnection::stopReading() not implemented");
+    throw MLDB::Exception("MirrorPeerConnection::stopReading() not implemented");
 }
 
 void

--- a/rest/peer_info.cc
+++ b/rest/peer_info.cc
@@ -20,11 +20,11 @@ const Date startupDate = Date::now();
 PeerInfo::
 PeerInfo()
 {
-    epoch = ML::format("%s-%d-%lld-%d",
-                       ML::hostname().c_str(),
-                       getpid(),
-                       (long long)Date::now().secondsSinceEpoch() * 1000000,
-                       random());
+    epoch = format("%s-%d-%lld-%d",
+                   hostname().c_str(),
+                   getpid(),
+                   (long long)Date::now().secondsSinceEpoch() * 1000000,
+                   random());
 }
 
 DEFINE_STRUCTURE_DESCRIPTION(PeerInfo);

--- a/rest/poly_collection.cc
+++ b/rest/poly_collection.cc
@@ -133,12 +133,12 @@ getKey(PolyConfig & config)
     // 1.  Newly seeded random number based on current time
     // 2.  Thread ID
     Utf8String disambig
-        = ML::format("%d-%d", random())
+        = MLDB::format("%d-%d", random())
         + Date::now().print(9)
         + std::to_string(std::hash<std::thread::id>()(std::this_thread::get_id()));
     
     // Create an auto hash that is cleary identified as one
-    return config.id = ML::format("auto-%016llx-%016llx",
+    return config.id = MLDB::format("auto-%016llx-%016llx",
                                   (unsigned long long)jsonHash(jsonEncode(config)),
                                   (unsigned long long)jsonHash(disambig));
 }

--- a/rest/poly_collection_impl.h
+++ b/rest/poly_collection_impl.h
@@ -266,7 +266,7 @@ struct PolyCollection<Entity>::Registry {
         } JML_CATCH_ALL {
             rethrowHttpException(500, "Error getting information for type '" + type
                                  + "' in collection " + nounPlural + ": "
-                                 + ML::getExceptionString(),
+                                 + getExceptionString(),
                                  "type", type,
                                  "nounPlural", nounPlural);
         }

--- a/rest/poly_entity.h
+++ b/rest/poly_entity.h
@@ -127,21 +127,21 @@ struct PolyEntity {
     const PolyConfig & getConfig() const
     {
         if (!config_)
-            throw ML::Exception("Entity has no configuration");
+            throw MLDB::Exception("Entity has no configuration");
         return *config_;
     }
 
     const Utf8String & getId() const
     {
         if (!config_)
-            throw ML::Exception("Entity has no configuration");
+            throw MLDB::Exception("Entity has no configuration");
         return config_->id;
     }
 
     const Utf8String & getType() const
     {
         if (!config_)
-            throw ML::Exception("Entity has no configuration");
+            throw MLDB::Exception("Entity has no configuration");
         return config_->type;
     }
 

--- a/rest/remote_peer.cc
+++ b/rest/remote_peer.cc
@@ -101,7 +101,7 @@ initAfterAccept(std::shared_ptr<PeerConnection> connection)
 
     if (!mutex.try_lock_for(std::chrono::milliseconds(1000))) {
         connection->shutdown();
-        throw ML::Exception("didn't receive handshake after one second");
+        throw MLDB::Exception("didn't receive handshake after one second");
     }
 
     remotePeerInfo = jsonDecodeStr<PeerInfo>(payload);
@@ -396,7 +396,7 @@ getMessage(std::string & payload)
             messagesSent += 1;
         }
         else {
-            //throw ML::Exception("how do we send a response?");
+            //throw MLDB::Exception("how do we send a response?");
             responsesSent += 1;
         }
 
@@ -477,7 +477,7 @@ handleMessageIn(PeerMessage && message)
         ++messagesReceived;
 
         if (message.layer == 0) {
-            throw ML::Exception("layer 0 message not understood");
+            throw MLDB::Exception("layer 0 message not understood");
         }
         else if (message.layer == 1) {
 
@@ -703,7 +703,7 @@ watchWithPath(const ResourceSpec & spec, bool catchUp, Any info,
                 std::unique_lock<std::mutex> guard(remoteWatchMutex);
                 cerr << "erasing local watch data for " << externalWatchId << endl;
                 if (!this->localWatches.erase(externalWatchId)) {
-                    throw ML::Exception("logic error: "
+                    throw MLDB::Exception("logic error: "
                                         "released watch with unknown ID");
                 }
                 //cerr << "done erasing local watch data" << endl;
@@ -1110,7 +1110,7 @@ handleLayerOneMessage(PeerMessage & message)
     }
     }
     
-    //throw ML::Exception("got unknown layer 0 message type %d", type);
+    //throw MLDB::Exception("got unknown layer 0 message type %d", type);
     // For forward compatibility, we simply won't respond to those
     cerr << "got unknown message type " << type << endl;
 }
@@ -1293,7 +1293,7 @@ void
 RemotePeer::
 handleRemoteWatchStatus(std::vector<std::string> & message)
 {
-    throw ML::Exception("handleRemoteWatchStatus");
+    throw MLDB::Exception("handleRemoteWatchStatus");
 }
 
 void
@@ -1321,7 +1321,7 @@ sendPeerWatchFired(int64_t externalWatchId,
             
             this->deletePeerWatch(externalWatchId);
 
-            //throw ML::Exception("peer watch fired error not done yet");
+            //throw MLDB::Exception("peer watch fired error not done yet");
         };
 
     sendMessage(PRI_NORMAL,
@@ -1403,7 +1403,7 @@ handleRemoteCreateLink(std::vector<std::string> & message)
                             
                             //this->deletePeerWatch(peer, externalWatchId);
 
-                            //throw ML::Exception("peer watch fired error not done yet");
+                            //throw MLDB::Exception("peer watch fired error not done yet");
                         };
 
                         sendMessage(PRI_NORMAL,

--- a/rest/rest_collection.cc
+++ b/rest/rest_collection.cc
@@ -227,7 +227,7 @@ watch(const ResourceSpec & spec,
     
 
     //cerr << "watching " << spec << " in entity "
-    //     << ML::type_name(*this) << " with catchUp " << catchUp
+    //     << MLDB::type_name(*this) << " with catchUp " << catchUp
     //     << endl;
 
     if (spec.empty())
@@ -309,7 +309,7 @@ watchWithPath(const ResourceSpec & spec,
               const std::vector<Utf8String> & currentPath)
 {
     //cerr << "watching " << spec << " in entity "
-    //     << ML::type_name(*this) << " with catchUp " << catchUp
+    //     << MLDB::type_name(*this) << " with catchUp " << catchUp
     //     << endl;
 
     if (spec.empty())
@@ -381,7 +381,7 @@ WatchT<RestEntityChildEvent>
 RestEntity::
 watchChildren(const Utf8String & spec, bool catchUp, Any info)
 {
-    throw HttpReturnException(400, "entity '" + ML::type_name(*this) + "' does not support watching children: spec " + spec);
+    throw HttpReturnException(400, "entity '" + MLDB::type_name(*this) + "' does not support watching children: spec " + spec);
 }
 
 Watch
@@ -451,7 +451,7 @@ acceptLink(const std::vector<Utf8String> & sourcePath,
            const std::string & linkType,
            Any linkParams)
 {
-    throw HttpReturnException(400, "acceptLink needs to be overridden for class " + ML::type_name(*this));
+    throw HttpReturnException(400, "acceptLink needs to be overridden for class " + MLDB::type_name(*this));
 }
 
 
@@ -523,7 +523,7 @@ getWatchBoundType(const ResourceSpec & spec)
     if (spec.empty())
         throw HttpReturnException(400, "no type for empty spec");
     if (spec[0].channel != "children")
-        throw HttpReturnException(400, "RestDirectory '" + ML::type_name(*this)
+        throw HttpReturnException(400, "RestDirectory '" + MLDB::type_name(*this)
                                   + "' has only a children channel: "
                                   + jsonEncodeUtf8(spec));
 

--- a/rest/rest_collection.h
+++ b/rest/rest_collection.h
@@ -562,7 +562,7 @@ struct RestConfigurableCollection: public RestCollection<Key, Value> {
     {
         auto key2 = getKey(config);
         if (key != key2)
-            throw ML::Exception("attempt to put under the wrong name (passed '%s', "
+            throw MLDB::Exception("attempt to put under the wrong name (passed '%s', "
                                 "should be '%s'",
                                 restEncode(key).rawData(),
                                 restEncode(key2).rawData());

--- a/rest/rest_collection_impl.h
+++ b/rest/rest_collection_impl.h
@@ -71,7 +71,7 @@ struct RestCollection<Key, Value>::Impl {
     /// Watches on the children
     WatchesT<ChildEvent> childWatches;
 
-    typedef ML::Spinlock MutateMutex;
+    typedef Spinlock MutateMutex;
 
     /** Mutex on mutation operations.  This is required so that the watch
         operations are serializable.  Could be turned off when there are no
@@ -861,7 +861,7 @@ getEntry(Key key) const
 
     Utf8String error_message;
     if (restEncode(key).empty()) {
-        error_message = ML::format("Collection URLs do not contain a trailing slash: try /v1/%1$s instead of /v1/%1$s/",
+        error_message = MLDB::format("Collection URLs do not contain a trailing slash: try /v1/%1$s instead of /v1/%1$s/",
                                    this->nounPlural.rawData());
         throw HttpReturnException(404, error_message);
     }
@@ -1028,7 +1028,7 @@ watchElements(const Utf8String & spec, bool catchUp, Any info)
 {
     using namespace std;
     //cerr << "restCollection watchElements spec = " << spec
-    //     << " entity " << ML::type_name(*this) << " " << catchUp
+    //     << " entity " << MLDB::type_name(*this) << " " << catchUp
     //     << " info " << jsonEncodeStr(info) << endl;
 
     // Filter that controls which events are seen by this watch
@@ -1114,8 +1114,8 @@ watchChannel(const Utf8String & channel,
     else if (channel == "names")
         return watchNames(filter, catchUp, std::move(info));
     else throw HttpReturnException(400,
-                                   ML::format("type %s doesn't have channel named '%s'",
-                                              ML::type_name(*this).c_str(),
+                                   MLDB::format("type %s doesn't have channel named '%s'",
+                                              MLDB::type_name(*this).c_str(),
                                               channel.rawData()));
 }
 
@@ -1142,10 +1142,10 @@ struct ChildHasGenericWatchType : public std::false_type {
     get(const ResourceSpec & spec)
     {
         throw HttpReturnException(400,
-                                  ML::format("need to override getWatchBoundType() or implement "
+                                  MLDB::format("need to override getWatchBoundType() or implement "
                                              "getWatchBoundTypeGeneric() "
                                              "for type %s to know about value watch types",
-                                             ML::type_name<T>().c_str()));
+                                             MLDB::type_name<T>().c_str()));
     }
 };
 
@@ -1174,8 +1174,8 @@ getWatchBoundType(const ResourceSpec & spec)
             return ChildHasGenericWatchType<Value>::get(childSpec);
         }
         else throw HttpReturnException(400,
-                                       ML::format("type %s doesn't have channel named '%s'",
-                                                  ML::type_name(*this).c_str(),
+                                       MLDB::format("type %s doesn't have channel named '%s'",
+                                                  MLDB::type_name(*this).c_str(),
                                                   spec[0].channel.rawData()));
     }
     else if (spec[0].channel == "children")
@@ -1185,8 +1185,8 @@ getWatchBoundType(const ResourceSpec & spec)
     else if (spec[0].channel == "names")
         return make_pair(&typeid(std::tuple<Utf8String>), nullptr);
     else throw HttpReturnException(400,
-                                   ML::format("type %s doesn't have channel named '%s'",
-                                              ML::type_name(*this).c_str(),
+                                   MLDB::format("type %s doesn't have channel named '%s'",
+                                              MLDB::type_name(*this).c_str(),
                                               spec[0].channel.rawData()));
 }
 
@@ -1469,7 +1469,7 @@ addPutRoute()
     Json::Value & v = help["jsonParams"];
     Json::Value & v2 = v[0];
     v2["description"] = "Configuration of new " + this->nounSingular;
-    v2["cppType"] = ML::type_name<Config>();
+    v2["cppType"] = MLDB::type_name<Config>();
     v2["encoding"] = "JSON";
     v2["location"] = "Request Body";
 
@@ -1575,7 +1575,7 @@ addPostRoute()
     Json::Value & v = help["jsonParams"];
     Json::Value & v2 = v[0];
     v2["description"] = "Configuration of new " + this->nounSingular;
-    v2["cppType"] = ML::type_name<Config>();
+    v2["cppType"] = MLDB::type_name<Config>();
     v2["encoding"] = "JSON";
     v2["location"] = "Request Body";
 
@@ -2053,8 +2053,8 @@ RestConfigurableCollection<Key, Value, Config, Status>::
 getConfig(Key key, const Value & value) const
 {
     throw HttpReturnException(400,
-                              ML::format("type '%s' needs to override getConfig",
-                                         ML::type_name(*this).c_str()));
+                              MLDB::format("type '%s' needs to override getConfig",
+                                         MLDB::type_name(*this).c_str()));
 }
 
 } // namespace MLDB

--- a/rest/rest_request_binding.h
+++ b/rest/rest_request_binding.h
@@ -325,7 +325,7 @@ createParameterExtractor(Json::Value & argHelp,
     if (!p.name.empty())
         v2["name"] = p.name;
     v2["description"] = p.description;
-    v2["cppType"] = ML::type_name<T>();
+    v2["cppType"] = MLDB::type_name<T>();
     v2["encoding"] = "URI encoded";
     v2["location"] = "query string";
 
@@ -353,7 +353,7 @@ createParameterExtractor(Json::Value & argHelp,
     if (!p.name.empty())
         v2["name"] = p.name;
     v2["description"] = p.description;
-    v2["cppType"] = ML::type_name<T>();
+    v2["cppType"] = MLDB::type_name<T>();
     v2["encoding"] = "URI encoded";
     v2["location"] = "query string";
     v2["defaultValue"] = p.defaultValueStr;
@@ -389,7 +389,7 @@ createParameterExtractor(Json::Value & argHelp,
     if (!p.name.empty())
         v2["name"] = p.name;
     v2["description"] = p.description;
-    v2["cppType"] = ML::type_name<T>();
+    v2["cppType"] = MLDB::type_name<T>();
     v2["encoding"] = "JSON";
     v2["location"] = "Request Body";
 
@@ -415,7 +415,7 @@ createParameterExtractor(Json::Value & argHelp,
         v2["name"] = p.name;
     }
     v2["description"] = p.description;
-    v2["cppType"] = ML::type_name<T>();
+    v2["cppType"] = MLDB::type_name<T>();
     v2["encoding"] = "JSON";
     v2["location"] = "Request Body";
 
@@ -449,7 +449,7 @@ createParameterExtractor(Json::Value & argHelp,
     Json::Value desc;
     desc["name"] = p.name;
     desc["description"] = p.description;
-    desc["cppType"] = ML::type_name<T>();
+    desc["cppType"] = MLDB::type_name<T>();
     desc["encoding"] = "URI encoded or JSON";
     desc["location"] = "query string or Request Body";
 
@@ -489,7 +489,7 @@ createParameterExtractor(Json::Value & argHelp,
     Json::Value desc;
     desc["name"] = p.name;
     desc["description"] = p.description;
-    desc["cppType"] = ML::type_name<T>();
+    desc["cppType"] = MLDB::type_name<T>();
     desc["encoding"] = "URI encoded or JSON";
     desc["location"] = "query string or Request Body";
 
@@ -535,7 +535,7 @@ createParameterExtractor(Json::Value & argHelp,
     if (!p.name.empty())
         v2["name"] = p.name;
     v2["description"] = p.description;
-    v2["cppType"] = ML::type_name<T>();
+    v2["cppType"] = MLDB::type_name<T>();
     v2["encoding"] = "URI encoded";
     v2["location"] = "URI";
 
@@ -555,7 +555,7 @@ createParameterExtractor(Json::Value & argHelp,
                     knownResources
                         += (knownResources.empty() ? "":",")
                         +  r;
-                throw ML::Exception("attempt to access missing resource %d of "
+                throw MLDB::Exception("attempt to access missing resource %d of "
                                     "%zd (known is %s)",
                                     index, context.resources.size(),
                                     knownResources.rawData());

--- a/rest/rest_request_router.cc
+++ b/rest/rest_request_router.cc
@@ -343,7 +343,7 @@ static std::string getVerbsStr(const std::set<std::string> & verbs)
 
 namespace {
 
-ML::Env_Option<bool, true> TRACE_REST_REQUESTS("TRACE_REST_REQUESTS", false);
+EnvOption<bool, true> TRACE_REST_REQUESTS("TRACE_REST_REQUESTS", false);
 
 } // file scope
 

--- a/rest/rest_request_router.h
+++ b/rest/rest_request_router.h
@@ -214,11 +214,11 @@ struct RestRequestParsingContext {
         if (index == -1)
             index = objects.size() + index;
         if (index < 0 || index >= objects.size())
-            throw ML::Exception("Attempt to extract invalid object number");
+            throw MLDB::Exception("Attempt to extract invalid object number");
 
         auto & res = objects[index];
         if (!res.obj || !res.type)
-            throw ML::Exception("invalid object");
+            throw MLDB::Exception("invalid object");
 
         return std::make_pair(res.obj, res.type);
     }
@@ -245,10 +245,10 @@ struct RestRequestParsingContext {
                                     //          *tp,
                                     //          obj.first);
         if (!converted)
-            throw ML::Exception("wanted to get object of type "
-                                + ML::type_name<As>()
+            throw MLDB::Exception("wanted to get object of type "
+                                + MLDB::type_name<As>()
                                 + " from incompatible object of type "
-                                + ML::demangle(obj.second->name()));
+                                + demangle(obj.second->name()));
 
         return *reinterpret_cast<As *>(converted);
     }

--- a/rest/rest_service_endpoint.cc
+++ b/rest/rest_service_endpoint.cc
@@ -29,7 +29,7 @@ RestServiceEndpoint::ConnectionId::
 sendResponse(int responseCode, std::string response, std::string contentType)
 {
     if (itl->responseSent)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
     if (itl->endpoint->logResponse)
         itl->endpoint->logResponse(*this, responseCode, response,
@@ -39,7 +39,7 @@ sendResponse(int responseCode, std::string response, std::string contentType)
         itl->http->sendResponse(responseCode,
                                 std::move(response), std::move(contentType));
     else
-        throw ML::Exception("missing connection handler");
+        throw MLDB::Exception("missing connection handler");
 
     itl->responseSent = true;
 }
@@ -50,7 +50,7 @@ sendResponse(int responseCode,
              const Json::Value & response, std::string contentType)
 {
     if (itl->responseSent)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
     if (itl->endpoint->logResponse)
         itl->endpoint->logResponse(*this, responseCode, response.toString(),
@@ -60,7 +60,7 @@ sendResponse(int responseCode,
         itl->http->sendResponse(responseCode,
                                 std::move(response), std::move(contentType));
     else
-        throw ML::Exception("missing connection handler");
+        throw MLDB::Exception("missing connection handler");
 
     itl->responseSent = true;
 }
@@ -75,7 +75,7 @@ sendErrorResponse(int responseCode,
          << endl;
 
     if (itl->responseSent)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
 
     if (itl->endpoint->logResponse)
@@ -85,7 +85,7 @@ sendErrorResponse(int responseCode,
     if (itl->http)
         itl->http->sendResponse(responseCode, std::move(error));
     else
-        throw ML::Exception("missing connection handler");
+        throw MLDB::Exception("missing connection handler");
     
     itl->responseSent = true;
 }
@@ -99,7 +99,7 @@ sendErrorResponse(int responseCode, const Json::Value & error)
          << endl;
 
     if (itl->responseSent)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
     if (itl->endpoint->logResponse)
         itl->endpoint->logResponse(*this, responseCode, error.toString(),
@@ -108,7 +108,7 @@ sendErrorResponse(int responseCode, const Json::Value & error)
     if (itl->http)
         itl->http->sendResponse(responseCode, error);
     else
-        throw ML::Exception("missing connection handler");
+        throw MLDB::Exception("missing connection handler");
     
     itl->responseSent = true;
 }
@@ -118,7 +118,7 @@ RestServiceEndpoint::ConnectionId::
 sendRedirect(int responseCode, std::string location)
 {
     if (itl->responseSent)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
     if (itl->endpoint->logResponse)
         itl->endpoint->logResponse(*this, responseCode, location,
@@ -128,7 +128,7 @@ sendRedirect(int responseCode, std::string location)
         itl->http->sendResponse(responseCode, string(""), "",
                                 { { "Location", std::move(location) } });
     else
-        throw ML::Exception("missing connection handler");
+        throw MLDB::Exception("missing connection handler");
     
     itl->responseSent = true;
 }
@@ -140,7 +140,7 @@ sendHttpResponse(int responseCode,
                  RestParams headers)
 {
     if (itl->responseSent)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
     if (itl->endpoint->logResponse)
         itl->endpoint->logResponse(*this, responseCode, response,
@@ -151,7 +151,7 @@ sendHttpResponse(int responseCode,
                                 std::move(response), std::move(contentType),
                                 std::move(headers));
     else
-        throw ML::Exception("missing connection handler");
+        throw MLDB::Exception("missing connection handler");
     
     itl->responseSent = true;
 }
@@ -163,10 +163,10 @@ sendHttpResponseHeader(int responseCode,
                        RestParams headers_)
 {
     if (itl->responseSent)
-        throw ML::Exception("response already sent");
+        throw MLDB::Exception("response already sent");
 
     if (!itl->http)
-        throw ML::Exception("sendHttpResponseHeader only works on HTTP connections");
+        throw MLDB::Exception("sendHttpResponseHeader only works on HTTP connections");
 
     if (itl->endpoint->logResponse)
         itl->endpoint->logResponse(*this, responseCode, "", contentType);
@@ -186,7 +186,7 @@ sendHttpResponseHeader(int responseCode,
     if (itl->http)
         itl->http->sendResponseHeader(responseCode, std::move(contentType), std::move(headers));
     else
-        throw ML::Exception("missing connection handler");
+        throw MLDB::Exception("missing connection handler");
 }
 
 void
@@ -195,7 +195,7 @@ sendPayload(std::string payload)
 {
     if (itl->chunkedEncoding) {
         if (payload.empty()) {
-            throw ML::Exception("Can't send empty chunk over a chunked connection");
+            throw MLDB::Exception("Can't send empty chunk over a chunked connection");
         }
         itl->http->sendHttpChunk(std::move(payload),
                                  HttpLegacySocketHandler::NEXT_CONTINUE);
@@ -223,7 +223,7 @@ std::shared_ptr<RestConnection>
 RestServiceEndpoint::ConnectionId::
 capture(std::function<void ()> onDisconnect)
 {
-    throw ML::Exception("RestServiceEndpoint::ConnectionId::capture(): "
+    throw MLDB::Exception("RestServiceEndpoint::ConnectionId::capture(): "
                         "needs to be implemented");
 }
 
@@ -231,7 +231,7 @@ std::shared_ptr<RestConnection>
 RestServiceEndpoint::ConnectionId::
 captureInConnection(std::shared_ptr<void> piggyBack)
 {
-    throw ML::Exception("RestServiceEndpoint::ConnectionId::captureInConnection(): "
+    throw MLDB::Exception("RestServiceEndpoint::ConnectionId::captureInConnection(): "
                         "needs to be implemented");
 }
 
@@ -305,7 +305,7 @@ handleRequest(ConnectionId & connection,
         onHandleRequest(connection, request);
     }
     else {
-        throw ML::Exception("need to override handleRequest or assign to "
+        throw MLDB::Exception("need to override handleRequest or assign to "
                             "onHandleRequest");
     }
 }
@@ -314,9 +314,9 @@ std::string
 RestServiceEndpoint::
 getHttpRequestId() const
 {
-    std::string s = Date::now().print(9) + ML::format("%d", random());
+    std::string s = Date::now().print(9) + MLDB::format("%d", random());
     uint64_t jobId = CityHash64(s.c_str(), s.size());
-    return ML::format("%016llx", jobId);
+    return MLDB::format("%016llx", jobId);
 }
 
 void
@@ -347,7 +347,7 @@ logToStream(std::ostream & stream)
             stream << "<-- ========================= finished request "
             << conn.itl->requestId
             << " at " << now.print(9)
-            << ML::format(" (%.3fms)", conn.itl->startDate.secondsUntil(now) * 1000)
+            << MLDB::format(" (%.3fms)", conn.itl->startDate.secondsUntil(now) * 1000)
             << endl;
             stream << code << " " << contentType << " " << resp.length() << " bytes" << endl;;
                 

--- a/rest/service_peer.cc
+++ b/rest/service_peer.cc
@@ -221,7 +221,7 @@ onNewPeer(const RestCollection<std::string, PeerInfo>::ChildEvent & newPeer)
     case CE_NEW:
         if (newPeer.key == peerInfo.peerName) {
             if (jsonEncode(*newPeer.value) != jsonEncode(peerInfo))
-                throw ML::Exception("our peer was discovered with different info");
+                throw MLDB::Exception("our peer was discovered with different info");
             DEBUG_MSG(logger) << "new entry for me " << peerInfo.peerName << " "
                  << newPeer.key << " " << jsonEncode(peers.getKeys());
             ExcAssert(peers.tryGetExistingEntry(peerInfo.peerName));
@@ -276,7 +276,7 @@ onNewPeer(const RestCollection<std::string, PeerInfo>::ChildEvent & newPeer)
         DEBUG_MSG(logger) << "updated peer " << newPeer.key;
         DEBUG_MSG(logger) << "TODO: implement updates";
     default:
-        throw ML::Exception("unexpected discovery event type");
+        throw MLDB::Exception("unexpected discovery event type");
     }
 }
 
@@ -359,7 +359,7 @@ start()
         std::future_status status
             = getStatus(future.wait_for(std::chrono::seconds(1)));
         if (status != std::future_status::ready)
-            throw ML::Exception("Self connection not accepted after "
+            throw MLDB::Exception("Self connection not accepted after "
                                 "one second");
         
         PeerInfo info = future.get();
@@ -377,7 +377,7 @@ start()
 
     // ... and check that we could
     if (selfEntry->state != PS_OK) {
-        throw ML::Exception("Can't start service peer: unable to talk to itself (error is '" + selfEntry->error + "').  Check that etcd is OK and that the published port and hostname is really the exterally accessible port and hostname.");
+        throw MLDB::Exception("Can't start service peer: unable to talk to itself (error is '" + selfEntry->error + "').  Check that etcd is OK and that the published port and hostname is really the exterally accessible port and hostname.");
     }
     //DEBUG_MSG(logger) << "done checking";
 
@@ -561,8 +561,8 @@ void
 ServicePeer::
 handlePeerMessage(RemotePeer * peer, PeerMessage && msg)
 {
-    throw ML::Exception("Service peer of type %s doesn't support peer to peer "
-                        "messages", ML::type_name(*this).c_str());
+    throw MLDB::Exception("Service peer of type %s doesn't support peer to peer "
+                        "messages", MLDB::type_name(*this).c_str());
 }
 
 WatchT<Date>
@@ -651,19 +651,19 @@ ServicePeer::PeerCollection::
 getWatchBoundType(const ResourceSpec & spec)
 {
     if (spec.empty())
-        throw ML::Exception("no type for empty spec");
+        throw MLDB::Exception("no type for empty spec");
 
     if (spec.size() == 1) {
         if (spec[0].channel == "names")
             return make_pair(&typeid(tuple<std::string>), nullptr);
         else if (spec[0].channel == "children")
             return make_pair(&typeid(tuple<RestEntityChildEvent>), nullptr);
-        else throw ML::Exception("PeerCollection has no channel named '%s'",
+        else throw MLDB::Exception("PeerCollection has no channel named '%s'",
                                  spec[0].channel.rawData());
     }
     
     if (spec[0].channel != "children")
-        throw ML::Exception("PeerCollection has only a children channel, "
+        throw MLDB::Exception("PeerCollection has only a children channel, "
                             "not '%s'", spec[0].channel.rawData());
 
     return service->getWatchBoundType(ResourceSpec(spec.begin() + 1, spec.end()));
@@ -693,7 +693,7 @@ watchChannel(const Utf8String & channel,
                                                ? "+" : "-") + ev.name; });
 #endif
     }
-    else throw ML::Exception("No channel named '%s' on PeerCollection",
+    else throw MLDB::Exception("No channel named '%s' on PeerCollection",
                              channel.rawData());
 }
 

--- a/rest/standalone_peer_server.cc
+++ b/rest/standalone_peer_server.cc
@@ -86,7 +86,7 @@ StandalonePeerServer::
 connect(const PeerInfo & info)
 {
     return connectToSelf();
-    //throw ML::Exception("StandalonePeerServer can only connect to itself");
+    //throw MLDB::Exception("StandalonePeerServer can only connect to itself");
 }
 
 std::shared_ptr<PeerConnection>

--- a/rest/testing/rest_collection_stress_test.cc
+++ b/rest/testing/rest_collection_stress_test.cc
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE( stress_test_watch_coherency )
                 if (collection.addEntry(key ,
                                         std::make_shared<std::string>(value),
                                         false /* mustAdd */)) {
-                    //cerr << ML::format("mut: added entry %s %s\n",
+                    //cerr << MLDB::format("mut: added entry %s %s\n",
                     //                   key.c_str(), value.c_str());
                 }
                     
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE( stress_test_watch_coherency )
                 key = "item" + to_string(random() % 20);
                 
                 if (collection.deleteEntry(key)) {
-                    //cerr << ML::format("mut: deleted entry %s\n",
+                    //cerr << MLDB::format("mut: deleted entry %s\n",
                     //                   key.c_str());
                 }
 
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE( stress_test_watch_coherency )
                         break;
                     }
                     default:
-                    throw ML::Exception("unexpected watch event");
+                    throw MLDB::Exception("unexpected watch event");
                     }
                 };
                 // Bind in our event handler
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE( stress_test_collection_integrity )
 
     auto overwriteThread = [&] ()
         {
-            ML::Timer timer;
+            Timer timer;
             while (!shutdown) {
 
                 std::string key = "item";
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE( stress_test_collection_overwrite )
 
     auto overwriteThread = [&] ()
         {
-            ML::Timer timer;
+            Timer timer;
             while (!shutdown) {
 
                 std::string key = "counter";

--- a/rest/testing/rest_collection_test.cc
+++ b/rest/testing/rest_collection_test.cc
@@ -344,7 +344,7 @@ struct RecursiveCollection: public RestCollection<std::string, RecursiveCollecti
         if (spec.size() > 1) {
             if (spec[0].channel == "children")
                 return getWatchBoundType(ResourceSpec(spec.begin() + 1, spec.end()));
-            throw ML::Exception("only children channel known");
+            throw MLDB::Exception("only children channel known");
         }
         
         if (spec[0].channel == "children")
@@ -352,7 +352,7 @@ struct RecursiveCollection: public RestCollection<std::string, RecursiveCollecti
                              nullptr);
         else if (spec[0].channel == "elements")
             return make_pair(&typeid(std::tuple<ChildEvent>), nullptr);
-        else throw ML::Exception("unknown channel");
+        else throw MLDB::Exception("unknown channel");
     }
 
     std::string name;

--- a/rest/testing/rest_request_router_test.cc
+++ b/rest/testing/rest_request_router_test.cc
@@ -15,7 +15,6 @@
 
 
 using namespace std;
-using namespace ML;
 using namespace MLDB;
 
 

--- a/rest/testing/rest_service_endpoint_test.cc
+++ b/rest/testing/rest_service_endpoint_test.cc
@@ -55,9 +55,9 @@ struct EchoService : public RestServiceEndpoint {
     {
         //cerr << "handling request " << request << endl;
         if (request.verb != "POST")
-            throw ML::Exception("echo service needs POST");
+            throw MLDB::Exception("echo service needs POST");
         if (request.resource != "/echo")
-            throw ML::Exception("echo service only responds to /echo");
+            throw MLDB::Exception("echo service only responds to /echo");
         connection.sendResponse(200, request.payload, "text/plain");
     }
 };

--- a/rest/testing/temporary_etcd_server.h
+++ b/rest/testing/temporary_etcd_server.h
@@ -63,10 +63,10 @@ struct TemporaryEtcdServer {
         cerr << "done waiting for start" << endl;
         
         if (!started) {
-            throw ML::Exception("error starting etcd: " + jsonEncodeStr(runResult));
+            throw MLDB::Exception("error starting etcd: " + jsonEncodeStr(runResult));
         }
         if (!runner.running()) {
-            throw ML::Exception("service is not running");
+            throw MLDB::Exception("service is not running");
         }
 
         string uri = "http://localhost:" + std::to_string(port);
@@ -143,7 +143,7 @@ inline std::string getEtcdPath()
     std::string val = stream.readAll();
     std::string exe = ML::split(val, 0).at(0);
     std::string basename = ML::split(exe, '/').back();
-    std::string result = ML::username() + "-" + basename;
+    std::string result = MLDB::username() + "-" + basename;
     return result;
 }
 

--- a/rest/testing/test_peer.h
+++ b/rest/testing/test_peer.h
@@ -123,11 +123,11 @@ struct TestPeer: public ServicePeer {
         }
         else if (msg.type == 3) {
             // Throws an exception
-            throw ML::Exception("exception handling message");
+            throw MLDB::Exception("exception handling message");
         }
         else if (msg.type == 4) {
             // Send back a typed object
-            throw ML::Exception("sendPeerResponseObject");
+            throw MLDB::Exception("sendPeerResponseObject");
 
             //sendPeerResponseObject(returnAddress,
             //                       header,
@@ -147,7 +147,7 @@ struct TestPeer: public ServicePeer {
     getWatchBoundType(const ResourceSpec & spec)
     {
         if (spec.empty())
-            throw ML::Exception("no type for empty spec");
+            throw MLDB::Exception("no type for empty spec");
 
         if (spec.size() == 1 && spec[0].channel == "pulse")
             return make_pair(&typeid(tuple<int>), nullptr);
@@ -181,7 +181,7 @@ struct TestPeer: public ServicePeer {
                                            linkParams);
         }
         if (linkType != "subscription")
-            throw ML::Exception("unknown link type '%s'", linkType.c_str());
+            throw MLDB::Exception("unknown link type '%s'", linkType.c_str());
 
         cerr << "sourcePath = " << jsonEncode(sourcePath)
              << " targetPath = " << jsonEncode(targetPath) << endl;
@@ -212,14 +212,14 @@ struct ForkedTestPeer {
         int startPipe[2];
         int res = ::pipe(startPipe);
         if (res == -1)
-            throw ML::Exception(errno, "pipe()");
+            throw MLDB::Exception(errno, "pipe()");
 
         childPid = fork();
 
         cerr << "afterForkedTestPeer childPid = " << childPid << endl;
 
         if (childPid == -1)
-            throw ML::Exception(errno, "fork()");
+            throw MLDB::Exception(errno, "fork()");
 
         //cerr << "pipe: read fd " << startPipe[0] << " write fd " << startPipe[1] << endl;
 
@@ -237,9 +237,9 @@ struct ForkedTestPeer {
             cerr << "write res is " << res << endl;
 
             if (res == -1)
-                throw ML::Exception(errno, "write of boundAddress");
+                throw MLDB::Exception(errno, "write of boundAddress");
             if (res != boundAddress.length() + 1)
-                throw ML::Exception("didn't write whole address");
+                throw MLDB::Exception("didn't write whole address");
             
             cerr << "*** PEER READY" << endl;
             ::close(startPipe[1]);
@@ -258,7 +258,7 @@ struct ForkedTestPeer {
         ::close(startPipe[0]);
         cerr << "read res is " << res << endl;
         if (res == -1)
-            throw ML::Exception(errno, "read() of bound address");
+            throw MLDB::Exception(errno, "read() of bound address");
         cerr << "res = " << res << endl;
 
         cerr << "http address is " << buf << endl;
@@ -338,13 +338,13 @@ struct ForkedTestPeer: public Runner {
 
         bool wasStarted = waitStart();
         if (!wasStarted)
-            throw ML::Exception("didn't start");
+            throw MLDB::Exception("didn't start");
 
         started.lock();
         started.unlock();
 
         if (httpAddr.empty())
-            throw ML::Exception("peer didn't return its HTTP address");
+            throw MLDB::Exception("peer didn't return its HTTP address");
 
     }
 

--- a/rest/testing/test_peer_runner.cc
+++ b/rest/testing/test_peer_runner.cc
@@ -12,7 +12,7 @@ int main(int argc, char ** argv)
     // arg 3 = etcd path
 
     if (argc != 4)
-        throw ML::Exception("wrong arguments: need peer name and etcd uri and etcd path; got %d",
+        throw MLDB::Exception("wrong arguments: need peer name and etcd uri and etcd path; got %d",
                             argc);
 
     TestPeer peer(argv[1], argv[2], argv[3]);

--- a/server/bound_queries.cc
+++ b/server/bound_queries.cc
@@ -490,7 +490,7 @@ struct OrderedExecutor: public BoundSelectQuery::Executor {
                 return true;
             };
 
-        ML::Timer timer;
+        Timer timer;
 
         parallelMap(0, rows.size(), doWhere);
 
@@ -657,7 +657,7 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
 
         QueryThreadTracker parentTracker;
 
-        ML::Timer rowsTimer;
+        Timer rowsTimer;
 
         // Get a list of rows that we run over
         // Ordering is arbitrary but deterministic
@@ -674,11 +674,11 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
              << " at " << rows.size() / rowsTimer.elapsed_wall() << "/second and "
              << rows.size() / rowsTimer.elapsed_cpu() << " /cpu-second" << endl;
         
-        ML::Timer scanTimer;
+        Timer scanTimer;
 
         // Special but exceedingly common case: we sort by row hash.
 
-        ML::Spinlock mutex;
+        Spinlock mutex;
         std::vector<std::tuple<RowHash, NamedRowValue, std::vector<ExpressionValue> > >
             sorted;
 
@@ -760,7 +760,7 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
                         selectOutput.mergeToRowDestructive(outputRow.columns);
                     }
 
-                    std::unique_lock<ML::Spinlock> guard(mutex);
+                    std::unique_lock<Spinlock> guard(mutex);
                     sorted.emplace_back(outputRow.rowHash,
                                         std::move(outputRow),
                                         std::move(calcd));
@@ -773,7 +773,7 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
                     return true;
                 } catch (...) {
                     rethrowHttpException(KEEP_HTTP_CODE,
-                                         "Executing non-grouped query bound to row: " + ML::getExceptionString(),
+                                         "Executing non-grouped query bound to row: " + getExceptionString(),
                                          "row", row,
                                          "rowHash", rows[rowNum],
                                          "rowNum", rowNum);
@@ -915,7 +915,7 @@ struct RowHashOrderedExecutor: public BoundSelectQuery::Executor {
         if (limit == 0)
           throw HttpReturnException(400, "limit must be non-zero");
 
-        ML::Timer rowsTimer;
+        Timer rowsTimer;
 
         typedef std::vector<RowPath> AccumRows;
         
@@ -1139,7 +1139,7 @@ BoundSelectQuery(const SelectExpression & select,
 
     } JML_CATCH_ALL {
         rethrowHttpException(KEEP_HTTP_CODE, "Binding error: "
-                             + ML::getExceptionString(),
+                             + getExceptionString(),
                              "select", select.surface,
                              "from", from.getStatus(),
                              "where", where.shallowCopy(),
@@ -1185,7 +1185,7 @@ execute(std::function<bool (NamedRowValue & output,
         return executor->execute(processor, processInParallel, offset, limit, onProgress);
     } JML_CATCH_ALL {
         rethrowHttpException(KEEP_HTTP_CODE, "Execution error: "
-                             + ML::getExceptionString(),
+                             + getExceptionString(),
                              "select", select.surface,
                              "from", from.getStatus(),
                              "where", where.shallowCopy(),
@@ -1235,7 +1235,7 @@ executeExpr(std::function<bool (Path & rowName,
                                      offset, limit, onProgress);
     } JML_CATCH_ALL {
         rethrowHttpException(KEEP_HTTP_CODE, "Execution error: "
-                             + ML::getExceptionString(),
+                             + getExceptionString(),
                              "select", select.surface,
                              "from", from.getStatus(),
                              "where", where.shallowCopy(),

--- a/server/column_scope.cc
+++ b/server/column_scope.cc
@@ -180,7 +180,7 @@ runIncrementalT(const std::vector<BoundSqlExpression> & exprs,
         }
     }
 
-    //ML::Timer timer;
+    //Timer timer;
     //cerr << "doing rows" << endl;
     auto rowGen = dataset->generateRowsWhere(*this, "" /* alias */,
                                              *SqlExpression::TRUE,

--- a/server/credential_collection.cc
+++ b/server/credential_collection.cc
@@ -136,7 +136,7 @@ CredentialRuleCollection::
 getKey(CredentialRuleConfig & config)
 {
     if (config.id == "")
-        return ML::format("%016llx", (unsigned long long)Id(jsonEncodeStr(config)).hash());
+        return MLDB::format("%016llx", (unsigned long long)Id(jsonEncodeStr(config)).hash());
     return config.id;
 }
 
@@ -145,7 +145,7 @@ CredentialRuleCollection::
 setKey(CredentialRuleConfig & config, std::string key)
 {
     if (config.id != "" && config.id != key)
-        throw ML::Exception("attempt to put with a different key than created with");
+        throw MLDB::Exception("attempt to put with a different key than created with");
     config.id = key;
 }
 

--- a/server/dataset_collection.cc
+++ b/server/dataset_collection.cc
@@ -165,7 +165,7 @@ void runHttpQuery(std::function<std::vector<MatrixNamedRow> ()> runQuery,
 
         // First, find all columns
         std::vector<ColumnPath> columns;
-        ML::Lightweight_Hash<ColumnHash, int> columnIndex;
+        Lightweight_Hash<ColumnHash, int> columnIndex;
         for (auto & o: sparseOutput) {
             for (auto & c: o.columns) {
                 auto & columnName = std::get<0>(c);

--- a/server/dataset_context.cc
+++ b/server/dataset_context.cc
@@ -199,7 +199,7 @@ ExpressionValue
 SqlExpressionDatasetScope::RowScope::
 getColumnCount() const
 {
-    ML::Lightweight_Hash_Set<ColumnHash> columns;
+    Lightweight_Hash_Set<ColumnHash> columns;
     Date ts = Date::negativeInfinity();
 
     if (row) {
@@ -579,7 +579,7 @@ doCreateRowsWhereGenerator(const SqlExpression & where,
     auto res = dataset.generateRowsWhere(*this, alias, where, offset, limit);
     if (!res)
         throw HttpReturnException(500, "Dataset returned null generator",
-                                  "datasetType", ML::type_name(dataset));
+                                  "datasetType", MLDB::type_name(dataset));
     return res;
 }
 

--- a/server/dataset_utils.cc
+++ b/server/dataset_utils.cc
@@ -10,7 +10,6 @@
 #include <algorithm>
 
 using namespace std;
-using namespace ML;
 
 
 namespace MLDB {

--- a/server/mldb_runner.cc
+++ b/server/mldb_runner.cc
@@ -228,7 +228,7 @@ int main(int argc, char ** argv)
     }
 
     if (numThreads < minimumWorkerThreads) {
-        cerr << ML::format("'num-threads' cannot be less than %d: %d\n",
+        cerr << MLDB::format("'num-threads' cannot be less than %d: %d\n",
                            minimumWorkerThreads, numThreads);
         exit(1);
     }
@@ -275,7 +275,7 @@ int main(int argc, char ** argv)
             else if (val.type() == Json::nullValue) {
                 // skip
             }
-            else throw ML::Exception("Couldn't understand credentials " + val.toString());
+            else throw MLDB::Exception("Couldn't understand credentials " + val.toString());
 
             if (!fileCredentials.empty()) {
                 CredentialProvider::registerProvider
@@ -343,7 +343,7 @@ int main(int argc, char ** argv)
         string runner = "";
         if     (extension == ".js")   runner = "javascript";
         else if(extension == ".py")   runner = "python";
-        else throw ML::Exception("Unsupported extension '" +extension+ "'");
+        else throw MLDB::Exception("Unsupported extension '" +extension+ "'");
 
         HttpRestProxy proxy(server.httpBoundAddress);
 

--- a/server/mldb_server.cc
+++ b/server/mldb_server.cc
@@ -37,18 +37,19 @@
 
 using namespace std;
 
+
+namespace MLDB {
+
 namespace {
 bool supportsSystemRequirements() {
 #if JML_INTEL_ISA
-    return ML::has_sse42();
+    return has_sse42();
 #else
     return true;
 #endif
 }
-} // anonymous
+} // file scope
 
-
-namespace MLDB {
 
 // Creation functions exposed elsewhere
 std::shared_ptr<PluginCollection>

--- a/server/per_thread_accumulator.h
+++ b/server/per_thread_accumulator.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** per_thread_accumulator.h                                       -*- C++ -*-
     Jeremy Barnes, 30 July 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
     Object that allows map-reduce over multiple threads and accumulation
     at the end.
@@ -21,7 +20,7 @@ struct PerThreadAccumulator {
 
     std::mutex threadsLock;
     std::vector<std::shared_ptr<Payload> > threads;
-    ML::ThreadSpecificInstanceInfo<std::shared_ptr<Payload>, void> payloadPerThread;
+    ThreadSpecificInstanceInfo<std::shared_ptr<Payload>, void> payloadPerThread;
 
     std::function<Payload * ()> createPayload;
     std::function<void (Payload *)> destroyPayload;

--- a/server/plugin_resource.cc
+++ b/server/plugin_resource.cc
@@ -107,7 +107,7 @@ ScriptLanguage parseScriptLanguage(const std::string lang)
 {
     if(lang == "python")        return PYTHON;
     if(lang == "javascript")    return JAVASCRIPT;
-    throw ML::Exception("Unknown language");
+    throw MLDB::Exception("Unknown language");
 }
 
 /*****************************************************************************/
@@ -124,7 +124,7 @@ LoadedPluginResource(ScriptLanguage lang, ScriptType type,
     scriptType = type;
 
     if(!url.empty() && !resource.source.empty())
-        throw ML::Exception("Cannot specify both address and source for plugin");
+        throw MLDB::Exception("Cannot specify both address and source for plugin");
 
     // if this is a plugin, we need to create a folder in the plugins folder
     // that we'll be keeping around
@@ -166,7 +166,7 @@ LoadedPluginResource(ScriptLanguage lang, ScriptType type,
     {
         if(!fs::exists(plugin_working_dir)) {
             if(!fs::create_directories(plugin_working_dir))
-                throw ML::Exception("Unable to create plugin directory: " +
+                throw MLDB::Exception("Unable to create plugin directory: " +
                         plugin_working_dir.string());
         }
 
@@ -191,13 +191,13 @@ LoadedPluginResource(ScriptLanguage lang, ScriptType type,
         fs::path symlink;
 
         if (!fs::exists(source)) {
-            throw ML::Exception("Source does not exist");
+            throw MLDB::Exception("Source does not exist");
         }
 
         // if a file at the end, symlink main.xx to that file
         if(!fs::is_directory(source)) {
             if(!fs::create_directories(plugin_working_dir)) {
-                throw ML::Exception("Unable to create plugin directory: " +
+                throw MLDB::Exception("Unable to create plugin directory: " +
                                     plugin_working_dir.string());
             }
             symlink = fs::path(getElementLocation(MAIN));
@@ -247,7 +247,7 @@ LoadedPluginResource(ScriptLanguage lang, ScriptType type,
             urlToClone = urlToClone.substr(0, hashLocation);
         }
 
-        cerr << ML::format("Cloning GIST %s -> %s", urlToClone, plugin_working_dir.string()) << endl;
+        cerr << MLDB::format("Cloning GIST %s -> %s", urlToClone, plugin_working_dir.string()) << endl;
 
         git_libgit2_init();
 
@@ -270,9 +270,9 @@ LoadedPluginResource(ScriptLanguage lang, ScriptType type,
         if(rtn != 0) {
             const git_error *err = giterr_last();
             JML_TRACE_EXCEPTIONS(false);
-            if (err) throw ML::Exception(ML::format("Git ERROR %d for %s: %s\n",
+            if (err) throw MLDB::Exception(MLDB::format("Git ERROR %d for %s: %s\n",
                                             err->klass, urlToClone, err->message));
-            else throw ML::Exception("Git ERROR %d: no detailed info\n", rtn);
+            else throw MLDB::Exception("Git ERROR %d: no detailed info\n", rtn);
         }
 
         if(commitHash != "") {
@@ -280,7 +280,7 @@ LoadedPluginResource(ScriptLanguage lang, ScriptType type,
 
             int error = git_revparse_single(&treeish, repo, commitHash.c_str());
             if(error != 0 || !treeish) {
-                throw ML::Exception(ML::format("Error checking out commit '%s' for "
+                throw MLDB::Exception(MLDB::format("Error checking out commit '%s' for "
                             "repository '%s'", commitHash, urlToClone));
             }
 
@@ -329,7 +329,7 @@ LoadedPluginResource(ScriptLanguage lang, ScriptType type,
 
     }
     else {
-        throw ML::Exception("Unsupported URL: " + url.toString());
+        throw MLDB::Exception("Unsupported URL: " + url.toString());
     }
 }
 
@@ -362,14 +362,14 @@ getElementFilename(PackageElement elem) const
         case ROUTES:    return "routes";
         case STATUS:    return "status";
     }
-    throw ML::Exception("Unsupported elem!");
+    throw MLDB::Exception("Unsupported elem!");
 }
 
 string LoadedPluginResource::
 getElementLocation(PackageElement elem) const
 {
     if(pluginLocation == SOURCE)
-        throw ML::Exception("no entrypoint for plugin configured with source");
+        throw MLDB::Exception("no entrypoint for plugin configured with source");
 
     string extension;
 
@@ -381,7 +381,7 @@ getElementLocation(PackageElement elem) const
         extension = "js";
         break;
     default:
-        throw ML::Exception("unknown plugin language");
+        throw MLDB::Exception("unknown plugin language");
     }
     
     return (fs::path(plugin_working_dir) / 
@@ -430,7 +430,7 @@ getScriptUri(PackageElement elem) const
         extension = "js";
         break;
     default:
-        throw ML::Exception("unknown plugin language");
+        throw MLDB::Exception("unknown plugin language");
     }
 
     std::string urlStr = url.toString();

--- a/server/plugin_resource.h
+++ b/server/plugin_resource.h
@@ -61,7 +61,7 @@ struct PackageElementSources {
             case ROUTES:    return routes;
             case STATUS:    return status;
         }
-        throw ML::Exception("Unknown PackageElem");
+        throw MLDB::Exception("Unknown PackageElem");
     }
 };
 

--- a/server/procedure_run_collection.cc
+++ b/server/procedure_run_collection.cc
@@ -118,12 +118,12 @@ getKey(ProcedureRunConfig & config)
     // 1.  Newly seeded random number based on current time
     // 2.  Thread ID
     Utf8String disambig
-        = ML::format("%d-%d", random())
+        = MLDB::format("%d-%d", random())
         + Date::now().print(9)
         + std::to_string(std::hash<std::thread::id>()(std::this_thread::get_id()));
     
     // Create an auto hash that is cleary identified as one
-    return config.id = ML::format("%s-%016llx",
+    return config.id = MLDB::format("%s-%016llx",
                                   Date::now().printIso8601(6).c_str(),
                                   (unsigned long long)jsonHash(jsonEncode(config)));
 }

--- a/server/script_output.h
+++ b/server/script_output.h
@@ -174,7 +174,7 @@ struct ScriptOutput {
     unsigned getReturnCode() const
     {
         if(_return_code == 0)
-            throw ML::Exception("Script return_code is set to 0. This should "
+            throw MLDB::Exception("Script return_code is set to 0. This should "
                     "never happen.");
 
         return _return_code;

--- a/server/static_content_handler.cc
+++ b/server/static_content_handler.cc
@@ -190,7 +190,7 @@ getStaticRouteHandler(string dir, MldbServer * server, bool hideInternalEntities
             const string & path = context.resources.back().rawString();
 
             if (path.find("..") != string::npos) {
-                throw ML::Exception("not dealing with path with .. in it");
+                throw MLDB::Exception("not dealing with path with .. in it");
             }
 
             string filename = (fs::path(dir) / fs::path(path)).string();

--- a/server/static_content_macro.cc
+++ b/server/static_content_macro.cc
@@ -93,7 +93,7 @@ static std::string getTypeName(const ValueDescription & description,
     }
     case ValueKind::ANY:       return description.typeName == "Json::Value" ? "JSON" : printTypeName(description.typeName);
     default:
-        throw ML::Exception("Unknown description kind");
+        throw MLDB::Exception("Unknown description kind");
     }
 }
 
@@ -134,7 +134,7 @@ static void renderType(MacroContext & context,
                         context.writeHtml(",");
                     }
                     context.writeHtml(
-                        ML::format("\n        \"%s\": &lt;%s&gt;",
+                        MLDB::format("\n        \"%s\": &lt;%s&gt;",
                                    fd.fieldName.c_str(),
                                    getTypeName(*fd.description,
                                                context.server).c_str()));
@@ -147,7 +147,7 @@ static void renderType(MacroContext & context,
 
             auto onField = [&] (const ValueDescription::FieldDescription & fd)
                 {
-                    context.writeHtml(ML::format("<tr><td align='right'><p><strong>%s</strong> <br/> <nobr>%s</nobr> <br/> <code>%s</code></p></td><td>%s</td></tr>\n",
+                    context.writeHtml(MLDB::format("<tr><td align='right'><p><strong>%s</strong> <br/> <nobr>%s</nobr> <br/> <code>%s</code></p></td><td>%s</td></tr>\n",
                                          fd.fieldName.c_str(),
                                          getTypeName(*fd.description, context.server).c_str(),
                                          getDefaultValue(*fd.description).c_str(),
@@ -161,7 +161,7 @@ static void renderType(MacroContext & context,
         context.writeHtml("<h4>Enumeration <code>" + printTypeName(cppType.rawString()) +"</code></h4>");
         context.writeHtml("<table class=\"params table\"><tr><th>Value</th><th>Description</th></tr>\n");
         for (auto & v: vd->getEnumValues()) {
-            context.writeHtml(ML::format("<tr><td><code>%s</code></td><td><p>%s</td></tr>\n",
+            context.writeHtml(MLDB::format("<tr><td><code>%s</code></td><td><p>%s</td></tr>\n",
                                  std::get<1>(v).c_str(),
                                  std::get<2>(v).c_str()));
         }

--- a/server/type_collection.cc
+++ b/server/type_collection.cc
@@ -65,7 +65,7 @@ struct TypeCollection: public RestCollection<Utf8String, TypeEntry> {
                    const Utf8String & nounPlural,
                    MldbServer * server, RestEntity * parent)
         : RestCollection<Utf8String, TypeEntry>(nounSingular, nounPlural, parent),
-          parent(parent), name(ML::type_name<Base>()),
+          parent(parent), name(MLDB::type_name<Base>()),
           server(server)
     {
         entryWatch = PolyCollection<Base>::watchTypes(true /* catchup */);
@@ -148,7 +148,7 @@ struct TypeCollection: public RestCollection<Utf8String, TypeEntry> {
 
     bool isCollection() const { return true; }
     
-    Utf8String getDescription() const { return "Collection of classes of type " + ML::type_name<Base>(); }
+    Utf8String getDescription() const { return "Collection of classes of type " + MLDB::type_name<Base>(); }
 
     Utf8String getName() const { return name; }
 

--- a/soa/credentials/credential_provider.cc
+++ b/soa/credentials/credential_provider.cc
@@ -83,7 +83,7 @@ getCredential(const std::string & resourceType,
         return bestMatch->credential;
     }
 
-    throw ML::Exception("No credentials found for " + resourceType + " "
+    throw MLDB::Exception("No credentials found for " + resourceType + " "
                         + resource);
 }
 

--- a/soa/service/aws.cc
+++ b/soa/service/aws.cc
@@ -234,7 +234,7 @@ uriEncode(const std::string & str)
 
         if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
             result += c;
-        else result += ML::format("%%%02X", c);
+        else result += MLDB::format("%%%02X", c);
     }
 
     return result;
@@ -252,11 +252,11 @@ AwsApi::
 escapeResource(const std::string & resource)
 {
     if (resource.size() == 0) {
-        throw ML::Exception("empty resource name");
+        throw MLDB::Exception("empty resource name");
     }
 
     if (resource[0] != '/') {
-        throw ML::Exception("resource name must start with a '/'");
+        throw MLDB::Exception("resource name must start with a '/'");
     }
 
     return "/" + uriEncode(resource.substr(1));
@@ -588,7 +588,7 @@ perform(const BasicRequest & request,
         }
     }
 
-    throw ML::Exception("failed request after %d retries", retries);
+    throw MLDB::Exception("failed request after %d retries", retries);
 }
 
 std::string

--- a/soa/service/connectfd.cc
+++ b/soa/service/connectfd.cc
@@ -36,7 +36,7 @@ int connectHostDgram(const std::string & hostname, int port)
 
     s = getaddrinfo(hostname.c_str(), std::to_string(port).c_str(), &hints, &result);
     if (s != 0) {
-        throw ML::Exception("getaddrinfo: %s\n", gai_strerror(s));
+        throw MLDB::Exception("getaddrinfo: %s\n", gai_strerror(s));
     }
 
     /* getaddrinfo() returns a list of address structures.
@@ -87,7 +87,7 @@ int connectHost(const std::string & hostname, int port)
 
     s = getaddrinfo(hostname.c_str(), std::to_string(port).c_str(), &hints, &result);
     if (s != 0) {
-        throw ML::Exception("getaddrinfo: %s\n", gai_strerror(s));
+        throw MLDB::Exception("getaddrinfo: %s\n", gai_strerror(s));
     }
 
     /* getaddrinfo() returns a list of address structures.

--- a/soa/service/event_service.cc
+++ b/soa/service/event_service.cc
@@ -140,9 +140,9 @@ recordEventFmt(EventType type,
     try {
         int res = vsnprintf(buf, 2048, fmt, ap);
         if (res < 0)
-            throw ML::Exception("unable to record hit with fmt");
+            throw MLDB::Exception("unable to record hit with fmt");
         if (res >= 2048)
-            throw ML::Exception("key is too long");
+            throw MLDB::Exception("key is too long");
             
         recordEvent(buf, type, value);
         va_end(ap);

--- a/soa/service/event_service.h
+++ b/soa/service/event_service.h
@@ -104,7 +104,7 @@ struct EventRecorder {
     void recordHit(const std::string & event, Args... args) const
     {
         return recordEventFmt(ET_HIT, 1.0, {}, event.c_str(),
-                              ML::forwardForPrintf(args)...);
+                              forwardForPrintf(args)...);
     }
 
     template<typename... Args>
@@ -112,7 +112,7 @@ struct EventRecorder {
     void recordHit(const char * event, Args... args) const
     {
         return recordEventFmt(ET_HIT, 1.0, {}, event,
-                              ML::forwardForPrintf(args)...);
+                              forwardForPrintf(args)...);
     }
 
     void recordHit(const char * event) const
@@ -129,7 +129,7 @@ struct EventRecorder {
     void recordCount(float count, const std::string & event, Args... args) const
     {
         return recordEventFmt(ET_COUNT, count, {}, event.c_str(),
-                              ML::forwardForPrintf(args)...);
+                              forwardForPrintf(args)...);
     }
     
     template<typename... Args>
@@ -137,7 +137,7 @@ struct EventRecorder {
     void recordCount(float count, const char * event, Args... args) const
     {
         return recordEventFmt(ET_COUNT, count, {}, event,
-                              ML::forwardForPrintf(args)...);
+                              forwardForPrintf(args)...);
     }
 
     void recordCount(float count, const char * event) const
@@ -154,14 +154,14 @@ struct EventRecorder {
     void recordOutcome(float outcome, const std::string & event, Args... args) const
     {
         return recordEventFmt(ET_OUTCOME, outcome, DefaultOutcomePercentiles, event.c_str(),
-                             ML::forwardForPrintf(args)...);
+                             forwardForPrintf(args)...);
     }
     
     template<typename... Args>
     void recordOutcome(float outcome, const char * event, Args... args) const
     {
         return recordEventFmt(ET_OUTCOME, outcome, DefaultOutcomePercentiles, event,
-                              ML::forwardForPrintf(args)...);
+                              forwardForPrintf(args)...);
     }
 
     void recordOutcome(float outcome, const char * event) const
@@ -179,7 +179,7 @@ struct EventRecorder {
                                const std::string& event, Args... args) const
     {
         return recordEventFmt(ET_OUTCOME, outcome, percentiles, event.c_str(),
-                             ML::forwardForPrintf(args)...);
+                             forwardForPrintf(args)...);
     }
 
     template<typename... Args>
@@ -187,7 +187,7 @@ struct EventRecorder {
                                const char * event, Args... args) const
     {
         return recordEventFmt(ET_OUTCOME, outcome, percentiles, event,
-                              ML::forwardForPrintf(args)...);
+                              forwardForPrintf(args)...);
     }
 
     void recordOutcomeCustom(float outcome, std::initializer_list<int> percentiles,
@@ -206,14 +206,14 @@ struct EventRecorder {
     void recordLevel(float level, const std::string & event, Args... args) const
     {
         return recordEventmt(ET_LEVEL, level, {}, event.c_str(),
-                             ML::forwardForPrintf(args)...);
+                             forwardForPrintf(args)...);
     }
     
     template<typename... Args>
     void recordLevel(float level, const char * event, Args... args) const
     {
         return recordEventFmt(ET_LEVEL, level, {}, event,
-                              ML::forwardForPrintf(args)...);
+                              forwardForPrintf(args)...);
     }
 
     void recordLevel(float level, const char * event) const
@@ -230,14 +230,14 @@ struct EventRecorder {
     void recordStableLevel(float level, const std::string & event, Args... args) const
     {
         return recordEventmt(ET_STABLE_LEVEL, level, {}, event.c_str(),
-                             ML::forwardForPrintf(args)...);
+                             forwardForPrintf(args)...);
     }
 
     template<typename... Args>
     void recordStableLevel(float level, const char * event, Args... args) const
     {
         return recordEventFmt(ET_STABLE_LEVEL, level, {}, event,
-                              ML::forwardForPrintf(args)...);
+                              forwardForPrintf(args)...);
     }
 
     void recordStableLevel(float level, const char * event) const

--- a/soa/service/loop_monitor.cc
+++ b/soa/service/loop_monitor.cc
@@ -47,7 +47,7 @@ void
 LoopMonitor::
 doLoops(uint64_t numTimeouts)
 {
-    std::lock_guard<ML::Spinlock> guard(lock);
+    std::lock_guard<Spinlock> guard(lock);
 
     LoadSample maxLoad;
     maxLoad.sequence = curLoad.sequence + 1;
@@ -92,7 +92,7 @@ void
 LoopMonitor::
 addCallback(const string& name, const SampleLoadFn& cb)
 {
-    std::lock_guard<ML::Spinlock> guard(lock);
+    std::lock_guard<Spinlock> guard(lock);
 
     auto ret = loops.insert(make_pair(name, cb));
     ExcCheck(ret.second, "loop already being monitored: " + name);
@@ -102,7 +102,7 @@ void
 LoopMonitor::
 remove(const string& name)
 {
-    std::lock_guard<ML::Spinlock> guard(lock);
+    std::lock_guard<Spinlock> guard(lock);
 
     size_t ret = loops.erase(name);
     ExcCheckEqual(ret, 1, "loop is not monitored: " + name);

--- a/soa/service/multi_aggregator.h
+++ b/soa/service/multi_aggregator.h
@@ -138,7 +138,7 @@ private:
 
     // Cache of lookups for each thread to avoid needing to acquire a lock
     // very much.
-    ML::ThreadSpecificInstanceInfo<LookupCache, void> lookupCache;
+    ThreadSpecificInstanceInfo<LookupCache, void> lookupCache;
 
     /** Look for the aggregator for this given stat.  If it doesn't exist,
         then initialize it from the given function.

--- a/soa/service/process_stats.cc
+++ b/soa/service/process_stats.cc
@@ -59,13 +59,13 @@ enum ProcLoadAvgFields {
 vector<string> readProcFile(const string& procFile) {
     ifstream ifs(procFile);
     if (ifs.fail()) {
-        throw ML::Exception ("Unable to open proc file " + procFile);
+        throw MLDB::Exception ("Unable to open proc file " + procFile);
     }
 
     std::array<char, 1024> buffer;
     ifs.getline(&buffer[0], buffer.max_size());
     if (ifs.fail() || ifs.eof()) {
-        throw ML::Exception ("Unable to read proc file " + procFile);
+        throw MLDB::Exception ("Unable to read proc file " + procFile);
     }
 
     std::string rawStats = &buffer[0];

--- a/soa/service/sns_send.cc
+++ b/soa/service/sns_send.cc
@@ -20,7 +20,6 @@ namespace po = boost::program_options;
 
 using namespace std;
 using namespace MLDB;
-using namespace ML;
 
 int main(int argc, char* argv[])
 {
@@ -72,7 +71,7 @@ int main(int argc, char* argv[])
     }
 
     if (message.empty())
-        throw ML::Exception("must specify a message");
+        throw MLDB::Exception("must specify a message");
     if (message[0] == '@') {
         filter_istream stream(string(message, 1));
         string msg;

--- a/soa/service/sqs.cc
+++ b/soa/service/sqs.cc
@@ -64,7 +64,7 @@ extractMessage(const tinyxml2::XMLNode * messageNode)
                     message.approximateReceiveCount = stoi(attrValue);
                 }
                 else {
-                    throw ML::Exception("unexpected attribute name: "
+                    throw MLDB::Exception("unexpected attribute name: "
                                         + attrName);
                 }
             }
@@ -151,7 +151,7 @@ createQueue(const std::string & queueName,
                      to_string(params.messageRetentionPeriod));
     }
     if (params.policy.size() > 0) {
-        throw ML::Exception("'policy' not supported yet");
+        throw MLDB::Exception("'policy' not supported yet");
     }
     if (params.receiveMessageWaitTimeSeconds > -1) {
         addAttribute("ReceiveMessageWaitTimeSeconds",
@@ -267,7 +267,7 @@ getQueueAttributes(const std::string & queueUri)
                 attributes.visibilityTimeout = stoi(attrValue);
             }
             else {
-                throw ML::Exception("unexpected attribute name: "
+                throw MLDB::Exception("unexpected attribute name: "
                                     + attrName);
             }
         }
@@ -530,7 +530,7 @@ getQueueResource(const std::string & queueUri) const
     ExcAssert(!serviceUri.empty());
 
     if (queueUri.find(serviceUri) != 0)
-        throw ML::Exception("unknown queue URI");
+        throw MLDB::Exception("unknown queue URI");
     string resource(queueUri, serviceUri.size());
 
     return resource;
@@ -548,7 +548,7 @@ rightToString(enum SqsApi::Rights rights)
     case GetQueueUrl: return "GetQueueUrl";
     case All: return "*";
     default:
-        throw ML::Exception("unknown right");
+        throw MLDB::Exception("unknown right");
     };
 }
 

--- a/soa/service/stat_aggregator.cc
+++ b/soa/service/stat_aggregator.cc
@@ -92,7 +92,7 @@ read(const std::string & prefix)
 
 GaugeAggregator::
 GaugeAggregator(Verbosity verbosity, const std::vector<int>& extra)
-    : verbosity(verbosity), values(new ML::distribution<float>())
+    : verbosity(verbosity), values(new distribution<float>())
     , extra(extra)
 {
     if (verbosity == Outcome)
@@ -113,7 +113,7 @@ void
 GaugeAggregator::
 record(float value)
 {
-    ML::distribution<float> * current;
+    distribution<float> * current;
     while ((current = values) == 0
            || !values.compare_exchange_weak(current, nullptr));
     
@@ -123,12 +123,12 @@ record(float value)
     values = current;
 }
 
-std::pair<ML::distribution<float> *, Date>
+std::pair<distribution<float> *, Date>
 GaugeAggregator::
 reset()
 {
-    ML::distribution<float> * current;
-    ML::distribution<float> * new_current = new ML::distribution<float>();
+    distribution<float> * current;
+    distribution<float> * new_current = new distribution<float>();
     new_current->reserve(100);
 
     while ((current = values) == 0
@@ -144,12 +144,12 @@ std::vector<StatReading>
 GaugeAggregator::
 read(const std::string & prefix)
 {
-    ML::distribution<float> * values;
+    distribution<float> * values;
     Date oldStart;
 
     std::tie(values, oldStart) = reset();
 
-    std::auto_ptr<ML::distribution<float> > vptr(values);
+    std::auto_ptr<distribution<float> > vptr(values);
 
     if (values->empty())
         return vector<StatReading>();
@@ -185,7 +185,7 @@ read(const std::string & prefix)
         if (verbosity == Outcome) {
             addMetric("count", values->size());
             for (int pct: extra) {
-                addMetric(ML::format("upper_%d", pct).c_str(), percentile(pct));
+                addMetric(MLDB::format("upper_%d", pct).c_str(), percentile(pct));
             }
         }
     }

--- a/soa/service/stat_aggregator.h
+++ b/soa/service/stat_aggregator.h
@@ -106,7 +106,7 @@ struct GaugeAggregator : public StatAggregator {
     virtual void record(float value);
 
     /** Obtain a the current statistics and replace with a new version. */
-    std::pair<ML::distribution<float> *, Date> reset();
+    std::pair<distribution<float> *, Date> reset();
 
     /** Read and reset the counter, providing output in Graphite's preferred
         format.
@@ -116,7 +116,7 @@ struct GaugeAggregator : public StatAggregator {
 private:
     Verbosity verbosity;
     Date start;  //< Date at which we last cleared the counter
-    std::atomic<ML::distribution<float> *> values;  //< List of added values
+    std::atomic<distribution<float> *> values;  //< List of added values
     std::vector<int> extra;
 };
 

--- a/soa/service/statsd_connector.cc
+++ b/soa/service/statsd_connector.cc
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /* statsd_connector.cc
    Nicolas Kruchten
    Copyright (c) 2011 Datacratic.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
 */
 
@@ -19,7 +18,6 @@
 
 
 using namespace std;
-using namespace ML;
 
 namespace MLDB {
 
@@ -52,7 +50,7 @@ open(const string& statsdAddr)
 {
     auto lastColon = statsdAddr.rfind(':');
     if (lastColon == string::npos)
-        throw ML::Exception("Need a host and portname to connect to statsd: passed '%s'",
+        throw MLDB::Exception("Need a host and portname to connect to statsd: passed '%s'",
                             statsdAddr.c_str());
 
     int newFd = connectHostDgram(string(statsdAddr, 0, lastColon),

--- a/soa/service/testing/endpoint_closed_connection_test.cc
+++ b/soa/service/testing/endpoint_closed_connection_test.cc
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE( test_protocol_dump )
                     while (current != end) {
                         res = send(fd, current, end - current, MSG_NOSIGNAL);
                         if (res == -1)
-                            throw ML::Exception(errno, "send()");
+                            throw MLDB::Exception(errno, "send()");
                         current += res;
                     }
                     
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE( test_protocol_dump )
                     //cerr << "shutdown reader " << res << " " << strerror(errno)
                     //<< endl;
                     if (res == -1)
-                        throw ML::Exception(errno, "shutdown");
+                        throw MLDB::Exception(errno, "shutdown");
                     
                     ExcAssertEqual((void *)current, (void *)end);
                     
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE( test_protocol_dump )
 
                     res = poll(fds, 1, 500 /* ms timeout */);
                     if (res == -1)
-                        throw ML::Exception(errno, "poll");
+                        throw MLDB::Exception(errno, "poll");
 
                     if (res == 0) {
                         cerr << "fd " << fd << " timed out after 500ms"
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE( test_protocol_dump )
                     char buf[16384];
                     res = recv(fd, buf, 16384, 0);
                     if (res == -1)
-                        throw ML::Exception(errno, "recv");
+                        throw MLDB::Exception(errno, "recv");
                     
                     //double timeTaken = Date::now().secondsSince(before);
                     //cerr << "took " << timeTaken * 1000 << "ms" << endl;
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE( test_protocol_dump )
                 //cerr << "shutdown reader " << res << " " << strerror(errno)
                 //<< endl;
                 //if (res == -1)
-                //    throw ML::Exception(errno, "shutdown");
+                //    throw MLDB::Exception(errno, "shutdown");
 
                 // Wait for the other end to close down
                 //char buf[16384];
@@ -181,22 +181,22 @@ BOOST_AUTO_TEST_CASE( test_protocol_dump )
                 //cerr << "recv " << res << " " << strerror(errno)
                 //<< endl;
                 //if (res == -1)
-                //    throw ML::Exception(errno, "recv");
+                //    throw MLDB::Exception(errno, "recv");
                 //if (res != 0)
-                //    throw ML::Exception("got garbage");
+                //    throw MLDB::Exception("got garbage");
                 
                 // Close our writing half
                 //res = ::shutdown(fd, SHUT_RD);
                 //cerr << "shutdown writer " << res << " " << strerror(errno)
                 //<< endl;
                 if (res == -1)
-                    throw ML::Exception(errno, "shutdown");
+                    throw MLDB::Exception(errno, "shutdown");
             
                 res = close(fd);
                 //cerr << "close " << res << " " << strerror(errno)
                 //<< endl;
                 if (res == -1)
-                    throw ML::Exception(errno, "close");
+                    throw MLDB::Exception(errno, "close");
             }            
         };
     

--- a/soa/service/testing/endpoint_unit_test.cc
+++ b/soa/service/testing/endpoint_unit_test.cc
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE( test_passive_endpoint_create_no_fds )
 
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(endpoint.init(), ML::Exception);
+        BOOST_CHECK_THROW(endpoint.init(), MLDB::Exception);
     }
 
     endpoint.shutdown();

--- a/soa/service/testing/sns_mock_test.cc
+++ b/soa/service/testing/sns_mock_test.cc
@@ -20,7 +20,7 @@ struct MockSnsApiWrapper : SnsApiWrapper {
 
         MockSnsApiWrapper(int cacheSize = 0) : cacheSize(cacheSize){
             if (cacheSize < 0) {
-                throw ML::Exception("Cache size cannot be below 0");
+                throw MLDB::Exception("Cache size cannot be below 0");
             }
         }
 

--- a/soa/service/xml_helpers.cc
+++ b/soa/service/xml_helpers.cc
@@ -30,7 +30,7 @@ extractNode(const tinyxml2::XMLNode * element, const string & path)
         p = p->FirstChildElement(splitPath[i].c_str());
         if (!p) {
             //element->GetDocument()->Print();
-            throw ML::Exception("required key " + splitPath[i]
+            throw MLDB::Exception("required key " + splitPath[i]
                                 + " not found on path " + path);
         }
     }

--- a/soa/service/xml_helpers.h
+++ b/soa/service/xml_helpers.h
@@ -25,7 +25,7 @@ T extract(const tinyxml2::XMLNode * element, const std::string & path)
     using namespace std;
 
     if (!element)
-        throw ML::Exception("can't extract from missing element");
+        throw MLDB::Exception("can't extract from missing element");
     //tinyxml2::XMLHandle handle(element);
 
     vector<string> splitPath = ML::split(path, '/');

--- a/sql/builtin_dataset_functions.cc
+++ b/sql/builtin_dataset_functions.cc
@@ -58,7 +58,7 @@ struct RegisterBuiltin {
                     return function(context, args, options, alias);
                 } JML_CATCH_ALL {
                     rethrowHttpException(-1, "Binding builtin Dataset function "
-                                         + str + ": " + ML::getExceptionString(),
+                                         + str + ": " + getExceptionString(),
                                          "functionName", str);
                 }
             };

--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -95,7 +95,7 @@ struct RegisterBuiltinUnaryScalar {
                 } JML_CATCH_ALL {
                     rethrowHttpException(-1, "Executing builtin function "
                                          + functionName
-                                         + ": " + ML::getExceptionString(),
+                                         + ": " + getExceptionString(),
                                          "functionName", functionName,
                                          "functionArgs", args);
                 }
@@ -250,7 +250,7 @@ struct RegisterBuiltinUnaryScalar {
                 } JML_CATCH_ALL {
                     rethrowHttpException(-1, "Binding builtin function "
                                          + functionName + ": "
-                                         + ML::getExceptionString(),
+                                         + getExceptionString(),
                                          "functionName", functionName,
                                          "functionArgs", args);
                 }
@@ -335,7 +335,7 @@ struct RegisterBuiltinBinaryScalar {
                 } JML_CATCH_ALL {
                     rethrowHttpException(-1, "Executing builtin function "
                                          + functionName
-                                         + ": " + ML::getExceptionString(),
+                                         + ": " + getExceptionString(),
                                          "functionName", functionName,
                                          "functionArgs", args);
                 }
@@ -691,7 +691,7 @@ struct RegisterBuiltinBinaryScalar {
                 } JML_CATCH_ALL {
                     rethrowHttpException(-1, "Binding builtin function "
                                          + functionName + ": "
-                                         + ML::getExceptionString(),
+                                         + getExceptionString(),
                                          "functionName", functionName,
                                          "functionArgs", args);
                 }
@@ -990,7 +990,7 @@ struct RegexHelper {
         } JML_CATCH_ALL {
             rethrowHttpException
                 (400, "Error when extracting regex from argument '"
-                 + expr.expr->surface + "': " + ML::getExceptionString()
+                 + expr.expr->surface + "': " + getExceptionString()
                  + ".  Regular expressions need to be strings.",
                  "expr", expr,
                  "value", val);
@@ -1001,7 +1001,7 @@ struct RegexHelper {
             rethrowHttpException
                 (400, "Error when compiling regex '"
                  + regexStr + "' from expression " + expr.expr->surface + "': "
-                 + ML::getExceptionString()
+                 + getExceptionString()
                  + ".  Regular expressions must adhere to Perl-style "
                  + "regular expression syntax.",
                  "expr", expr,
@@ -1398,7 +1398,7 @@ BoundFunction jaccard_index(const std::vector<BoundSqlExpression> & args)
                  const SqlRowScope & scope) -> ExpressionValue
             {
                 if(!args[0].isRow() || !args[1].isRow())
-                    throw ML::Exception("The arguments passed to the jaccard_index must be two "
+                    throw MLDB::Exception("The arguments passed to the jaccard_index must be two "
                         "row expressions");
 
                 set<Path> a, b;
@@ -1692,7 +1692,7 @@ BoundFunction date_trunc(const std::vector<BoundSqlExpression> & args)
 
 static RegisterBuiltin registerdate_trunc(date_trunc, "date_trunc");
 
-void normalize(ML::distribution<double>& val, double p)
+void normalize(distribution<double>& val, double p)
 {
     if (p == 0) {
         double n = (val != 0).count();
@@ -1740,7 +1740,7 @@ void normalize(ML::distribution<double>& val, double p)
                           const SqlRowScope & scope) -> ExpressionValue
                      {
                          // Get it as an embedding
-                         ML::distribution<double> val
+                         distribution<double> val
                              = args.at(0).getEmbeddingDouble();
                          Date ts = args.at(0).getEffectiveTimestamp();
                          double p = args.at(1).toDouble();
@@ -1777,7 +1777,7 @@ void normalize(ML::distribution<double>& val, double p)
                           const SqlRowScope & scope) -> ExpressionValue
                      {
                          // Get it as an embedding
-                         ML::distribution<double> val = args[0].getEmbeddingDouble();
+                         distribution<double> val = args[0].getEmbeddingDouble();
                          Date ts = args[0].getEffectiveTimestamp();
                          double p = args[1].toDouble();
 
@@ -1808,7 +1808,7 @@ BoundFunction norm(const std::vector<BoundSqlExpression> & args)
                  const SqlRowScope & scope) -> ExpressionValue
             {
                 // Get it as an embedding
-                ML::distribution<double> val = args[0].getEmbeddingDouble();
+                distribution<double> val = args[0].getEmbeddingDouble();
                 Date ts = args[0].getEffectiveTimestamp();
 
                 double p = args[1].toDouble();
@@ -1975,7 +1975,7 @@ BoundFunction tokenize(const std::vector<BoundSqlExpression> & args)
                     options = args[1].extractT<TokenizeOptions>();
                 }
 
-                ML::Parse_Context pcontext(text.rawData(), text.rawData(), text.rawLength());
+                ParseContext pcontext(text.rawData(), text.rawData(), text.rawLength());
 
                 std::unordered_map<Utf8String, int> bagOfWords;
 
@@ -2032,7 +2032,7 @@ BoundFunction token_extract(const std::vector<BoundSqlExpression> & args)
                     options = args[2].extractT<TokenizeOptions>();
                 }
                 
-                ML::Parse_Context pcontext(text.rawData(), text.rawData(), text.rawLength());
+                ParseContext pcontext(text.rawData(), text.rawData(), text.rawLength());
 
                 ExpressionValue result;
 
@@ -2305,32 +2305,32 @@ BoundFunction horizontal_latest(const std::vector<BoundSqlExpression> & args)
 static RegisterBuiltin registerHorizontal_Latest(horizontal_latest, "horizontal_latest");
 
 struct DiffOp {
-    static ML::distribution<double> apply(ML::distribution<double> & d1,
-                                          ML::distribution<double> & d2)
+    static distribution<double> apply(distribution<double> & d1,
+                                          distribution<double> & d2)
     {
         return d1 - d2;
     }
 };
 
 struct SumOp {
-    static ML::distribution<double> apply(ML::distribution<double> & d1,
-                                          ML::distribution<double> & d2)
+    static distribution<double> apply(distribution<double> & d1,
+                                          distribution<double> & d2)
     {
         return d1 + d2;
     }
 };
 
 struct ProductOp {
-    static ML::distribution<double> apply(ML::distribution<double> & d1,
-                                          ML::distribution<double> & d2)
+    static distribution<double> apply(distribution<double> & d1,
+                                          distribution<double> & d2)
     {
         return d1 * d2;
     }
 };
 
 struct QuotientOp {
-    static ML::distribution<double> apply(ML::distribution<double> & d1,
-                                          ML::distribution<double> & d2)
+    static distribution<double> apply(distribution<double> & d1,
+                                          distribution<double> & d2)
     {
         return d1 / d2;
     }
@@ -2373,7 +2373,7 @@ struct RegisterVectorOp {
                      const SqlRowScope & scope) -> ExpressionValue
                 {
                     checkArgsSize(args.size(), 2);
-                    ML::distribution<double> embedding1, embedding2;
+                    distribution<double> embedding1, embedding2;
                     std::shared_ptr<const void> token;
                     Date ts;
                     std::tie(embedding1, embedding2, token, ts)
@@ -2507,7 +2507,7 @@ BoundFunction length(const std::vector<BoundSqlExpression> & args)
              {
                 checkArgsSize(args.size(), 1);
                 //if(!args[0].isString())
-                    //throw ML::Exception("The parameter passed to the length "
+                    //throw MLDB::Exception("The parameter passed to the length "
                             //"function must be a string");
 
                 return ExpressionValue
@@ -2531,7 +2531,7 @@ BoundFunction levenshtein_distance(const std::vector<BoundSqlExpression> & args)
 
                 checkArgsSize(args.size(), 2);
                 if(!args[0].isString() || !args[1].isString())
-                    throw ML::Exception("The parameters passed to the levenshtein_distance "
+                    throw MLDB::Exception("The parameters passed to the levenshtein_distance "
                             "function must be strings");
 
                 const auto query = args[0].getAtom().toUtf8String().rawString();
@@ -2560,7 +2560,7 @@ BoundFunction levenshtein_distance(const std::vector<BoundSqlExpression> & args)
                 edlibFreeAlignResult(alignRes);
 
                 if(bestScore == -1)
-                    throw ML::Exception("Error computing Levenshtein distance");
+                    throw MLDB::Exception("Error computing Levenshtein distance");
 
                 return ExpressionValue(bestScore,
                                        args[0].getEffectiveTimestamp());
@@ -3366,7 +3366,7 @@ BoundFunction tryFct(const std::vector<BoundSqlExpression> & args)
             }
             catch (const std::exception & exc) {
                 return storage
-                = ExpressionValue(ML::getExceptionString(),
+                = ExpressionValue(getExceptionString(),
                                   Date::negativeInfinity());
             }
         },
@@ -3470,7 +3470,7 @@ bind(const std::vector<BoundSqlExpression> & args,
                     return bound(rowScope, GET_ALL);
                 } JML_CATCH_ALL {
                     rethrowHttpException(-1, "Executing builtin function "
-                                         + functionName + ": " + ML::getExceptionString(),
+                                         + functionName + ": " + getExceptionString(),
                                          "functionName", functionName,
                                          "functionArgs", args);
                 }
@@ -3481,7 +3481,7 @@ bind(const std::vector<BoundSqlExpression> & args,
         return result;
     } JML_CATCH_ALL {
         rethrowHttpException(-1, "Binding builtin function "
-                             + functionName + ": " + ML::getExceptionString(),
+                             + functionName + ": " + getExceptionString(),
                              "functionName", functionName,
                              "functionArgs", args);
     }
@@ -3528,7 +3528,7 @@ BoundFunction fetcher(const std::vector<BoundSqlExpression> & args)
                                               info.lastModified);
                 }
                 JML_CATCH_ALL {
-                    error = ExpressionValue(ML::getExceptionString(),
+                    error = ExpressionValue(getExceptionString(),
                                             Date::now());
                 }
                 result.emplace_back("content", content);

--- a/sql/builtin_functions.h
+++ b/sql/builtin_functions.h
@@ -131,7 +131,7 @@ struct RegisterBuiltin {
                             return fn(args, scope);
                         } JML_CATCH_ALL {
                             rethrowHttpException(-1, "Executing builtin function "
-                                                 + str + ": " + ML::getExceptionString(),
+                                                 + str + ": " + getExceptionString(),
                                                  "functionName", str,
                                                  "functionArgs", args);
                         }
@@ -140,7 +140,7 @@ struct RegisterBuiltin {
                     return result;
                 } JML_CATCH_ALL {
                     rethrowHttpException(-1, "Binding builtin function "
-                                         + str + ": " + ML::getExceptionString(),
+                                         + str + ": " + getExceptionString(),
                                          "functionName", str,
                                          "functionArgs", args);
                 }

--- a/sql/builtin_signal_functions.cc
+++ b/sql/builtin_signal_functions.cc
@@ -178,7 +178,7 @@ ExpressionValue fft(const std::vector<ExpressionValue> & args,
         if (direction == PFFFT_BACKWARD) {
             // The ifft doesn't rescale, so we do so here in order to
             // ensure that ifft(fft(x)) = x
-            ML::SIMD::vec_scale(data.get(), 1.0 / n, data.get(), numToScale);
+            SIMD::vec_scale(data.get(), 1.0 / n, data.get(), numToScale);
         }
         
         return ExpressionValue::embedding(args[0].getEffectiveTimestamp(),

--- a/sql/cell_value.cc
+++ b/sql/cell_value.cc
@@ -171,7 +171,7 @@ initString(const char * stringValue, size_t len, bool isUtf8, bool check)
             if (check) {
                 const char * end = utf8::find_invalid(stringValue, stringValue + len);
                 if (end != stringValue + len)
-                    throw ML::Exception("Invalid sequence within utf-8 string");
+                    throw MLDB::Exception("Invalid sequence within utf-8 string");
             }
             type = ST_UTF8_SHORT_STRING;
         }
@@ -187,7 +187,7 @@ initString(const char * stringValue, size_t len, bool isUtf8, bool check)
             if (check) {
                 const char * end = utf8::find_invalid(stringValue, stringValue + len);
                 if (end != stringValue + len)
-                    throw ML::Exception("Invalid sequence within utf-8 string");
+                    throw MLDB::Exception("Invalid sequence within utf-8 string");
             }
 
             type = ST_UTF8_LONG_STRING;
@@ -1215,12 +1215,12 @@ CellValue::printInterval() const
 
     if (year != 0)
     {
-        result.append(ML::format("%dY", year));
+        result.append(MLDB::format("%dY", year));
     }  
 
     if (monthsCount != 0)
     {
-        result.append(ML::format("%d MONTH", monthsCount));
+        result.append(MLDB::format("%d MONTH", monthsCount));
     } 
 
     if (timeInterval.days != 0)
@@ -1228,7 +1228,7 @@ CellValue::printInterval() const
         if (year != 0 || monthsCount != 0)
             result.append(" ");
 
-        result.append(ML::format("%dD", timeInterval.days));
+        result.append(MLDB::format("%dD", timeInterval.days));
     }   
 
     if (hours != 0 || minutes != 0 || secondCount != 0)
@@ -1237,11 +1237,11 @@ CellValue::printInterval() const
             result.append(" ");
 
         if (hours != 0)
-            result.append(ML::format("%dH %dM %gS", hours, minutes, secondCount));
+            result.append(MLDB::format("%dH %dM %gS", hours, minutes, secondCount));
         else if (minutes != 0)
-            result.append(ML::format("%dM %gS", minutes, secondCount));
+            result.append(MLDB::format("%dM %gS", minutes, secondCount));
         else
-            result.append(ML::format("%gS", secondCount));
+            result.append(MLDB::format("%gS", secondCount));
     }
 
     if (result.empty())
@@ -1441,7 +1441,7 @@ struct CellValueDescription: public ValueDescriptionT<CellValue> {
             }
             else if (v.isMember("interval")) {
                 std::string text = v["interval"].asString();
-                ML::Parse_Context context(text, text.c_str(), text.length());
+                ParseContext context(text, text.c_str(), text.length());
                 uint32_t months = 0;
                 uint32_t days = 0;
                 double seconds = 0.0f;

--- a/sql/cell_value_impl.h
+++ b/sql/cell_value_impl.h
@@ -103,7 +103,7 @@ CellValue(const char * stringValue, size_t length,
         initStringFromAscii(stringValue, length, false /* check validity */);
         break;
     default:
-        throw ML::Exception("Unknown string characteristic");
+        throw MLDB::Exception("Unknown string characteristic");
     }
 }
 

--- a/sql/execution_pipeline.cc
+++ b/sql/execution_pipeline.cc
@@ -96,7 +96,7 @@ tableScope(std::shared_ptr<LexicalScope> table)
                                std::make_move_iterator(outputAdded.begin()),
                                std::make_move_iterator(outputAdded.end()));
 
-    //cerr << "table scope for " << ML::type_name(*table) << " goes from "
+    //cerr << "table scope for " << MLDB::type_name(*table) << " goes from "
     //     << entry.fieldOffset << " to " << result->numOutputFields()
     //     << endl;
 

--- a/sql/execution_pipeline_impl.cc
+++ b/sql/execution_pipeline_impl.cc
@@ -1342,8 +1342,8 @@ createOutputScope()
         ->tableScope(std::make_shared<JoinLexicalScope>(rootScope, leftScope, rightScope));
 
 #if 0
-    cerr << "root is " << ML::type_name(*root_) << " left is "
-         << ML::type_name(*left_) << " right is " << ML::type_name(*right_)
+    cerr << "root is " << MLDB::type_name(*root_) << " left is "
+         << MLDB::type_name(*left_) << " right is " << MLDB::type_name(*right_)
          << endl;
     cerr << "output scope for join: rootScope size is " << rootScope->numOutputFields()
          << " leftScope is " << leftScope->outputAdded().size()
@@ -1353,7 +1353,7 @@ createOutputScope()
 
     cerr << "known tables: " << endl;
     for (auto & t: tableScope->tables) {
-        cerr << t.first << " " << t.second.fieldOffset << " " << ML::type_name(*t.second.scope) << endl;
+        cerr << t.first << " " << t.second.fieldOffset << " " << MLDB::type_name(*t.second.scope) << endl;
     }
 #endif
 

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -183,7 +183,7 @@ toRow(std::shared_ptr<ExpressionValueInfo> row)
     ExcAssert(row);
     auto result = dynamic_pointer_cast<RowValueInfo>(row);
     if (!result)
-        throw HttpReturnException(500, "Value is not a row: " + ML::type_name(*row));
+        throw HttpReturnException(500, "Value is not a row: " + MLDB::type_name(*row));
     return result;
 }
 
@@ -198,8 +198,8 @@ SchemaCompleteness
 ExpressionValueInfo::
 getSchemaCompleteness() const
 {
-    throw HttpReturnException(500, "Value description doesn't describe a row: type " + ML::type_name(*this) + " " + jsonEncodeStr(std::shared_ptr<ExpressionValueInfo>(const_cast<ExpressionValueInfo *>(this), [] (ExpressionValueInfo *) {})),
-                              "type", ML::type_name(*this));
+    throw HttpReturnException(500, "Value description doesn't describe a row: type " + MLDB::type_name(*this) + " " + jsonEncodeStr(std::shared_ptr<ExpressionValueInfo>(const_cast<ExpressionValueInfo *>(this), [] (ExpressionValueInfo *) {})),
+                              "type", MLDB::type_name(*this));
 }
 
 SchemaCompleteness
@@ -214,7 +214,7 @@ ExpressionValueInfo::
 getKnownColumns() const
 {
     throw HttpReturnException(500, "Value description doesn't describe a row",
-                              "type", ML::type_name(*this));
+                              "type", MLDB::type_name(*this));
 }
 
 std::vector<KnownColumn>
@@ -260,7 +260,7 @@ ExpressionValueInfo::
 getScalarDescription() const
 {
     throw HttpReturnException(500, "Value description doesn't describe a scalar",
-                              "type", ML::type_name(*this));
+                              "type", MLDB::type_name(*this));
 }
 
 std::shared_ptr<ExpressionValueInfo>
@@ -320,7 +320,7 @@ struct ExpressionValueInfoPtrDescription
             return;
         }
         Json::Value out;
-        out["type"] = ML::type_name(**val);
+        out["type"] = MLDB::type_name(**val);
         if ((*val)->isScalar()) {
             out["kind"] = "scalar";
             out["scalar"] = (*val)->getScalarDescription();
@@ -367,7 +367,7 @@ struct RowValueInfoPtrDescription
             return;
         }
         Json::Value out;
-        out["type"] = ML::type_name(**val);
+        out["type"] = MLDB::type_name(**val);
         out["kind"] = "row";
         out["knownColumns"] = jsonEncode((*val)->getKnownColumns());
         out["hasUnknownColumns"] = (*val)->getSchemaCompleteness() == SCHEMA_OPEN;
@@ -2739,18 +2739,18 @@ reshape(DimsVector newShape,
 }
 
 #if 1
-ML::distribution<float, std::vector<float> >
+distribution<float, std::vector<float> >
 ExpressionValue::
 getEmbedding(ssize_t knownLength) const
 {
     return getEmbeddingDouble(knownLength).cast<float>();
 }
 
-ML::distribution<double, std::vector<double> >
+distribution<double, std::vector<double> >
 ExpressionValue::
 getEmbedding(const ColumnPath * knownNames, size_t len) const
 {
-    ML::distribution<double> features
+    distribution<double> features
         (len, std::numeric_limits<float>::quiet_NaN());
 
     // Index of value we're writing.  If they aren't in order, this will
@@ -2758,7 +2758,7 @@ getEmbedding(const ColumnPath * knownNames, size_t len) const
     int currentIndex = 0;
 
     /// If they're not in order, we create this index
-    ML::Lightweight_Hash<uint64_t, int> columnIndex;
+    Lightweight_Hash<uint64_t, int> columnIndex;
     
     /// Add a CellValue we extracted to the output.  This will also
     /// deal with non-ordered column names.
@@ -2915,7 +2915,7 @@ getEmbedding(const ColumnPath * knownNames, size_t len) const
     return features;
 }
 
-ML::distribution<double, std::vector<double> >
+distribution<double, std::vector<double> >
 ExpressionValue::
 getEmbeddingDouble(ssize_t knownLength) const
 {
@@ -2938,7 +2938,7 @@ getEmbeddingDouble(ssize_t knownLength) const
 
     forEachAtom(onAtom);
 
-    ML::distribution<double> result;
+    distribution<double> result;
     result.reserve(features.size());
     for (unsigned i = 0;  i < features.size();  ++i) {
         result.push_back(features[i].second);
@@ -3764,7 +3764,7 @@ joinColumns(const ExpressionValue & val1,
 
         // Assume they have the same keys and exactly one of each; if not we
         // have to restart
-        ML::Lightweight_Hash_Set<uint64_t> colsFound;
+        Lightweight_Hash_Set<uint64_t> colsFound;
 
         for (size_t i = 0;  i < row1.size(); ++i) {
             const ColumnPath & col1 = std::get<0>(row1[i]);
@@ -4560,7 +4560,7 @@ extractExpressionValueInfo(const std::shared_ptr<const ValueDescription> & desc)
     const ExpressionValueDescription * descCast
         = dynamic_cast<const ExpressionValueDescription *>(desc.get());
     if (!descCast) {
-        cerr << "field type was " << ML::type_name(*desc) << endl;
+        cerr << "field type was " << MLDB::type_name(*desc) << endl;
         return nullptr;
     }
     return descCast->info;
@@ -4749,7 +4749,7 @@ template class ScalarExpressionValueInfoT<Date>;
 
 template class ExpressionValueInfoT<RowValue>;
 template class ExpressionValueInfoT<ExpressionValue>;
-template class ExpressionValueInfoT<ML::distribution<double, std::vector<double> > >;
+template class ExpressionValueInfoT<distribution<double, std::vector<double> > >;
 
 
 /*****************************************************************************/

--- a/sql/expression_value.h
+++ b/sql/expression_value.h
@@ -22,13 +22,11 @@
 // should be added, especially value_description.h.
 
 
-namespace ML {
-template<typename T, typename Underlying>
-struct distribution;
-} // namespace ML
-
 
 namespace MLDB {
+
+template<typename T, typename Underlying>
+struct distribution;
 
 struct Date;
 struct MatrixNamedRow;
@@ -424,7 +422,7 @@ struct ExpressionValueInfo {
     */
     virtual StorageType getEmbeddingType() const;
 
-    typedef ML::distribution<double, std::vector<double> > DoubleDist;
+    typedef distribution<double, std::vector<double> > DoubleDist;
 
     /** Return a function which, when called, will extract an embedding
         from the given value.
@@ -975,12 +973,12 @@ struct ExpressionValue {
 
     /** Return an embedding from the value, asserting on the length.  If the
         length is -1, it is unknown and any length will be accepted. */
-    ML::distribution<float, std::vector<float> >
+    distribution<float, std::vector<float> >
     getEmbedding(ssize_t knownLength = -1) const;
 
     /** Return an embedding from the value, asserting on the length.  If the
         length is -1, it is unknown and any length will be accepted. */
-    ML::distribution<double, std::vector<double> >
+    distribution<double, std::vector<double> >
     getEmbeddingDouble(ssize_t knownLength = -1) const;
 
     /** Return a flattened embedding as CellValues. */
@@ -1013,7 +1011,7 @@ struct ExpressionValue {
         The numDone parameter tells how many have already been done.  It
         is used as an offset in the knownNames array.
     */
-    ML::distribution<double, std::vector<double> >
+    distribution<double, std::vector<double> >
     getEmbedding(const ColumnPath * knownNames, size_t len) const;
 
     /** Convert an embedding to an array of the given storage type.  The
@@ -1375,7 +1373,7 @@ struct ScalarExpressionValueInfoT: public ExpressionValueInfoT<Storage> {
 
     virtual std::string getScalarDescription() const
     {
-        return ML::type_name<Storage>();
+        return MLDB::type_name<Storage>();
     }
 
     virtual std::vector<ssize_t> getEmbeddingShape() const
@@ -1415,7 +1413,7 @@ extern template class ScalarExpressionValueInfoT<Date>;
 
 extern template class ExpressionValueInfoT<RowValue>;
 extern template class ExpressionValueInfoT<ExpressionValue>;
-extern template class ExpressionValueInfoT<ML::distribution<double, std::vector<double> > >;
+extern template class ExpressionValueInfoT<distribution<double, std::vector<double> > >;
 
 
 /*****************************************************************************/

--- a/sql/expression_value_conversions.cc
+++ b/sql/expression_value_conversions.cc
@@ -422,7 +422,7 @@ getCompatibleDoubleEmbeddings(const ExpressionValueInfo & other) const
             // then get the same values for the second, and return enough to
             // reconstitute the same structure again.
             std::vector<ColumnPath> columnNames;
-            ML::distribution<double> d1;
+            distribution<double> d1;
 
             auto onAtom = [&] (const ColumnPath & name,
                                const ColumnPath & prefix,

--- a/sql/interval.cc
+++ b/sql/interval.cc
@@ -15,7 +15,7 @@ using namespace std;
 namespace MLDB {
 
 
-void expect_interval(ML::Parse_Context & context, uint32_t& months, uint32_t& days, double& seconds)
+void expect_interval(ParseContext & context, uint32_t& months, uint32_t& days, double& seconds)
 { 
     months = 0;
     days = 0;
@@ -39,7 +39,7 @@ void expect_interval(ML::Parse_Context & context, uint32_t& months, uint32_t& da
         unsigned value = 0;
         // Parse an unsigned value
         {
-            ML::Parse_Context::Revert_Token token(context);
+            ParseContext::Revert_Token token(context);
             if (!context.match_unsigned(value))
         	break;
         }

--- a/sql/interval.h
+++ b/sql/interval.h
@@ -1,21 +1,18 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** interval.h
     Mathieu Marquis Bolduc, October 14th 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 */
 
 #pragma once
 
 #include <stdint.h>
 
-namespace ML {
-	struct Parse_Context;
-}
-
 namespace MLDB {
 
-void expect_interval(ML::Parse_Context & context, uint32_t& months, uint32_t& days, double& seconds);
+struct ParseContext;
+void expect_interval(ParseContext & context, uint32_t& months, uint32_t& days, double& seconds);
 
-}
+} // namespace MLDB
+
 

--- a/sql/sql_expression.cc
+++ b/sql/sql_expression.cc
@@ -349,7 +349,7 @@ doGetAggregator(const Utf8String & aggregatorName,
     }
     
     return {nullptr, nullptr};
-    //throw HttpReturnException(400, "Binding context " + ML::type_name(*this)
+    //throw HttpReturnException(400, "Binding context " + MLDB::type_name(*this)
     //                    + " must override getAggregator: wanted "
     //                    + aggregatorName);
 }
@@ -358,7 +358,7 @@ ColumnGetter
 SqlBindingScope::
 doGetColumn(const Utf8String & tableName, const ColumnPath & columnName)
 {
-    throw HttpReturnException(500, "Binding context " + ML::type_name(*this)
+    throw HttpReturnException(500, "Binding context " + MLDB::type_name(*this)
                               + " must override getColumn: wanted "
                               + columnName.toUtf8String());
 }
@@ -368,7 +368,7 @@ SqlBindingScope::
 doGetAllColumns(const Utf8String & tableName,
                 const ColumnFilter& keep)
 {
-    throw HttpReturnException(500, "Binding context " + ML::type_name(*this)
+    throw HttpReturnException(500, "Binding context " + MLDB::type_name(*this)
                         + " must override getAllColumns: wanted "
                         + tableName);
 }
@@ -387,7 +387,7 @@ doCreateRowsWhereGenerator(const SqlExpression & where,
                   ssize_t offset,
                   ssize_t limit)
 {
-    throw HttpReturnException(500, "Binding context " + ML::type_name(*this)
+    throw HttpReturnException(500, "Binding context " + MLDB::type_name(*this)
                         + " must override doCreateRowsWhereGenerator");
 }
 
@@ -395,7 +395,7 @@ ColumnFunction
 SqlBindingScope::
 doGetColumnFunction(const Utf8String & functionName)
 {
-    throw HttpReturnException(500, "Binding context " + ML::type_name(*this)
+    throw HttpReturnException(500, "Binding context " + MLDB::type_name(*this)
                         + " must override doGetColumnFunction");
 }
 
@@ -403,7 +403,7 @@ ColumnGetter
 SqlBindingScope::
 doGetBoundParameter(const Utf8String & paramName)
 {
-    throw HttpReturnException(500, "Binding context " + ML::type_name(*this)
+    throw HttpReturnException(500, "Binding context " + MLDB::type_name(*this)
                               + " does not support bound parameters ($1... or $name)");
 }
 
@@ -411,7 +411,7 @@ std::shared_ptr<Dataset>
 SqlBindingScope::
 doGetDataset(const Utf8String & datasetName)
 {
-    throw HttpReturnException(500, "Binding context " + ML::type_name(*this)
+    throw HttpReturnException(500, "Binding context " + MLDB::type_name(*this)
                               + " does not support getting datasets");
 }
 
@@ -419,7 +419,7 @@ std::shared_ptr<Dataset>
 SqlBindingScope::
 doGetDatasetFromConfig(const Any & datasetConfig)
 {
-    throw HttpReturnException(500, "Binding context " + ML::type_name(*this)
+    throw HttpReturnException(500, "Binding context " + MLDB::type_name(*this)
                               + " does not support getting datasets");
 }
 
@@ -427,7 +427,7 @@ TableOperations
 SqlBindingScope::
 doGetTable(const Utf8String & tableName)
 {
-    throw HttpReturnException(500, "Binding context " + ML::type_name(*this)
+    throw HttpReturnException(500, "Binding context " + MLDB::type_name(*this)
                               + " does not support getting tables");
 }
 
@@ -678,7 +678,7 @@ UnboundEntitiesDescription()
 
 // Environment variable that tells us whether we check the row scope types
 // or not, which may be more expensive.
-ML::Env_Option<bool> MLDB_CHECK_ROW_SCOPE_TYPES
+EnvOption<bool> MLDB_CHECK_ROW_SCOPE_TYPES
 ("MLDB_CHECK_ROW_SCOPE_TYPES", false);
 
 // Visible manifestation of that variable.  We statically initialize it here
@@ -700,8 +700,8 @@ SqlRowScope::
 throwBadNestingError(const std::type_info & typeRequested,
                      const std::type_info & typeFound)
 {
-    std::string t_req = ML::demangle(typeRequested.name());
-    std::string t_found = ML::demangle(typeFound.name());
+    std::string t_req = demangle(typeRequested.name());
+    std::string t_found = demangle(typeFound.name());
     throw HttpReturnException(500, "Invalid scope nesting: requested "
                               + t_req + " got " + t_found,
                               "typeRequested", t_req,
@@ -721,7 +721,7 @@ SqlExpression::
 namespace {
 
 // Match a non-scoped identifier
-static bool matchPathIdentifier(ML::Parse_Context & context,
+static bool matchPathIdentifier(ParseContext & context,
                                 bool allowUtf8, Utf8String & result)
 {
     if (context.eof()) {
@@ -731,7 +731,7 @@ static bool matchPathIdentifier(ML::Parse_Context & context,
     if (context.match_literal('"')) {
         //read until the double quote closes.
         {
-            ML::Parse_Context::Revert_Token token(context);
+            ParseContext::Revert_Token token(context);
 
             for (;;) {
                 if (context.match_literal("\"\"")) {
@@ -765,14 +765,14 @@ static bool matchPathIdentifier(ML::Parse_Context & context,
     return !result.empty();
 }
 
-static Utf8String matchIdentifier(ML::Parse_Context & context, bool allowUtf8)
+static Utf8String matchIdentifier(ParseContext & context, bool allowUtf8)
 {
     Utf8String result;
     matchPathIdentifier(context, allowUtf8, result);
     return result;
 }
 
-static ColumnPath matchColumnName(ML::Parse_Context & context, bool allowUtf8)
+static ColumnPath matchColumnName(ParseContext & context, bool allowUtf8)
 {
     ColumnPath result;
 
@@ -797,13 +797,13 @@ static ColumnPath matchColumnName(ML::Parse_Context & context, bool allowUtf8)
     return result;
 }
 
-bool matchBlockCommentStart(ML::Parse_Context & ctx)
+bool matchBlockCommentStart(ParseContext & ctx)
 {
     if (ctx.eof() || *ctx != '/')
         return false;
 
     {
-        ML::Parse_Context::Revert_Token token(ctx);
+        ParseContext::Revert_Token token(ctx);
         ++ctx;
         if (!ctx.eof() && (*ctx == '*')) {
             ++ctx;
@@ -816,7 +816,7 @@ bool matchBlockCommentStart(ML::Parse_Context & ctx)
 
 }
 
-void skipToBlockCommentEnd(ML::Parse_Context & ctx)
+void skipToBlockCommentEnd(ParseContext & ctx)
 {
     while (!ctx.eof()) {
         if (*ctx == '*') {
@@ -832,13 +832,13 @@ void skipToBlockCommentEnd(ML::Parse_Context & ctx)
     }
 }
 
-bool matchLineCommentStart(ML::Parse_Context & ctx)
+bool matchLineCommentStart(ParseContext & ctx)
 {
     if (ctx.eof() || *ctx != '-')
         return false;
 
     {
-        ML::Parse_Context::Revert_Token token(ctx);
+        ParseContext::Revert_Token token(ctx);
         ++ctx;
         if (!ctx.eof() && (*ctx == '-')) {
             ++ctx;
@@ -851,7 +851,7 @@ bool matchLineCommentStart(ML::Parse_Context & ctx)
 
 }
 
-void skipToEndOfLine(ML::Parse_Context & ctx)
+void skipToEndOfLine(ParseContext & ctx)
 {
     while (!ctx.eof()) {
         if (ctx.match_eol())
@@ -861,8 +861,8 @@ void skipToEndOfLine(ML::Parse_Context & ctx)
     }
 }
 
-// Parse_Context doesn't consider \n to be a whitespace...
-bool match_whitespace(ML::Parse_Context & ctx)
+// ParseContext doesn't consider \n to be a whitespace...
+bool match_whitespace(ParseContext & ctx)
 {
     bool result = false;
     bool inBlockComment = false;
@@ -885,20 +885,20 @@ bool match_whitespace(ML::Parse_Context & ctx)
     return result;
 }
 
-void skip_whitespace(ML::Parse_Context & ctx)
+void skip_whitespace(ParseContext & ctx)
 {
     match_whitespace(ctx);
 }
 
-void expect_whitespace(ML::Parse_Context & ctx)
+void expect_whitespace(ParseContext & ctx)
 {
     if (!match_whitespace(ctx)) ctx.exception("expected whitespace");
 }
 
 // Match a keyword in any case
-static bool matchKeyword(ML::Parse_Context & context, const char * keyword)
+static bool matchKeyword(ParseContext & context, const char * keyword)
 {
-    ML::Parse_Context::Revert_Token token(context);
+    ParseContext::Revert_Token token(context);
 
     skip_whitespace(context);
     const char * p = keyword;
@@ -928,7 +928,7 @@ static bool matchKeyword(ML::Parse_Context & context, const char * keyword)
 }
 
 // Expect a keyword in any case
-static void expectKeyword(ML::Parse_Context & context, const char * keyword)
+static void expectKeyword(ParseContext & context, const char * keyword)
 {
     if (!matchKeyword(context, keyword)) {
         context.exception("expected keyword " + string(keyword));
@@ -936,16 +936,16 @@ static void expectKeyword(ML::Parse_Context & context, const char * keyword)
 }
 
 // Read ahead to see if a keyword matches
-static bool peekKeyword(ML::Parse_Context & context, const char * keyword)
+static bool peekKeyword(ParseContext & context, const char * keyword)
 {
-    ML::Parse_Context::Revert_Token token(context);
+    ParseContext::Revert_Token token(context);
     return matchKeyword(context, keyword);
 }
 
-void matchSingleQuoteStringAscii(ML::Parse_Context & context, std::string& resultStr)
+void matchSingleQuoteStringAscii(ParseContext & context, std::string& resultStr)
 {
     {
-        ML::Parse_Context::Revert_Token token(context);
+        ParseContext::Revert_Token token(context);
 
         for (;;) {
             if (context.match_literal("\'\'"))
@@ -966,11 +966,11 @@ void matchSingleQuoteStringAscii(ML::Parse_Context & context, std::string& resul
     context.exception("No closing quote character for string");
 }
 
-void matchSingleQuoteStringUTF8(ML::Parse_Context & context,
+void matchSingleQuoteStringUTF8(ParseContext & context,
                                 std::basic_string<char32_t>& resultStr)
 {
     {
-        ML::Parse_Context::Revert_Token token(context);
+        ParseContext::Revert_Token token(context);
 
         for (;;) {
             if (context.match_literal("\'\'"))
@@ -990,7 +990,7 @@ void matchSingleQuoteStringUTF8(ML::Parse_Context & context,
     context.exception("No closing quote character for string");
 }
 
-bool matchConstant(ML::Parse_Context & context, ExpressionValue & result,
+bool matchConstant(ParseContext & context, ExpressionValue & result,
                    bool allowUtf8)
 {
     double d_num;
@@ -1073,9 +1073,9 @@ bool matchConstant(ML::Parse_Context & context, ExpressionValue & result,
 
 
 // Match an operator in any case
-static bool matchOperator(ML::Parse_Context & context, const char * keyword)
+static bool matchOperator(ParseContext & context, const char * keyword)
 {
-    ML::Parse_Context::Revert_Token token(context);
+    ParseContext::Revert_Token token(context);
 
     const char * p = keyword;
 
@@ -1103,7 +1103,7 @@ static bool matchOperator(ML::Parse_Context & context, const char * keyword)
 }
 
 bool
-matchJoinQualification(ML::Parse_Context & context, JoinQualification& joinQualify)
+matchJoinQualification(ParseContext & context, JoinQualification& joinQualify)
 {
     joinQualify = JOIN_INNER;
     bool inner = matchKeyword(context, "INNER ");
@@ -1186,11 +1186,11 @@ const SqlExpression::Operator operators[] = {
 
 std::shared_ptr<SqlExpression>
 SqlExpression::
-parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
+parse(ParseContext & context, int currentPrecedence, bool allowUtf8)
 {
     skip_whitespace(context);
 
-    ML::Parse_Context::Hold_Token token(context);
+    ParseContext::Hold_Token token(context);
 
     //cerr << "parsing at context " << context.get_offset() << " precedence " << currentPrecedence
     //     << " char " << *context << endl;
@@ -1619,7 +1619,7 @@ SqlExpression::
 parse(const std::string & expression, const std::string & filename,
       int row, int col)
 {
-    ML::Parse_Context context(filename.empty() ? expression : filename,
+    ParseContext context(filename.empty() ? expression : filename,
                               expression.c_str(),
                               expression.length(), row, col);
     auto result = parse(context, 10 /* starting precedence */, false /* allowUtf8 */);
@@ -1642,7 +1642,7 @@ SqlExpression::
 parse(const Utf8String & expression, const std::string & filename,
       int row, int col)
 {
-    ML::Parse_Context context(filename.empty() ? expression.rawData() : filename,
+    ParseContext context(filename.empty() ? expression.rawData() : filename,
                               expression.rawData(),
                               expression.rawLength(), row, col);
     auto result = parse(context, 10 /* starting precedence */, true /* allowUtf8 */);
@@ -2091,9 +2091,9 @@ SqlRowExpression::
 
 std::shared_ptr<SqlRowExpression>
 SqlRowExpression::
-parse(ML::Parse_Context & context, bool allowUtf8)
+parse(ParseContext & context, bool allowUtf8)
 {
-    ML::Parse_Context::Hold_Token capture(context);
+    ParseContext::Hold_Token capture(context);
 
     if (matchKeyword(context, "COLUMN EXPR")) {
 
@@ -2177,7 +2177,7 @@ parse(ML::Parse_Context & context, bool allowUtf8)
     */
     auto matchPrefixedWildcard = [&] (ColumnPath & prefix)
         {
-            ML::Parse_Context::Revert_Token token(context);
+            ParseContext::Revert_Token token(context);
             skip_whitespace(context);
             prefix = matchColumnName(context, allowUtf8);
             if (context.match_literal('*')) {
@@ -2198,7 +2198,7 @@ parse(ML::Parse_Context & context, bool allowUtf8)
     ColumnPath columnName;
 
     {
-        ML::Parse_Context::Revert_Token token(context);
+        ParseContext::Revert_Token token(context);
 
         if (matchPrefixedWildcard(prefix)) {
             // Sort out ambiguity between * operator and wildcard by looking at trailing
@@ -2212,7 +2212,7 @@ parse(ML::Parse_Context & context, bool allowUtf8)
             // - EXCLUDING
             // - a keyword: FROM, WHERE, GROUP BY, HAVING, LIMIT, OFFSET
 
-            ML::Parse_Context::Revert_Token token2(context);
+            ParseContext::Revert_Token token2(context);
 
             skip_whitespace(context);
             if (context.eof() || context.match_literal(',') || context.match_literal(')') || context.match_literal('}')
@@ -2231,7 +2231,7 @@ parse(ML::Parse_Context & context, bool allowUtf8)
     // MLDB-1002 case 1: x: y <--> y AS x
     if (!matched) {
         // Allow backtracking if we don't find a colon
-        ML::Parse_Context::Revert_Token token(context);
+        ParseContext::Revert_Token token(context);
 
         // Do we have an identifier?
         ColumnPath asName = matchColumnName(context, allowUtf8);
@@ -2257,7 +2257,7 @@ parse(ML::Parse_Context & context, bool allowUtf8)
     // MLDB-1002 case 2: x*: y* <--> y* AS x*
     if (!matched) {
         // Allow backtracking if we don't find a colon
-        ML::Parse_Context::Revert_Token token(context);
+        ParseContext::Revert_Token token(context);
 
         // Do we have an identifier?
         if (matchPrefixedWildcard(prefix)) {
@@ -2387,7 +2387,7 @@ SqlRowExpression::
 parse(const std::string & expression, const std::string & filename,
       int row, int col)
 {
-    ML::Parse_Context context(filename.empty() ? expression : filename,
+    ParseContext context(filename.empty() ? expression : filename,
                               expression.c_str(),
                               expression.length(), row, col);
     auto result = parse(context, false /* allowUtf8 */);
@@ -2406,7 +2406,7 @@ parse(const char *  expression, const std::string & filename,
 
 std::vector<std::shared_ptr<SqlRowExpression> >
 SqlRowExpression::
-parseList(ML::Parse_Context & context, bool allowUtf8)
+parseList(ParseContext & context, bool allowUtf8)
 {
     std::vector<std::shared_ptr<SqlRowExpression> > result;
 
@@ -2436,7 +2436,7 @@ parseList(const std::string & expression,
           const std::string & filename, int row, int col)
 {
     //cerr << "parsing " << expression << endl;
-    ML::Parse_Context context(filename.empty() ? expression : filename,
+    ParseContext context(filename.empty() ? expression : filename,
                               expression.c_str(),
                               expression.length(), row, col);
     auto result = parseList(context, false);
@@ -2459,7 +2459,7 @@ parseList(const Utf8String & expression,
           const std::string & filename, int row, int col)
 {
     //cerr << "parsing " << expression << endl;
-    ML::Parse_Context context(filename.empty() ? expression.rawData() : filename,
+    ParseContext context(filename.empty() ? expression.rawData() : filename,
                               expression.rawData(),
                               expression.rawLength(), row, col);
     auto result = parseList(context, true);
@@ -2607,7 +2607,7 @@ OrderByExpression
 OrderByExpression::
 parse(const std::string & str)
 {
-    ML::Parse_Context context(str, str.c_str(), str.length());
+    ParseContext context(str, str.c_str(), str.length());
     OrderByExpression result = parse(context, false /* allowUtf8 */);
     context.expect_eof("Unexpected characters at end of order by expression");
     return result;
@@ -2624,7 +2624,7 @@ OrderByExpression
 OrderByExpression::
 parse(const Utf8String & str)
 {
-    ML::Parse_Context context(str.rawData(), str.rawData(), str.rawLength());
+    ParseContext context(str.rawData(), str.rawData(), str.rawLength());
     OrderByExpression result = parse(context, true /* allowUtf8 */);
     context.expect_eof("Unexpected characters at end of order by expression");
     return result;
@@ -2632,9 +2632,9 @@ parse(const Utf8String & str)
 
 OrderByExpression
 OrderByExpression::
-parse(ML::Parse_Context & context, bool allowUtf8)
+parse(ParseContext & context, bool allowUtf8)
 {
-    ML::Parse_Context::Hold_Token token(context);
+    ParseContext::Hold_Token token(context);
 
     OrderByExpression result;
 
@@ -2837,9 +2837,9 @@ const OrderByExpression ORDER_BY_NOTHING;
 
 TupleExpression
 TupleExpression::
-parse(ML::Parse_Context & context, bool allowUtf8)
+parse(ParseContext & context, bool allowUtf8)
 {
-    ML::Parse_Context::Hold_Token token(context);
+    ParseContext::Hold_Token token(context);
 
     TupleExpression result;
 
@@ -2871,7 +2871,7 @@ TupleExpression
 TupleExpression::
 parse(const std::string & str)
 {
-    ML::Parse_Context context(str, str.c_str(), str.length());
+    ParseContext context(str, str.c_str(), str.length());
     TupleExpression result = parse(context, false /* allowUtf8 */);
     context.expect_eof("Unexpected characters at end of tuple expression");
     return result;
@@ -2888,7 +2888,7 @@ TupleExpression
 TupleExpression::
 parse(const Utf8String & str)
 {
-    ML::Parse_Context context(str.rawData(), str.rawData(), str.rawLength());
+    ParseContext context(str.rawData(), str.rawData(), str.rawLength());
     TupleExpression result = parse(context, true /* allowUtf8 */);
     context.expect_eof("Unexpected characters at end of tuple expression");
     return result;
@@ -3050,9 +3050,9 @@ SelectExpression(std::vector<std::shared_ptr<SqlRowExpression> > clauses)
 
 SelectExpression
 SelectExpression::
-parse(ML::Parse_Context & context, bool allowUtf8)
+parse(ParseContext & context, bool allowUtf8)
 {
-    ML::Parse_Context::Hold_Token token(context);
+    ParseContext::Hold_Token token(context);
     std::vector<std::shared_ptr<SqlExpression>> distinctExpr;
 
     if (matchKeyword(context, "DISTINCT ON ")) {
@@ -3087,7 +3087,7 @@ SelectExpression::
 parse(const std::string & expr,
       const std::string & filename, int row, int col)
 {
-    ML::Parse_Context context(filename.empty() ? expr : filename,
+    ParseContext context(filename.empty() ? expr : filename,
                               expr.c_str(),
                               expr.length(), row, col);
 
@@ -3112,7 +3112,7 @@ SelectExpression::
 parse(const Utf8String & expr,
       const std::string & filename, int row, int col)
 {
-    ML::Parse_Context context(filename.empty() ? expr.rawData() : filename,
+    ParseContext context(filename.empty() ? expr.rawData() : filename,
                               expr.rawData(),
                               expr.rawLength(), row, col);
    
@@ -3345,11 +3345,11 @@ TableExpression::
 
 std::shared_ptr<TableExpression>
 TableExpression::
-parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
+parse(ParseContext & context, int currentPrecedence, bool allowUtf8)
 {
     skip_whitespace(context);
 
-    ML::Parse_Context::Hold_Token token(context);
+    ParseContext::Hold_Token token(context);
 
     std::shared_ptr<TableExpression> result;
 
@@ -3447,7 +3447,7 @@ parse(ML::Parse_Context & context, int currentPrecedence, bool allowUtf8)
 
                         bool found = false;
                         {
-                            ML::Parse_Context::Revert_Token token(context);
+                            ParseContext::Revert_Token token(context);
                             found = context.match_literal('{');
                         }
 
@@ -3521,7 +3521,7 @@ TableExpression::
 parse(const Utf8String & expression, const std::string & filename,
       int row, int col)
 {
-    ML::Parse_Context context(filename.empty() ? expression.rawData() : filename,
+    ParseContext context(filename.empty() ? expression.rawData() : filename,
                               expression.rawData(),
                               expression.rawLength(), row, col);
     auto result = parse(context, 10 /* starting precedence */, true /* allowUtf8 */);
@@ -3544,7 +3544,7 @@ printJson(JsonPrintingContext & context)
 {
     if (surface.empty())
         throw HttpReturnException(400, "Attempt to write table expression with no surface and no printJson method",
-                                  "expressionType", ML::type_name(*this),
+                                  "expressionType", MLDB::type_name(*this),
                                   "expressionTree", print());
     else context.writeStringUtf8(surface);
 }
@@ -3669,7 +3669,7 @@ WhenExpression
 WhenExpression::
 parse(const std::string & str)
 {
-    ML::Parse_Context context(str, str.c_str(), str.length());
+    ParseContext context(str, str.c_str(), str.length());
     auto result = parse(context, false /* allowUtf8 */);
     context.expect_eof("Unexpected characters at end of when expression");
     return result;
@@ -3686,7 +3686,7 @@ WhenExpression
 WhenExpression::
 parse(const Utf8String & str)
 {
-    ML::Parse_Context context(str.rawData(), str.rawData(), str.rawLength());
+    ParseContext context(str.rawData(), str.rawData(), str.rawLength());
     auto result = parse(context, true /* allowUtf8 */);
     context.expect_eof("Unexpected characters at end of when expression");
     return result;
@@ -3694,7 +3694,7 @@ parse(const Utf8String & str)
 
 WhenExpression
 WhenExpression::
-parse(ML::Parse_Context & context, bool allowUtf8) {
+parse(ParseContext & context, bool allowUtf8) {
     auto result = SqlExpression::parse(context, 10,  allowUtf8);
     return WhenExpression(result);
 }
@@ -3911,7 +3911,7 @@ SelectStatement
 SelectStatement::
 parse(const std::string& body)
 {
-    ML::Parse_Context context(body, body.c_str(), body.length());
+    ParseContext context(body, body.c_str(), body.length());
 
     const bool acceptUtf8 = true;
 
@@ -3930,9 +3930,9 @@ parse(const char * body)
 }
 
 SelectStatement
-SelectStatement::parse(ML::Parse_Context& context, bool acceptUtf8)
+SelectStatement::parse(ParseContext& context, bool acceptUtf8)
 {
-    ML::Parse_Context::Hold_Token token(context);
+    ParseContext::Hold_Token token(context);
 
     SelectStatement statement;
 

--- a/sql/sql_expression.h
+++ b/sql/sql_expression.h
@@ -21,13 +21,8 @@
 // should be added, especially value_description.h.  Only
 // value_expression_fwd.h is OK.
 
-
-namespace ML {
-struct Parse_Context;
-} // namespace ML
-
-
 namespace MLDB {
+struct ParseContext;
 
 /** SQL expressions
     
@@ -957,7 +952,7 @@ struct SqlExpression: public std::enable_shared_from_this<SqlExpression> {
         http://www.sqlite.org/syntax/expr.html
     */
     static std::shared_ptr<SqlExpression>
-    parse(ML::Parse_Context & context, int precendence, bool allowUtf8);
+    parse(ParseContext & context, int precendence, bool allowUtf8);
 
     static std::shared_ptr<SqlExpression>
     parse(const std::string & expression, const std::string & filename = "",
@@ -1180,7 +1175,7 @@ struct SqlRowExpression: public SqlExpression {
 
     /** Parses a single result variable expression. */
     static std::shared_ptr<SqlRowExpression>
-    parse(ML::Parse_Context & context, bool allowUtf8);
+    parse(ParseContext & context, bool allowUtf8);
 
     static std::shared_ptr<SqlRowExpression>
     parse(const std::string & expr,
@@ -1196,7 +1191,7 @@ struct SqlRowExpression: public SqlExpression {
 
     /** Parses a comma separated list of result variable expressions. */
     static std::vector<std::shared_ptr<SqlRowExpression> >
-    parseList(ML::Parse_Context & context, bool allowUtf8);
+    parseList(ParseContext & context, bool allowUtf8);
 
     static std::vector<std::shared_ptr<SqlRowExpression> >
     parseList(const std::string & expr,
@@ -1250,7 +1245,7 @@ struct SelectExpression: public SqlRowExpression {
     static const SelectExpression STAR;
     
     static SelectExpression
-    parse(ML::Parse_Context & context, bool allowUtf8);
+    parse(ParseContext & context, bool allowUtf8);
 
     static SelectExpression
     parse(const std::string & expr,
@@ -1366,7 +1361,7 @@ struct OrderByExpression {
 
     std::vector<std::pair<std::shared_ptr<SqlExpression>, OrderByDirection> > clauses;
 
-    static OrderByExpression parse(ML::Parse_Context & context, bool allowUtf8);
+    static OrderByExpression parse(ParseContext & context, bool allowUtf8);
     static OrderByExpression parse(const std::string & expression);
     static OrderByExpression parse(const char * expression);
     static OrderByExpression parse(const Utf8String & expression);
@@ -1434,7 +1429,7 @@ struct TupleExpression {  // TODO: should be a row expression
         return clauses.size();
     }
 
-    static TupleExpression parse(ML::Parse_Context & context, bool allowUtf8);
+    static TupleExpression parse(ParseContext & context, bool allowUtf8);
     static TupleExpression parse(const std::string & expression);
     static TupleExpression parse(const char * expression);
     static TupleExpression parse(const Utf8String & expression);
@@ -1584,7 +1579,7 @@ struct TableExpression: public std::enable_shared_from_this<TableExpression> {
     virtual Utf8String print() const = 0;
 
     static std::shared_ptr<TableExpression>
-    parse(ML::Parse_Context & context, int precendence, bool allowUtf8);
+    parse(ParseContext & context, int precendence, bool allowUtf8);
 
     static std::shared_ptr<TableExpression>
     parse(const Utf8String & expression, const std::string & filename = "",
@@ -1691,7 +1686,7 @@ struct WhenExpression {
     parse(const Utf8String & str);
 
     static WhenExpression
-    parse(ML::Parse_Context & context, bool allowUtf8);
+    parse(ParseContext & context, bool allowUtf8);
 
     BoundWhenExpression
     bind(SqlBindingScope & context) const;
@@ -1753,7 +1748,7 @@ struct SelectStatement
     static SelectStatement parse(const std::string& body);
     static SelectStatement parse(const char * body);
     static SelectStatement parse(const Utf8String& body);
-    static SelectStatement parse(ML::Parse_Context& context, bool allowUtf8);
+    static SelectStatement parse(ParseContext& context, bool allowUtf8);
 
     UnboundEntities getUnbound() const;
 

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -1514,7 +1514,7 @@ bind(SqlBindingScope & scope) const
     auto getVariable = scope.doGetColumn("" /*tableName*/, columnName);
 
     if (!getVariable.info) {
-        throw HttpReturnException(400, "scope " + ML::type_name(scope)
+        throw HttpReturnException(400, "scope " + MLDB::type_name(scope)
                                   + " getColumn '" + columnName.toUtf8String()
                                   + "' didn't return info");
     }
@@ -2234,7 +2234,7 @@ bind(SqlBindingScope & scope) const
         throw HttpReturnException(400, message,
                                   "functionName", functionName,
                                   "tableName", tableName,
-                                  "scopeType", ML::type_name(scope),
+                                  "scopeType", MLDB::type_name(scope),
                                   "expr", print(),
                                   "surface", surface);
     }
@@ -3391,7 +3391,7 @@ bind(SqlBindingScope & scope) const
     auto getParam = scope.doGetBoundParameter(paramName);
 
     if (!getParam.info) {
-        throw HttpReturnException(400, "scope " + ML::type_name(scope)
+        throw HttpReturnException(400, "scope " + MLDB::type_name(scope)
                             + " getBoundParameter '" + paramName
                             + "' didn't return info");
     }

--- a/sql/testing/path_test.cc
+++ b/sql/testing/path_test.cc
@@ -146,15 +146,15 @@ BOOST_AUTO_TEST_CASE(test_coord_parsing)
 
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(PathElement::parse("."), ML::Exception);
-        BOOST_CHECK_THROW(PathElement::parse("\n"), ML::Exception);
-        BOOST_CHECK_THROW(PathElement::parse("\""), ML::Exception);
-        BOOST_CHECK_THROW(PathElement::parse(".."), ML::Exception);
-        BOOST_CHECK_THROW(PathElement::parse("\"x."), ML::Exception);
-        BOOST_CHECK_THROW(PathElement::parse("\"x."), ML::Exception);
-        BOOST_CHECK_THROW(PathElement::parse("x\"\""), ML::Exception);
-        BOOST_CHECK_THROW(PathElement::parse("x.y"), ML::Exception);
-        BOOST_CHECK_THROW(PathElement::parse("\"x\",y"), ML::Exception);
+        BOOST_CHECK_THROW(PathElement::parse("."), MLDB::Exception);
+        BOOST_CHECK_THROW(PathElement::parse("\n"), MLDB::Exception);
+        BOOST_CHECK_THROW(PathElement::parse("\""), MLDB::Exception);
+        BOOST_CHECK_THROW(PathElement::parse(".."), MLDB::Exception);
+        BOOST_CHECK_THROW(PathElement::parse("\"x."), MLDB::Exception);
+        BOOST_CHECK_THROW(PathElement::parse("\"x."), MLDB::Exception);
+        BOOST_CHECK_THROW(PathElement::parse("x\"\""), MLDB::Exception);
+        BOOST_CHECK_THROW(PathElement::parse("x.y"), MLDB::Exception);
+        BOOST_CHECK_THROW(PathElement::parse("\"x\",y"), MLDB::Exception);
     }
 }
 
@@ -222,14 +222,14 @@ BOOST_AUTO_TEST_CASE(test_coords_parsing)
 
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(Path::parse("\n"), ML::Exception);
-        BOOST_CHECK_THROW(Path::parse("\0", 1), ML::Exception);
-        BOOST_CHECK_THROW(Path::parse("\"\0\"", 3), ML::Exception);
-        BOOST_CHECK_THROW(Path::parse("\""), ML::Exception);
-        BOOST_CHECK_THROW(Path::parse("\"x."), ML::Exception);
-        BOOST_CHECK_THROW(Path::parse("\"x."), ML::Exception);
-        BOOST_CHECK_THROW(Path::parse("x\"\""), ML::Exception);
-        BOOST_CHECK_THROW(Path::parse("\"x\",y"), ML::Exception);
+        BOOST_CHECK_THROW(Path::parse("\n"), MLDB::Exception);
+        BOOST_CHECK_THROW(Path::parse("\0", 1), MLDB::Exception);
+        BOOST_CHECK_THROW(Path::parse("\"\0\"", 3), MLDB::Exception);
+        BOOST_CHECK_THROW(Path::parse("\""), MLDB::Exception);
+        BOOST_CHECK_THROW(Path::parse("\"x."), MLDB::Exception);
+        BOOST_CHECK_THROW(Path::parse("\"x."), MLDB::Exception);
+        BOOST_CHECK_THROW(Path::parse("x\"\""), MLDB::Exception);
+        BOOST_CHECK_THROW(Path::parse("\"x\",y"), MLDB::Exception);
     }
 
     {
@@ -438,12 +438,12 @@ BOOST_AUTO_TEST_CASE(test_null)
     // pe = path element
     // p = path
     JML_TRACE_EXCEPTIONS(false);
-    BOOST_CHECK_THROW(null + e, ML::Exception); // pe - pe, null lhs
-    BOOST_CHECK_THROW(e + null, ML::Exception); // pe - pe, null rhs
-    BOOST_CHECK_THROW(null + std::move(e), ML::Exception); // pe - moved pe, null lhs
-    BOOST_CHECK_THROW(e + std::move(null), ML::Exception); // pe - moved pe, null rhs
-    BOOST_CHECK_THROW(null + p, ML::Exception); // pe - path, null lhs
-    BOOST_CHECK_THROW(null + std::move(p), ML::Exception); // pe - moved path, null lhs
-    BOOST_CHECK_THROW(p + null, ML::Exception); // path - pe, null rhs
-    BOOST_CHECK_THROW(p + std::move(null), ML::Exception); // path - moved pe, null rhs
+    BOOST_CHECK_THROW(null + e, MLDB::Exception); // pe - pe, null lhs
+    BOOST_CHECK_THROW(e + null, MLDB::Exception); // pe - pe, null rhs
+    BOOST_CHECK_THROW(null + std::move(e), MLDB::Exception); // pe - moved pe, null lhs
+    BOOST_CHECK_THROW(e + std::move(null), MLDB::Exception); // pe - moved pe, null rhs
+    BOOST_CHECK_THROW(null + p, MLDB::Exception); // pe - path, null lhs
+    BOOST_CHECK_THROW(null + std::move(p), MLDB::Exception); // pe - moved path, null lhs
+    BOOST_CHECK_THROW(p + null, MLDB::Exception); // path - pe, null rhs
+    BOOST_CHECK_THROW(p + std::move(null), MLDB::Exception); // path - moved pe, null rhs
 }

--- a/sql/tokenize.cc
+++ b/sql/tokenize.cc
@@ -88,7 +88,7 @@ struct NGramer {
           count(0), buffer_pos(0)
     {
         if(max_range<min_range || min_range<1 || max_range<1)
-            throw ML::Exception("ngramRange values must be bigger than 0 "
+            throw MLDB::Exception("ngramRange values must be bigger than 0 "
                     "and the second value needs to be equal or bigger than the first");
     
         buffer.resize(max_range);
@@ -135,7 +135,7 @@ struct NGramer {
 
 
 
-char32_t expectUtf8Char(ML::Parse_Context & context)
+char32_t expectUtf8Char(ParseContext & context)
 {
     if (!context)
         context.exception("Expected UTF-8 character but got EOF instead");
@@ -169,9 +169,9 @@ char32_t expectUtf8Char(ML::Parse_Context & context)
     return res;
 }
 
-static bool matchUtf8Literal(ML::Parse_Context & context, const Utf8String& literal)
+static bool matchUtf8Literal(ParseContext & context, const Utf8String& literal)
 {
-    ML::Parse_Context::Revert_Token token(context);
+    ParseContext::Revert_Token token(context);
     auto it = literal.begin();
     while (!context.eof() && it != literal.end())
     {
@@ -189,9 +189,9 @@ static bool matchUtf8Literal(ML::Parse_Context & context, const Utf8String& lite
     return false;
 }
 
-static bool matchOneOfUtf8(ML::Parse_Context & context, const Utf8String& literals)
+static bool matchOneOfUtf8(ParseContext & context, const Utf8String& literals)
 {
-    ML::Parse_Context::Revert_Token token(context);
+    ParseContext::Revert_Token token(context);
 
     if (context.eof())
        return false;
@@ -211,12 +211,12 @@ static bool matchOneOfUtf8(ML::Parse_Context & context, const Utf8String& litera
 
 void
 tokenize_exec(std::function<bool (Utf8String&)> exec,
-              ML::Parse_Context& context,
+              ParseContext& context,
               const Utf8String& splitchars,
               const Utf8String& quotechar,
               int minTokenLength)
 {
-    auto expect_token = [=] (ML::Parse_Context& context, bool& another) -> Utf8String
+    auto expect_token = [=] (ParseContext& context, bool& another) -> Utf8String
         {
             Utf8String result;
 
@@ -259,7 +259,7 @@ tokenize_exec(std::function<bool (Utf8String&)> exec,
             }
 
             if (quoted)
-                throw ML::Exception("string finished inside quote");
+                throw MLDB::Exception("string finished inside quote");
 
             return result;
         };
@@ -280,7 +280,7 @@ tokenize_exec(std::function<bool (Utf8String&)> exec,
 }
 
 bool tokenize(std::unordered_map<Utf8String, int>& bagOfWords,
-              ML::Parse_Context& pcontext,
+              ParseContext& pcontext,
               const TokenizeOptions & options)
 {
     int count = 0;
@@ -325,7 +325,7 @@ bool tokenize(std::unordered_map<Utf8String, int>& bagOfWords,
 }
 
 
-Utf8String token_extract(ML::Parse_Context& context,
+Utf8String token_extract(ParseContext& context,
                          int nth,
                          const TokenizeOptions & options)
 {

--- a/sql/tokenize.h
+++ b/sql/tokenize.h
@@ -18,7 +18,7 @@
 #include "cell_value.h"
 
 namespace ML {
-struct Parse_Context;
+struct ParseContext;
 }
 
 namespace MLDB {
@@ -40,18 +40,18 @@ DECLARE_STRUCTURE_DESCRIPTION(TokenizeOptions);
 
 void
 tokenize_exec(std::function<bool (Utf8String&)> exec,
-              ML::Parse_Context& context,
+              ParseContext& context,
               const Utf8String& splitchars,
               const Utf8String& quotechar,
               int minTokenLength);
 
-char32_t expectUtf8Char(ML::Parse_Context & context);
+char32_t expectUtf8Char(ParseContext & context);
 
 bool tokenize(std::unordered_map<Utf8String, int>& bagOfWords,
-              ML::Parse_Context& pcontext,
+              ParseContext& pcontext,
               const TokenizeOptions & options);
 
-Utf8String token_extract(ML::Parse_Context& context,
+Utf8String token_extract(ParseContext& context,
                          int nth,
                          const TokenizeOptions & options);
 

--- a/tensorflow/tensorflow_plugin.cc
+++ b/tensorflow/tensorflow_plugin.cc
@@ -1377,8 +1377,8 @@ struct TensorflowGraphBase: public Function {
         for (const auto & st: sortedStats) {
             if (i++ % 50 == 0)
                 cerr << "device    \tkernel                                            \tsched\twait\tpre\trun\tpost" << endl;
-                    cerr << ML::format("%-10s", string(st.first.first, st.first.first.length() - 5).c_str())
-                 << "\t" << ML::format("%-50s", st.first.second.c_str()) << "\t"
+                    cerr << MLDB::format("%-10s", string(st.first.first, st.first.first.length() - 5).c_str())
+                 << "\t" << MLDB::format("%-50s", st.first.second.c_str()) << "\t"
                  << st.second.sched << "\t" << st.second.wait << "\t"
                  << st.second.pre << "\t" << st.second.run << "\t"
                  << st.second.post << endl;

--- a/testing/MLDB-1025-output-dataset-serialization-test.cc
+++ b/testing/MLDB-1025-output-dataset-serialization-test.cc
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE( test_output_dataset_parsing )
     Json::Value conf;
     Json::Reader reader;
     if (!reader.parse(jsConf, conf))
-        throw ML::Exception("can't parse js conf");
+        throw MLDB::Exception("can't parse js conf");
 
     // convert it to an Any, the way it would be received in
     // the params field of a procedure config struct
@@ -57,7 +57,7 @@ ConfigType createConfig(const std::string & datasetName, const std::string input
     Json::Value conf;
     Json::Reader reader;
     if (!reader.parse(jsConf, conf))
-        throw ML::Exception("can't parse js conf");
+        throw MLDB::Exception("can't parse js conf");
     
     Any params(conf);
     return params.convert<ConfigType>();

--- a/testing/MLDB-1360-sparse-mutable-multithreaded-insert.cc
+++ b/testing/MLDB-1360-sparse-mutable-multithreaded-insert.cc
@@ -51,7 +51,7 @@ void testMtInsert(MutableSparseMatrixDatasetConfig config)
 
     cerr << "testing " << jsonEncode(config) << endl;
 
-    ML::Timer timer;
+    Timer timer;
 
     std::vector<std::thread> threads;
     for (unsigned i = 0;  i < nthreads;  ++i)

--- a/testing/MLDB-1742-tabular-dataset-integer-columns.cc
+++ b/testing/MLDB-1742-tabular-dataset-integer-columns.cc
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE( test_frozen_ints_only )
 
     auto frozen = freezeAndTest(vals);
 
-    BOOST_CHECK_EQUAL(ML::type_name(*frozen),
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
                       "MLDB::IntegerFrozenColumn");
 }
 
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE( test_frozen_ints_and_nulls_only )
 
     auto frozen = freezeAndTest(vals);
 
-    BOOST_CHECK_EQUAL(ML::type_name(*frozen),
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
                       "MLDB::IntegerFrozenColumn");
 }
 
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE( test_frozen_neg_ints )
 
     auto frozen = freezeAndTest(vals);
 
-    BOOST_CHECK_EQUAL(ML::type_name(*frozen),
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
                    "MLDB::IntegerFrozenColumn");
 }
 
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE( test_frozen_neg_ints_and_nulls_only )
 
     auto frozen = freezeAndTest(vals);
 
-    BOOST_CHECK_EQUAL(ML::type_name(*frozen),
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
                    "MLDB::IntegerFrozenColumn");
 }
 
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE( test_frozen_neg_only_ints_and_nulls )
 
     auto frozen = freezeAndTest(vals);
 
-    BOOST_CHECK_EQUAL(ML::type_name(*frozen),
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
                    "MLDB::IntegerFrozenColumn");
 }
 
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE( test_big_pos_neg_range )
 
     auto frozen = freezeAndTest(vals);
 
-    BOOST_CHECK_EQUAL(ML::type_name(*frozen),
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
                    "MLDB::IntegerFrozenColumn");
 }
 

--- a/testing/MLDB-896_table_expression_serialised_as_string.cc
+++ b/testing/MLDB-896_table_expression_serialised_as_string.cc
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE( tbl_expression_serialised_as_string )
     Json::Value conf;
     Json::Reader reader;
     if (!reader.parse(jsConf, conf))
-        throw ML::Exception("can't parse js conf");
+        throw MLDB::Exception("can't parse js conf");
     
     // convert it to an Any, the way it would be received in
     // the params field of a procedure config struct

--- a/testing/MLDB-991_permuter_permutations.cc
+++ b/testing/MLDB-991_permuter_permutations.cc
@@ -27,7 +27,7 @@ Json::Value parse(const string & js)
     Json::Value root;
     Json::Reader reader;
     if(!reader.parse(js, root))
-        throw ML::Exception("unable to parse");
+        throw MLDB::Exception("unable to parse");
     return root;
 }
 
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE( simple_permutation )
 
     set<string> keyVals;
     for(auto & conf : configs) {
-        keyVals.insert(ML::format("%d%s", conf["args"]["hoho"].asInt(),
+        keyVals.insert(MLDB::format("%d%s", conf["args"]["hoho"].asInt(),
                                           conf["args"]["bouya"].asString()));
     }
 
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE( deeper_permutation )
     
     set<string> keyvals;
     for(auto & conf : configs) {
-        keyvals.insert(ML::format("%d%s%s%s", conf["args"]["hoho"].asInt(),
+        keyvals.insert(MLDB::format("%d%s%s%s", conf["args"]["hoho"].asInt(),
                                               conf["args"]["bouya"].asString(),
                                               conf["args"]["deep"]["learning"].asString(),
                                               conf["args"]["deep"]["deeper"]["cobb"].asString()));

--- a/testing/MLDBFB-239-s3-test.cc
+++ b/testing/MLDBFB-239-s3-test.cc
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE( test_s3_attributes )
 
     ML::Call_Guard guard([&] () { for (auto & f: filesToClean) tryEraseUriObject(f); });
 
-    string filename = ML::format("s3://%s/attributes"
+    string filename = MLDB::format("s3://%s/attributes"
                                  "/pid-%d-reduced-redundancy",
                                  bucket.c_str(), getpid());
     filesToClean.push_back(filename);
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE( test_s3_foreach_bucket )
     set<string> buckets;
     auto onBucket = [&] (const string & name) {
         if (buckets.count(name)) {
-            throw ML::Exception("bucket already reported");
+            throw MLDB::Exception("bucket already reported");
         }
         buckets.insert(name);
         return true;
@@ -428,10 +428,10 @@ BOOST_AUTO_TEST_CASE( test_s3_getObjectInfo )
 
         /* unexisting object */
         BOOST_CHECK_THROW(s3Api->getObjectInfo(bucket, filename + "-missing"),
-                          ML::Exception);
+                          MLDB::Exception);
         BOOST_CHECK_THROW(s3Api->getObjectInfo(bucket, filename + "-missing",
                                                S3ObjectInfoTypes::FULL_INFO),
-                          ML::Exception);
+                          MLDB::Exception);
 
         /* "try" versions on unexisting */
         info = s3Api->tryGetObjectInfo(bucket, filename + "-missing");
@@ -463,10 +463,10 @@ BOOST_AUTO_TEST_CASE( test_s3_getObjectInfo )
 
         /* unexisting object */
         BOOST_CHECK_THROW(s3Api->getObjectInfo(url + "-missing"),
-                          ML::Exception);
+                          MLDB::Exception);
         BOOST_CHECK_THROW(s3Api->getObjectInfo(url + "-missing",
                                                S3ObjectInfoTypes::FULL_INFO),
-                          ML::Exception);
+                          MLDB::Exception);
 
         /* "try" versions on unexisting */
         info = s3Api->tryGetObjectInfo(url + "-missing");

--- a/testing/cell_value_test.cc
+++ b/testing/cell_value_test.cc
@@ -42,9 +42,9 @@ BOOST_AUTO_TEST_CASE( test_basics )
     //BOOST_CHECK_NO_THROW(CellValue(L"Mutua Madrileña Madrid Open").cellType());
     {
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(CellValue(std::string("Crédit Agricole Suisse Open Gstaad")).cellType(), ML::Exception);
+        BOOST_CHECK_THROW(CellValue(std::string("Crédit Agricole Suisse Open Gstaad")).cellType(), MLDB::Exception);
         BOOST_CHECK_THROW(CellValue(std::string("Mutua Madrileña Madrid Open")).cellType(),
-                          ML::Exception);
+                          MLDB::Exception);
     }
     BOOST_CHECK_EQUAL(CellValue(Utf8String("Crédit Agricole Suisse Open Gstaad")).cellType(), CellValue::UTF8_STRING);
     BOOST_CHECK_EQUAL(CellValue(Utf8String("Mutua Madrileña Madrid Open")).cellType(), CellValue::UTF8_STRING);
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE( test_64_bit_range )
     {
         JML_TRACE_EXCEPTIONS(false);
         auto v = [&] () { return CellValue(std::numeric_limits<uint64_t>::max()).toInt(); };
-        BOOST_CHECK_THROW(v(), ML::Exception);
+        BOOST_CHECK_THROW(v(), MLDB::Exception);
     }
 }
 

--- a/testing/credentials_persistence_test.cc
+++ b/testing/credentials_persistence_test.cc
@@ -38,7 +38,7 @@ void addCredentialRule(const HttpRestProxy & conn,
 
     if (res.code() != 201) {
         std::cerr << res << std::endl;
-        throw ML::Exception("Couldn't add credentials: returned code %d",
+        throw MLDB::Exception("Couldn't add credentials: returned code %d",
                             res.code());
     }
 }
@@ -49,7 +49,7 @@ void deleteAllCredentials(const HttpRestProxy & conn)
     auto res = conn.perform("DELETE", "/v1/credentials");
     if (res.code() != 200 && res.code() != 204) {
         std::cerr << res << std::endl;
-        throw ML::Exception("Couldn't delete credentials: returned code %d",
+        throw MLDB::Exception("Couldn't delete credentials: returned code %d",
                             res.code());
     }
 }
@@ -63,7 +63,7 @@ void deleteCredentialRule(const HttpRestProxy & conn,
     auto res = conn.perform("DELETE", uri);
     if (res.code() != 200 && res.code() != 204) {
         std::cerr << res << std::endl;
-        throw ML::Exception("Couldn't delete credentials: returned code %d",
+        throw MLDB::Exception("Couldn't delete credentials: returned code %d",
                             res.code());
     }
 }

--- a/testing/expression_value_test.cc
+++ b/testing/expression_value_test.cc
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE( test_get_embedding_row )
 
     auto dist = val2.getEmbedding(cols, 2);
 
-    ML::distribution<double> expected{1, 2};
+    distribution<double> expected{1, 2};
 
     BOOST_CHECK_EQUAL(dist, expected);
 
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE( test_get_embedding_row )
 
     dist = val2.getEmbedding(cols2, 2);
 
-    ML::distribution<double> expected2{2, 1};
+    distribution<double> expected2{2, 1};
 
     BOOST_CHECK_EQUAL(dist, expected2);
 }

--- a/testing/for_each_line_test.cc
+++ b/testing/for_each_line_test.cc
@@ -83,9 +83,9 @@ BOOST_AUTO_TEST_CASE( test_forEachLine_throw )
     atomic<int> count(0);
     auto processLine = [&] (const string & data, int64_t lineNum) {
         if (count.fetch_add(1) > 500) {
-            throw ML::Exception("thrown");
+            throw MLDB::Exception("thrown");
         }
     };
 
-    BOOST_CHECK_THROW(forEachLineStr(stream, processLine), ML::Exception);
+    BOOST_CHECK_THROW(forEachLineStr(stream, processLine), MLDB::Exception);
 }

--- a/testing/mldb_crash_multiple_py_routes.cc
+++ b/testing/mldb_crash_multiple_py_routes.cc
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE( test_python_loading )
     plugRes.address = "git://github.com/datacratic/mldb-cls-plugin.git";
     pluginConfig2.params = plugRes;
 
-    auto putResult = proxy.put(ML::format("/v1/plugins/cls%d", 0),
+    auto putResult = proxy.put(MLDB::format("/v1/plugins/cls%d", 0),
                                jsonEncode(pluginConfig2));
     cerr << putResult << endl;
     auto jsPutResult = putResult.jsonBody();
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE( test_python_loading )
 
     vector<string> calls;
     int j = 0;
-    string url = ML::format("curl %s/v1/plugins/cls%d", httpBoundAddress, j);
+    string url = MLDB::format("curl %s/v1/plugins/cls%d", httpBoundAddress, j);
     for(int i=0; i<500; i++) {
         calls.push_back(url + "/routes/dataset-details");
         calls.push_back(url + "/routes/classifier-list");

--- a/testing/mldb_determinism_test.cc
+++ b/testing/mldb_determinism_test.cc
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE( test_determinism_agggregator )
 
     for (int i = 0; i < 1001; ++i)
     {
-       addRow(ML::format("row_%d", i), i);
+       addRow(MLDB::format("row_%d", i), i);
     }
 
      // Commit it.  This will also create our distance index

--- a/testing/sql_expression_test.cc
+++ b/testing/sql_expression_test.cc
@@ -937,7 +937,7 @@ BOOST_AUTO_TEST_CASE(test_result_variable_expressions)
     {
         JML_TRACE_EXCEPTIONS(false);
         BOOST_CHECK_THROW(SqlRowExpression::parse("* EXCLUDING bonus AS myvar*"),
-                          ML::Exception);
+                          MLDB::Exception);
     }
 
     {
@@ -977,7 +977,7 @@ BOOST_AUTO_TEST_CASE(test_result_variable_expressions)
         // MLDB-200
         JML_TRACE_EXCEPTIONS(false);
         BOOST_CHECK_THROW(SqlRowExpression::parse("2.2*"),
-                          ML::Exception);
+                          MLDB::Exception);
     }
 
     {
@@ -1125,25 +1125,25 @@ BOOST_AUTO_TEST_CASE(test_select_statement_parse)
     }
 
     {
-        ML::Set_Trace_Exceptions trace(false);
+        Set_Trace_Exceptions trace(false);
 
-        BOOST_CHECK_THROW(SelectStatement::parse("select * SELECT *"), ML::Exception);
+        BOOST_CHECK_THROW(SelectStatement::parse("select * SELECT *"), MLDB::Exception);
 
-        BOOST_CHECK_THROW(SelectStatement::parse("where a = 0 where b = 0"), ML::Exception);
-        BOOST_CHECK_THROW(SelectStatement::parse("having a = 0 having b = 0"), ML::Exception);
+        BOOST_CHECK_THROW(SelectStatement::parse("where a = 0 where b = 0"), MLDB::Exception);
+        BOOST_CHECK_THROW(SelectStatement::parse("having a = 0 having b = 0"), MLDB::Exception);
 
-        BOOST_CHECK_THROW(SelectStatement::parse("group by a group by b"), ML::Exception);
-        BOOST_CHECK_THROW(SelectStatement::parse("order by a order by b"), ML::Exception);
+        BOOST_CHECK_THROW(SelectStatement::parse("group by a group by b"), MLDB::Exception);
+        BOOST_CHECK_THROW(SelectStatement::parse("order by a order by b"), MLDB::Exception);
 
-        BOOST_CHECK_THROW(SelectStatement::parse("limit 10 limit 20"), ML::Exception);
-        BOOST_CHECK_THROW(SelectStatement::parse("offset 10 offset 20"), ML::Exception);
+        BOOST_CHECK_THROW(SelectStatement::parse("limit 10 limit 20"), MLDB::Exception);
+        BOOST_CHECK_THROW(SelectStatement::parse("offset 10 offset 20"), MLDB::Exception);
     }
 
     {
         // MLDB-637
         auto statement = SelectStatement::parse("select 1 from table");
         BOOST_CHECK_EQUAL(statement.select.clauses.size(), 1);
-        BOOST_CHECK_EQUAL(ML::type_name(*statement.select.clauses[0].get()),
+        BOOST_CHECK_EQUAL(MLDB::type_name(*statement.select.clauses[0].get()),
                           "MLDB::NamedColumnExpression");
         auto cast = dynamic_cast<NamedColumnExpression *>(statement.select.clauses[0].get());
         BOOST_CHECK_EQUAL(cast->alias, ColumnPath("1"));

--- a/types/any.cc
+++ b/types/any.cc
@@ -172,7 +172,7 @@ void
 Any::
 throwNoValueDescription() const
 {
-    throw ML::Exception("Any had no type attached");
+    throw MLDB::Exception("Any had no type attached");
 }
 
 bool operator==(const Any & lhs, const Any & rhs)

--- a/types/any_impl.h
+++ b/types/any_impl.h
@@ -24,8 +24,8 @@ Any::
 as() const
 {
     if (!type_)
-        throw ML::Exception("bad Any cast: null value can't convert to '%s'",
-                            ML::type_name<T>().c_str());
+        throw MLDB::Exception("bad Any cast: null value can't convert to '%s'",
+                            MLDB::type_name<T>().c_str());
 
     // If the same type, conversion is trivial
     if (type_ == &typeid(T))
@@ -37,9 +37,9 @@ as() const
     //    return *reinterpret_cast<const T *>(res);
 
     // Otherwise, no conversion is possible
-    throw ML::Exception("bad Any cast: requested '%s', contained '%s'",
-                        ML::type_name<T>().c_str(),
-                        ML::demangle(*type_).c_str());
+    throw MLDB::Exception("bad Any cast: requested '%s', contained '%s'",
+                        MLDB::type_name<T>().c_str(),
+                        demangle(*type_).c_str());
 }
 
 template<typename T>
@@ -71,9 +71,9 @@ convert(const ValueDescription & desc) const
     }
 
     // Otherwise, no conversion is possible
-    throw ML::Exception("bad Any conversion: requested '%s', contained '%s'",
-                        ML::type_name<T>().c_str(),
-                        ML::demangle(*type_).c_str());
+    throw MLDB::Exception("bad Any conversion: requested '%s', contained '%s'",
+                        MLDB::type_name<T>().c_str(),
+                        demangle(*type_).c_str());
 }
 
 /** Assign a new value of the same type. */

--- a/types/date.cc
+++ b/types/date.cc
@@ -23,17 +23,16 @@
 
 
 using namespace std;
-using namespace ML;
 using namespace MLDB;
 
 namespace {
 
 bool
-matchFixedWidthInt(ML::Parse_Context & context,
+matchFixedWidthInt(ParseContext & context,
                    int minLength, int maxLength,
                    int min, int max, int & value)
 {
-    ML::Parse_Context::Revert_Token token(context);
+    ParseContext::Revert_Token token(context);
 
     char buf[maxLength + 1];
     unsigned i = 0;
@@ -71,7 +70,7 @@ matchFixedWidthInt(ML::Parse_Context & context,
 }
 
 int
-expectFixedWidthInt(ML::Parse_Context & context,
+expectFixedWidthInt(ParseContext & context,
                     int minLength, int maxLength,
                     int min, int max, const char * message)
 {
@@ -149,9 +148,9 @@ parseSecondsSinceEpoch(const std::string & date)
     char * end = 0;
     double seconds = strtod(date.c_str(), &end);
     if (errno != 0)
-        throw ML::Exception(errno, "date parseSecondsSinceEpoch: " + date);
+        throw MLDB::Exception(errno, "date parseSecondsSinceEpoch: " + date);
     if (end != date.c_str() + date.length())
-        throw ML::Exception("couldn't convert " + date + " to date");
+        throw MLDB::Exception("couldn't convert " + date + " to date");
     return fromSecondsSinceEpoch(seconds);
 }
 
@@ -237,7 +236,7 @@ now()
     timespec time;
     int res = clock_gettime(CLOCK_REALTIME, &time);
     if (res == -1)
-        throw ML::Exception(errno, "clock_gettime");
+        throw MLDB::Exception(errno, "clock_gettime");
     return fromSecondsSinceEpoch(time.tv_sec + time.tv_nsec * 0.000000001);
 }
 
@@ -313,7 +312,7 @@ static void addFractionalSeconds(std::string & result,
         // Remove the leading "0" and append
         result.append(fractional, 1, -1);
     }
-    else throw ML::Exception("Unknown seconds_digits argument %d to Date::printIso8601()",
+    else throw MLDB::Exception("Unknown seconds_digits argument %d to Date::printIso8601()",
                              seconds_digits);
 }
 
@@ -437,7 +436,7 @@ quantize(double fraction)
 
         uint64_t frac = fraction;
         if (frac != fraction)
-            throw ML::Exception("non-integral numbers of seconds not supported");
+            throw MLDB::Exception("non-integral numbers of seconds not supported");
         uint64_t whole2 = whole_seconds;
         whole2 /= fraction;
         secondsSinceEpoch_ = whole2 * fraction;
@@ -919,11 +918,11 @@ std::istream & operator >> (std::istream & stream, Date & date)
 
 bool
 Date::
-match_date(ML::Parse_Context & context,
+match_date(ParseContext & context,
            Date & result,
            const std::string & format)
 {
-    Parse_Context::Revert_Token token(context);
+    ParseContext::Revert_Token token(context);
     
     int year = -1, month = 1, day = 1;
     
@@ -1055,7 +1054,7 @@ match_date(ML::Parse_Context & context,
 
 Date
 Date::
-expect_date(ML::Parse_Context & context, const std::string & format)
+expect_date(ParseContext & context, const std::string & format)
 {
     int year = -1, month = 1, day = 1;
 
@@ -1196,7 +1195,7 @@ expect_date(ML::Parse_Context & context, const std::string & format)
 #if 0
 Date
 Date::
-expect_date(ML::Parse_Context & context,
+expect_date(ParseContext & context,
            const std::string & format)
 {
     Date result;
@@ -1208,11 +1207,11 @@ expect_date(ML::Parse_Context & context,
 
 bool
 Date::
-match_time(ML::Parse_Context & context,
+match_time(ParseContext & context,
            double & result,
            const std::string & format)
 {
-    Parse_Context::Revert_Token token(context);
+    ParseContext::Revert_Token token(context);
 
     int hour = 0, minute = 0, offset = 0;
     double second = 0;
@@ -1287,7 +1286,7 @@ match_time(ML::Parse_Context & context,
 
 double
 Date::
-expect_time(ML::Parse_Context & context, const std::string & format)
+expect_time(ParseContext & context, const std::string & format)
 {
     int hour = 0, minute = 0, offset = 0;
     double second = 0;
@@ -1359,7 +1358,7 @@ expect_time(ML::Parse_Context & context, const std::string & format)
 #if 0
 double
 Date::
-expect_time(ML::Parse_Context & context,
+expect_time(ParseContext & context,
            const std::string & format)
 {
     double time;
@@ -1409,7 +1408,7 @@ parse_date_time(const std::string & str,
     
     Date result;
     try {
-        ML::Parse_Context context(str,
+        ParseContext context(str,
                                   str.c_str(), str.c_str() + str.length());
         result = expect_date_time(context, date_format, time_format);
         
@@ -1425,7 +1424,7 @@ parse_date_time(const std::string & str,
 
 Date
 Date::
-expect_date_time(ML::Parse_Context & context,
+expect_date_time(ParseContext & context,
                  const std::string & date_format,
                  const std::string & time_format)
 {
@@ -1435,7 +1434,7 @@ expect_date_time(ML::Parse_Context & context,
     date = expect_date(context, date_format);
     
     if (!context.eof()) {
-        Parse_Context::Revert_Token token(context);
+        ParseContext::Revert_Token token(context);
         context.match_whitespace();
         if (match_time(context, time, time_format))
             token.ignore();
@@ -1446,7 +1445,7 @@ expect_date_time(ML::Parse_Context & context,
 
 bool
 Date::
-match_date_time(ML::Parse_Context & context,
+match_date_time(ParseContext & context,
                 Date & result,
                 const std::string & date_format,
                 const std::string & time_format)
@@ -1468,7 +1467,7 @@ Date Date::parse(const std::string & date,
     tm time;
     memset(&time, 0, sizeof(time));
     if(strptime(date.c_str(), format.c_str(), &time) == NULL)
-        throw ML::Exception("strptime error. format='" + format + "', string='" + date + "'");
+        throw MLDB::Exception("strptime error. format='" + format + "', string='" + date + "'");
 
     //not using fromTm because I don't want it to assume it's local time
     return Date(1900 + time.tm_year, 1 + time.tm_mon, time.tm_mday,
@@ -1483,7 +1482,7 @@ toTm() const
     errno = 0;
     time_t t = toTimeT();
     if (gmtime_r(&t, &result) == 0)
-        throw ML::Exception("error converting time: t = %lld",
+        throw MLDB::Exception("error converting time: t = %lld",
                             (long long)t,
                             strerror(errno));
     return result;
@@ -1496,7 +1495,7 @@ fromTm(const tm & t)
     tm t2 = t;
     time_t t3 = mktime(&t2);
     if (t3 == (time_t)-1)
-        throw ML::Exception("couldn't construct from invalid time");
+        throw MLDB::Exception("couldn't construct from invalid time");
     return fromTimeT(t3);
 }
 
@@ -1507,7 +1506,7 @@ void Date::addFromString(string str){
         string format = "^[1-9][0-9]*[SMHd]$";
         regex e(format);
         if(!regex_match(str, e)){
-            throw ML::Exception("String " + str + " did not match format "
+            throw MLDB::Exception("String " + str + " did not match format "
                 + format);
         }
     }
@@ -1532,7 +1531,7 @@ void Date::addFromString(string str){
             this->addDays(length);
             break;
         default:
-            throw ML::Exception("Should never get here with string: " + str);
+            throw MLDB::Exception("Should never get here with string: " + str);
             break;
     }
 }
@@ -1544,7 +1543,7 @@ void Date::addFromString(string str){
 
 Iso8601Parser::
 Iso8601Parser(const std::string & dateStr)
-    : parser(new Parse_Context(dateStr, dateStr.c_str(),
+    : parser(new ParseContext(dateStr, dateStr.c_str(),
                                dateStr.c_str() + dateStr.size()))
 {
 }
@@ -1637,7 +1636,7 @@ matchDate(Date &date)
         int day(1);
 
         {
-            ML::Parse_Context::Revert_Token token(*parser);
+            ParseContext::Revert_Token token(*parser);
 
             if (matchYearDay(day) && (parser->eof() || !isdigit(*(*parser)))) {
                 Date tempDate(year, 1, 1);
@@ -1745,7 +1744,7 @@ bool
 Iso8601Parser::
 matchTimezone(int& tzminutes)
 {
-    ML::Parse_Context::Revert_Token token(*parser);
+    ParseContext::Revert_Token token(*parser);
     if (parser->match_literal('+')) {
         if (matchTimeZoneMinutes(tzminutes)) {
             token.ignore();
@@ -2023,7 +2022,7 @@ printJsonTyped(const Date * val,
 /* TIME UNITS                                                                */
 /*****************************************************************************/
 
-TimeUnit ParseTimeUnit(ML::Parse_Context& context)
+TimeUnit ParseTimeUnit(ParseContext& context)
 {
     if (context.match_test_icase("MICROSECOND"))  {
         return MICROSECOND;
@@ -2079,7 +2078,7 @@ TimeUnit ParseTimeUnit(ML::Parse_Context& context)
 
 TimeUnit ParseTimeUnit(std::string& sinput)
 {
-    ML::Parse_Context context(sinput, sinput.c_str(), sinput.c_str() + sinput.size());
+    ParseContext context(sinput, sinput.c_str(), sinput.c_str() + sinput.size());
     return ParseTimeUnit(context);
 }
 

--- a/types/date.h
+++ b/types/date.h
@@ -21,14 +21,12 @@ class Value;
 
 } // namespace Json
 
-namespace ML {
-struct Parse_Context;
-} // namespace ML
 
 namespace MLDB {
 namespace JS {
 struct JSValue;
 } // namespace JS
+struct ParseContext;
 
 /*****************************************************************************/
 /* TIME UNITS                                                                */
@@ -55,7 +53,7 @@ enum TimeUnit
     TIMEUNIT_INVALID
 };
 
-TimeUnit ParseTimeUnit(ML::Parse_Context& context);
+TimeUnit ParseTimeUnit(ParseContext& context);
 TimeUnit ParseTimeUnit(std::string& sinput);
 
 /*****************************************************************************/
@@ -368,22 +366,22 @@ struct Date {
 
     //static const boost::posix_time::ptime epoch;
 
-    static Date expect_date(ML::Parse_Context & context,
+    static Date expect_date(ParseContext & context,
                             const std::string & format);
-    static bool match_date(ML::Parse_Context & context, Date & date,
+    static bool match_date(ParseContext & context, Date & date,
                            const std::string & format);
     
-    static double expect_time(ML::Parse_Context & context,
+    static double expect_time(ParseContext & context,
                               const std::string & format);
-    static bool match_time(ML::Parse_Context & context,
+    static bool match_time(ParseContext & context,
                            double & time,
                            const std::string & format);
 
-    static Date expect_date_time(ML::Parse_Context & context,
+    static Date expect_date_time(ParseContext & context,
                                  const std::string & date_format,
                                  const std::string & time_format);
 
-    static bool match_date_time(ML::Parse_Context & context,
+    static bool match_date_time(ParseContext & context,
                                 Date & result,
                                 const std::string & date_format,
                                 const std::string & time_format);
@@ -510,7 +508,7 @@ private:
     int expectTimeZoneMinutes();
     bool matchTimeZoneMinutes(int & result);
 
-     std::unique_ptr<ML::Parse_Context> parser;
+     std::unique_ptr<ParseContext> parser;
  };
 
 PREDECLARE_VALUE_DESCRIPTION(Date);

--- a/types/distribution_description.h
+++ b/types/distribution_description.h
@@ -1,8 +1,7 @@
-// This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
-
 /** value_descriptions.h                                           -*- C++ -*-
     Jeremy Barnes, 5 January 2015
     Copyright (c) 2015 Datacratic Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2015 Datacratic. All rights reserved.
 
 */
 
@@ -22,7 +21,7 @@ namespace MLDB {
 
 template<typename T, typename Underlying>
 struct DistributionValueDescription
-    : public ValueDescriptionI<ML::distribution<T, Underlying>, ValueKind::ARRAY,
+    : public ValueDescriptionI<distribution<T, Underlying>, ValueKind::ARRAY,
                                DistributionValueDescription<T, Underlying> >,
       public ListDescriptionBase<T> {
 
@@ -44,12 +43,12 @@ struct DistributionValueDescription
     virtual void
     parseJson(void * val, JsonParsingContext & context) const override
     {
-        ML::distribution<T, Underlying> * val2 = reinterpret_cast<ML::distribution<T, Underlying> *>(val);
+        distribution<T, Underlying> * val2 = reinterpret_cast<distribution<T, Underlying> *>(val);
         return parseJsonTyped(val2, context);
     }
 
     virtual void
-    parseJsonTyped(ML::distribution<T, Underlying> * val,
+    parseJsonTyped(distribution<T, Underlying> * val,
                    JsonParsingContext & context) const override
     {
         this->parseJsonTypedList(val, context);
@@ -58,12 +57,12 @@ struct DistributionValueDescription
     virtual void
     printJson(const void * val, JsonPrintingContext & context) const override
     {
-        const ML::distribution<T, Underlying> * val2 = reinterpret_cast<const ML::distribution<T, Underlying> *>(val);
+        const distribution<T, Underlying> * val2 = reinterpret_cast<const distribution<T, Underlying> *>(val);
         return printJsonTyped(val2, context);
     }
 
     virtual void
-    printJsonTyped(const ML::distribution<T, Underlying> * val,
+    printJsonTyped(const distribution<T, Underlying> * val,
                    JsonPrintingContext & context) const override
     {
         this->printJsonTypedList(val, context);
@@ -71,38 +70,38 @@ struct DistributionValueDescription
 
     virtual bool isDefault(const void * val) const override
     {
-        const ML::distribution<T, Underlying> * val2 = reinterpret_cast<const ML::distribution<T, Underlying> *>(val);
+        const distribution<T, Underlying> * val2 = reinterpret_cast<const distribution<T, Underlying> *>(val);
         return isDefaultTyped(val2);
     }
 
     virtual bool
-    isDefaultTyped(const ML::distribution<T, Underlying> * val) const override
+    isDefaultTyped(const distribution<T, Underlying> * val) const override
     {
         return val->empty();
     }
 
     virtual size_t getArrayLength(void * val) const override
     {
-        const ML::distribution<T, Underlying> * val2 = reinterpret_cast<const ML::distribution<T, Underlying> *>(val);
+        const distribution<T, Underlying> * val2 = reinterpret_cast<const distribution<T, Underlying> *>(val);
         return val2->size();
     }
 
     virtual void * getArrayElement(void * val, uint32_t element) const override
     {
-        ML::distribution<T, Underlying> * val2 = reinterpret_cast<ML::distribution<T, Underlying> *>(val);
+        distribution<T, Underlying> * val2 = reinterpret_cast<distribution<T, Underlying> *>(val);
         return &val2->at(element);
     }
 
     virtual const
     void * getArrayElement(const void * val, uint32_t element) const override
     {
-        const ML::distribution<T, Underlying> * val2 = reinterpret_cast<const ML::distribution<T, Underlying> *>(val);
+        const distribution<T, Underlying> * val2 = reinterpret_cast<const distribution<T, Underlying> *>(val);
         return &val2->at(element);
     }
 
     virtual void setArrayLength(void * val, size_t newLength) const override
     {
-        ML::distribution<T, Underlying> * val2 = reinterpret_cast<ML::distribution<T, Underlying> *>(val);
+        distribution<T, Underlying> * val2 = reinterpret_cast<distribution<T, Underlying> *>(val);
         val2->resize(newLength);
     }
     
@@ -117,19 +116,19 @@ struct DistributionValueDescription
     }
 };
 
-DECLARE_TEMPLATE_VALUE_DESCRIPTION_2(DistributionValueDescription, ML::distribution, typename, T, class, Underlying);
+DECLARE_TEMPLATE_VALUE_DESCRIPTION_2(DistributionValueDescription, distribution, typename, T, class, Underlying);
 
-MLDB::ValueDescriptionT<ML::distribution<float> > *
-getDefaultDescription(const ML::distribution<float> * = 0);
+MLDB::ValueDescriptionT<distribution<float> > *
+getDefaultDescription(const distribution<float> * = 0);
 
-MLDB::ValueDescriptionT<ML::distribution<float> > *
-getDefaultDescriptionUninitialized(const ML::distribution<float> * = 0);
+MLDB::ValueDescriptionT<distribution<float> > *
+getDefaultDescriptionUninitialized(const distribution<float> * = 0);
 
-MLDB::ValueDescriptionT<ML::distribution<double> > *
-getDefaultDescription(const ML::distribution<double> * = 0);
+MLDB::ValueDescriptionT<distribution<double> > *
+getDefaultDescription(const distribution<double> * = 0);
 
-MLDB::ValueDescriptionT<ML::distribution<double> > *
-getDefaultDescriptionUninitialized(const ML::distribution<double> * = 0);
+MLDB::ValueDescriptionT<distribution<double> > *
+getDefaultDescriptionUninitialized(const distribution<double> * = 0);
 
 extern template class DistributionValueDescription<float, std::vector<float> >;
 extern template class DistributionValueDescription<double, std::vector<double> >;

--- a/types/enum_description.h
+++ b/types/enum_description.h
@@ -31,7 +31,7 @@ struct EnumDescription: public ValueDescriptionT<Enum> {
     {
         auto it = parse.find(s);
         if (it == parse.end())
-            throw ML::Exception("unknown value for " + this->typeName
+            throw MLDB::Exception("unknown value for " + this->typeName
                                 + ": " + s);
         return it->second;
     }
@@ -98,7 +98,7 @@ struct EnumDescription: public ValueDescriptionT<Enum> {
     void addValue(const std::string & name, Enum value)
     {
         if (!parse.insert(make_pair(name, value)).second)
-            throw ML::Exception("double added name to enum");
+            throw MLDB::Exception("double added name to enum");
         print.insert({ value, { name, "" } });
     }
 
@@ -106,7 +106,7 @@ struct EnumDescription: public ValueDescriptionT<Enum> {
                   const std::string & description)
     {
         if (!parse.insert(make_pair(name, value)).second)
-            throw ML::Exception("double added name to enum");
+            throw MLDB::Exception("double added name to enum");
         print.insert({ value, { name, description } });
     }
 

--- a/types/hash_wrapper.h
+++ b/types/hash_wrapper.h
@@ -56,12 +56,12 @@ struct HashWrapper : public IntWrapper<uint64_t, Domain> {
 
     std::string toString() const
     {
-        return ML::format("%016llx", (unsigned long long)this->index());
+        return MLDB::format("%016llx", (unsigned long long)this->index());
     }
 
     std::string toTaggedString() const
     {
-        return ML::format("%016llx:%d", (unsigned long long)this->index(), Domain);
+        return MLDB::format("%016llx:%d", (unsigned long long)this->index(), Domain);
     }
 
     static HashWrapper fromString(const std::string & str)
@@ -69,7 +69,7 @@ struct HashWrapper : public IntWrapper<uint64_t, Domain> {
         unsigned long long val = 0;
         int res = sscanf(str.c_str(), "%llx", &val);
         if (res != 1)
-            throw ML::Exception("didn't finish parsing hash '%s': returned %d",
+            throw MLDB::Exception("didn't finish parsing hash '%s': returned %d",
                                 str.c_str(), res);
         return HashWrapper(val);
     }
@@ -80,10 +80,10 @@ struct HashWrapper : public IntWrapper<uint64_t, Domain> {
         int dom = 0;
         int res = sscanf(str.c_str(), "%llx:%d", &val, &dom);
         if (res != 2)
-            throw ML::Exception("didn't finish parsing hash '%s': returned %d",
+            throw MLDB::Exception("didn't finish parsing hash '%s': returned %d",
                                 str.c_str(), res);
         if (dom != Domain)
-            throw ML::Exception("wrong domain for HashWrapper");
+            throw MLDB::Exception("wrong domain for HashWrapper");
         return HashWrapper(val);
     }
 

--- a/types/id.cc
+++ b/types/id.cc
@@ -205,10 +205,10 @@ parse(const char * value, size_t len, Type type)
     auto finish = [&] ()
         {
             //if (r.toString() != value)
-            //    throw ML::Exception("Id::parse() modified an Id: input " + value
+            //    throw MLDB::Exception("Id::parse() modified an Id: input " + value
             //                        + " output " + r.toString());
             if (r.type != type && type != UNKNOWN)
-                throw ML::Exception("Id::parse() changed type from %d to %d parsing %s",
+                throw MLDB::Exception("Id::parse() changed type from %d to %d parsing %s",
                                     r.type, type, value);
 
             *this = std::move(r);
@@ -223,7 +223,7 @@ parse(const char * value, size_t len, Type type)
 
     if ((type == UNKNOWN || type == NULLID) && len == 4
         && strcmp(value, "null") == 0) {
-        //throw ML::Exception("null id");
+        //throw MLDB::Exception("null id");
         r.type = NULLID;
         r.val1 = r.val2 = 0;
         finish();
@@ -532,7 +532,7 @@ toStringLength() const
     case SHORTSTR:
         return strnlen(shortStr, 16);
     default:
-        throw ML::Exception("unknown ID type");
+        throw MLDB::Exception("unknown ID type");
     }
 }
 
@@ -546,12 +546,12 @@ toString() const
     case NULLID:
         return "null";
     case UUID:
-        return ML::format(
+        return MLDB::format(
             "%08x-%04x-%04x-%04x-%012llx",
             (unsigned)f1, (unsigned)f2, (unsigned)f3, (unsigned)f4,
             (unsigned long long)f5);
     case UUID_CAPS:
-        return ML::format(
+        return MLDB::format(
             "%08X-%04X-%04X-%04X-%012llX",
             (unsigned)f1, (unsigned)f2, (unsigned)f3, (unsigned)f4,
             (unsigned long long)f5);
@@ -566,7 +566,7 @@ toString() const
                 if (i < 62) return i - 36 + 'a';
                 if (i == 62) return '-';
                 if (i == 63) return '_';
-                throw ML::Exception("bad goog base64 char");
+                throw MLDB::Exception("bad goog base64 char");
             };
 
         auto v = make128(valLow, valHigh);
@@ -610,7 +610,7 @@ toString() const
                 if (i < 12) return '0' + i - 2;
                 if (i < 38) return 'A' + i - 12;
                 if (i < 64) return 'a' + i - 38;
-                throw ML::Exception("bad base64 char");
+                throw MLDB::Exception("bad base64 char");
             };
         
         auto v = make128(val1, val2);
@@ -620,7 +620,7 @@ toString() const
         return result;
     }
     case HEX128LC: {
-        return ML::format("%016llx%016llx",
+        return MLDB::format("%016llx%016llx",
                           (unsigned long long)val1,
                           (unsigned long long)val2);
     }
@@ -631,7 +631,7 @@ toString() const
     case SHORTSTR:
         return std::string(shortStr, shortStr + strnlen(shortStr, 16));
     default:
-        throw ML::Exception("unknown ID type");
+        throw MLDB::Exception("unknown ID type");
     }
 }
 
@@ -671,7 +671,7 @@ complexEqual(const Id & other) const
         return compoundId1() == other.compoundId1()
             && compoundId2() == other.compoundId2();
     }
-    else throw ML::Exception("unknown Id type");
+    else throw MLDB::Exception("unknown Id type");
 }
 
 bool
@@ -688,10 +688,10 @@ complexLess(const Id & other) const
         //cerr << "complex less for string" << endl;
         //cerr << "type = " << (int)type << " other.type = " << (int)other.type << endl;
 
-        //cerr << "a.val1 = " << ML::format("%016llx", (long long)val1) << endl;
-        //cerr << "a.val2 = " << ML::format("%016llx", (long long)val2) << endl;
-        //cerr << "b.val1 = " << ML::format("%016llx", (long long)other.val1) << endl;
-        //cerr << "b.val2 = " << ML::format("%016llx", (long long)other.val2) << endl;
+        //cerr << "a.val1 = " << MLDB::format("%016llx", (long long)val1) << endl;
+        //cerr << "a.val2 = " << MLDB::format("%016llx", (long long)val2) << endl;
+        //cerr << "b.val1 = " << MLDB::format("%016llx", (long long)other.val1) << endl;
+        //cerr << "b.val2 = " << MLDB::format("%016llx", (long long)other.val2) << endl;
 
         // If the other isn't a string, we don't continue
         if (other.type != STR && other.type != SHORTSTR) {
@@ -709,7 +709,7 @@ complexLess(const Id & other) const
         return ML::less_all(compoundId1(), other.compoundId1(),
                             compoundId2(), other.compoundId2());
     }
-    else throw ML::Exception("unknown Id type");
+    else throw MLDB::Exception("unknown Id type");
 }
 
 uint64_t
@@ -724,7 +724,7 @@ complexHash() const
     }
     //else if (type == CUSTOM)
     //    return controlFn(CF_HASH, data);
-    else throw ML::Exception("unknown Id type");
+    else throw MLDB::Exception("unknown Id type");
 }
 
 void
@@ -750,7 +750,7 @@ complexDestroy()
     }
     //else if (type == CUSTOM)
     //    controlFn(CF_DESTROY, data);
-    else throw ML::Exception("unknown Id type");
+    else throw MLDB::Exception("unknown Id type");
 }
 
 void
@@ -769,7 +769,7 @@ complexFinishCopy()
     }
     //else if (type == CUSTOM)
     //    data = (void *)controlFn(CF_COPY, data);
-    else throw ML::Exception("unknown Id type");
+    else throw MLDB::Exception("unknown Id type");
 }
 
 Json::Value
@@ -861,7 +861,7 @@ stringData() const
         return str->data;
     else if (type == SHORTSTR)
         return shortStr;
-    else throw ML::Exception("stringData() on non-string Id");
+    else throw MLDB::Exception("stringData() on non-string Id");
 }
 
 std::ostream & operator << (std::ostream & stream, const Id & id)
@@ -955,7 +955,7 @@ void parseJson(Id * output, Context & context)
 
     std::cerr << context.expectJson() << endl;
 
-    throw ML::Exception("unhandled id conversion type");
+    throw MLDB::Exception("unhandled id conversion type");
 }
 
 void

--- a/types/id.h
+++ b/types/id.h
@@ -210,9 +210,9 @@ struct Id {
     uint64_t toInt() const
     {
         if (type != BIGDEC)
-            throw ML::Exception("can't convert non-BIGDEC to int");
+            throw MLDB::Exception("can't convert non-BIGDEC to int");
         if (val2) {
-            throw ML::Exception("cannot convert 128-bit value to uint64_t");
+            throw MLDB::Exception("cannot convert 128-bit value to uint64_t");
         }
         return val1;
     }

--- a/types/jml_serialization.h
+++ b/types/jml_serialization.h
@@ -82,7 +82,7 @@ inline ML::DB::Store_Writer & operator << (ML::DB::Store_Writer & store, const I
         store << id.compoundId1() << id.compoundId2();
         break;
     default:
-        throw ML::Exception("unknown Id type");
+        throw MLDB::Exception("unknown Id type");
     }
 
     return store;
@@ -96,7 +96,7 @@ inline ML::DB::Store_Reader & operator >> (ML::DB::Store_Reader & store, Id & id
     char v, tp;
     store >> v;
     if (v < 0 || v > 1)
-        throw ML::Exception("unknown Id version reconstituting");
+        throw MLDB::Exception("unknown Id version reconstituting");
     store >> tp;
     r.type = tp;
 
@@ -163,7 +163,7 @@ inline ML::DB::Store_Reader & operator >> (ML::DB::Store_Reader & store, Id & id
         break;
     }
     default:
-        throw ML::Exception("unknown Id type %d reconstituting",
+        throw MLDB::Exception("unknown Id type %d reconstituting",
                             tp);
     }
 

--- a/types/json_parsing.cc
+++ b/types/json_parsing.cc
@@ -15,7 +15,6 @@
 
 
 using namespace std;
-using namespace ML;
 
 
 namespace {
@@ -60,7 +59,7 @@ trim(const string & other)
 namespace MLDB {
 
 
-bool expectJsonBool(Parse_Context & context)
+bool expectJsonBool(ParseContext & context)
 {
     if (context.match_literal("true"))
         return true;
@@ -73,17 +72,17 @@ bool expectJsonBool(Parse_Context & context)
     because JsonCPP is not a require dependency of jml, but the function
     needs to be out-of-line.
 */
-JsonNumber expectJsonNumber(Parse_Context & context);
+JsonNumber expectJsonNumber(ParseContext & context);
 
 /** Match a JSON number. */
-bool matchJsonNumber(Parse_Context & context, JsonNumber & num);
+bool matchJsonNumber(ParseContext & context, JsonNumber & num);
 
 
 /*****************************************************************************/
 /* JSON UTILITIES                                                            */
 /*****************************************************************************/
 
-void skipJsonWhitespace(Parse_Context & context)
+void skipJsonWhitespace(ParseContext & context)
 {
     // Fast-path for the usual case for not EOF and no whitespace
     if (JML_LIKELY(!context.eof())) {
@@ -99,9 +98,9 @@ void skipJsonWhitespace(Parse_Context & context)
            && (context.match_whitespace() || context.match_eol()));
 }
 
-bool matchJsonString(Parse_Context & context, std::string & str)
+bool matchJsonString(ParseContext & context, std::string & str)
 {
-    Parse_Context::Revert_Token token(context);
+    ParseContext::Revert_Token token(context);
 
     skipJsonWhitespace(context);
     if (!context.match_literal('"')) return false;
@@ -146,7 +145,7 @@ bool matchJsonString(Parse_Context & context, std::string & str)
     return true;
 }
 
-std::string expectJsonStringAsciiPermissive(Parse_Context & context, char sub)
+std::string expectJsonStringAsciiPermissive(ParseContext & context, char sub)
 {
     skipJsonWhitespace(context);
     context.expect_literal('"');
@@ -201,7 +200,7 @@ std::string expectJsonStringAsciiPermissive(Parse_Context & context, char sub)
     return result;
 }
 
-ssize_t expectJsonStringAscii(Parse_Context & context, char * buffer, size_t maxLength)
+ssize_t expectJsonStringAscii(ParseContext & context, char * buffer, size_t maxLength)
 {
     skipJsonWhitespace(context);
     context.expect_literal('"');
@@ -248,7 +247,7 @@ ssize_t expectJsonStringAscii(Parse_Context & context, char * buffer, size_t max
     return pos;
 }
 
-std::string expectJsonStringAscii(Parse_Context & context)
+std::string expectJsonStringAscii(ParseContext & context)
 {
     skipJsonWhitespace(context);
     context.expect_literal('"');
@@ -316,7 +315,7 @@ std::string expectJsonStringAscii(Parse_Context & context)
     return result;
 }
 
-Utf8String expectJsonStringUtf8(Parse_Context & context)
+Utf8String expectJsonStringUtf8(ParseContext & context)
 {
     skipJsonWhitespace(context);
     context.expect_literal('"');
@@ -393,15 +392,15 @@ Utf8String expectJsonStringUtf8(Parse_Context & context)
 }
 
 bool
-matchJsonNull(Parse_Context & context)
+matchJsonNull(ParseContext & context)
 {
     skipJsonWhitespace(context);
     return context.match_literal("null");
 }
 
 void
-expectJsonArray(Parse_Context & context,
-                const std::function<void (int, Parse_Context &)> & onEntry)
+expectJsonArray(ParseContext & context,
+                const std::function<void (int, ParseContext &)> & onEntry)
 {
     skipJsonWhitespace(context);
 
@@ -427,8 +426,8 @@ expectJsonArray(Parse_Context & context,
 }
 
 void
-expectJsonObject(Parse_Context & context,
-                 const std::function<void (const std::string &, Parse_Context &)> & onEntry)
+expectJsonObject(ParseContext & context,
+                 const std::function<void (const std::string &, ParseContext &)> & onEntry)
 {
     skipJsonWhitespace(context);
 
@@ -464,8 +463,8 @@ expectJsonObject(Parse_Context & context,
 }
 
 void
-expectJsonObjectAscii(Parse_Context & context,
-                      const std::function<void (const char *, Parse_Context &)> & onEntry)
+expectJsonObjectAscii(ParseContext & context,
+                      const std::function<void (const char *, ParseContext &)> & onEntry)
 {
     skipJsonWhitespace(context);
 
@@ -505,8 +504,8 @@ expectJsonObjectAscii(Parse_Context & context,
 }
 
 bool
-matchJsonObject(Parse_Context & context,
-                const std::function<bool (const std::string &, Parse_Context &)> & onEntry)
+matchJsonObject(ParseContext & context,
+                const std::function<bool (const std::string &, ParseContext &)> & onEntry)
 {
     skipJsonWhitespace(context);
 
@@ -539,7 +538,7 @@ matchJsonObject(Parse_Context & context,
     return true;
 }
 
-JsonNumber expectJsonNumber(Parse_Context & context)
+JsonNumber expectJsonNumber(ParseContext & context)
 {
     JsonNumber result;
 
@@ -612,7 +611,7 @@ JsonNumber expectJsonNumber(Parse_Context & context)
             errno = 0;
             result.fp = strtod(number.c_str(), &endptr);
             if (errno || endptr != number.c_str() + number.length())
-                context.exception(ML::format("failed to convert '%s' to long long",
+                context.exception(MLDB::format("failed to convert '%s' to long long",
                                              number.c_str()));
             result.type = JsonNumber::FLOATING_POINT;
         } else if (negative) {
@@ -620,7 +619,7 @@ JsonNumber expectJsonNumber(Parse_Context & context)
             errno = 0;
             result.sgn = strtol(number.c_str(), &endptr, 10);
             if (errno || endptr != number.c_str() + number.length())
-                context.exception(ML::format("failed to convert '%s' to long long",
+                context.exception(MLDB::format("failed to convert '%s' to long long",
                                              number.c_str()));
             result.type = JsonNumber::SIGNED_INT;
         } else {
@@ -628,7 +627,7 @@ JsonNumber expectJsonNumber(Parse_Context & context)
             errno = 0;
             result.uns = strtoull(number.c_str(), &endptr, 10);
             if (errno || endptr != number.c_str() + number.length())
-                context.exception(ML::format("failed to convert '%s' to unsigned long long",
+                context.exception(MLDB::format("failed to convert '%s' to unsigned long long",
                                              number.c_str()));
             result.type = JsonNumber::UNSIGNED_INT;
         }
@@ -878,7 +877,7 @@ StreamingJsonParsingContext()
 }
 
 StreamingJsonParsingContext::
-StreamingJsonParsingContext(ML::Parse_Context & context)
+StreamingJsonParsingContext(ParseContext & context)
     : context(nullptr)
 {
     init(context);
@@ -923,7 +922,7 @@ StreamingJsonParsingContext::
 
 void
 StreamingJsonParsingContext::
-init(ML::Parse_Context & context)
+init(ParseContext & context)
 {
     this->context = &context;
     ownedContext.reset();
@@ -933,7 +932,7 @@ void
 StreamingJsonParsingContext::
 init(const std::string & filename)
 {
-    ownedContext.reset(new ML::Parse_Context(filename));
+    ownedContext.reset(new ParseContext(filename));
     context = ownedContext.get();
 }
     
@@ -942,7 +941,7 @@ StreamingJsonParsingContext::
 init(const std::string & filename, const char * start,
      const char * finish, unsigned line, unsigned col)
 {
-    ownedContext.reset(new ML::Parse_Context(filename, start, finish, line, col));
+    ownedContext.reset(new ParseContext(filename, start, finish, line, col));
     context = ownedContext.get();
 }
 
@@ -951,7 +950,7 @@ StreamingJsonParsingContext::
 init(const std::string & filename, const char * start,
      size_t length, unsigned line, unsigned col)
 {
-    ownedContext.reset(new ML::Parse_Context(filename, start, length, line, col));
+    ownedContext.reset(new ParseContext(filename, start, length, line, col));
     context = ownedContext.get();
 }
 
@@ -961,7 +960,7 @@ init(const std::string & filename, std::istream & stream,
      unsigned line, unsigned col,
      size_t chunk_size)
 {
-    ownedContext.reset(new ML::Parse_Context(filename, stream, line, col, chunk_size));
+    ownedContext.reset(new ParseContext(filename, stream, line, col, chunk_size));
     context = ownedContext.get();
 }
 
@@ -1141,7 +1140,7 @@ isInt() const
     // Find the offset at which an integer finishes
     size_t offset1;
     {
-        ML::Parse_Context::Revert_Token token(*context);
+        ParseContext::Revert_Token token(*context);
         long long v;
         if (!context->match_long_long(v))
             return false;
@@ -1150,7 +1149,7 @@ isInt() const
 
     // It's an integer only if a double only matches the same.
     // Otherwise it's surely a double.
-    ML::Parse_Context::Revert_Token token(*context);
+    ParseContext::Revert_Token token(*context);
     double d;
     if (!context->match_double(d))
         return false;
@@ -1166,7 +1165,7 @@ isUnsigned() const
     // Find the offset at which an integer finishes
     size_t offset1;
     {
-        ML::Parse_Context::Revert_Token token(*context);
+        ParseContext::Revert_Token token(*context);
         unsigned long long v;
         if (!context->match_unsigned_long_long(v))
             return false;
@@ -1175,7 +1174,7 @@ isUnsigned() const
 
     // It's an integer only if a double only matches the same.
     // Otherwise it's surely a double.
-    ML::Parse_Context::Revert_Token token(*context);
+    ParseContext::Revert_Token token(*context);
     double d;
     if (!context->match_double(d))
         return false;
@@ -1187,7 +1186,7 @@ StreamingJsonParsingContext::
 isNumber() const
 {
     skipJsonWhitespace(*context);
-    ML::Parse_Context::Revert_Token token(*context);
+    ParseContext::Revert_Token token(*context);
     double d;
     if (context->match_double(d))
         return true;
@@ -1199,7 +1198,7 @@ StreamingJsonParsingContext::
 isNull() const
 {
     skipJsonWhitespace(*context);
-    ML::Parse_Context::Revert_Token token(*context);
+    ParseContext::Revert_Token token(*context);
     if (context->match_literal("null"))
         return true;
     return false;
@@ -1247,10 +1246,10 @@ StreamingJsonParsingContext::
 printCurrent()
 {
     try {
-        ML::Parse_Context::Revert_Token token(*context);
+        ParseContext::Revert_Token token(*context);
         return trim(expectJson().toString());
     } catch (const std::exception & exc) {
-        ML::Parse_Context::Revert_Token token(*context);
+        ParseContext::Revert_Token token(*context);
         return context->expect_text("\n");
     }
 }
@@ -1259,7 +1258,7 @@ ssize_t
 StreamingJsonParsingContext::
 expectStringUtf8(char * buffer, size_t maxLen)
 {
-    ML::Parse_Context::Revert_Token token(*context);
+    ParseContext::Revert_Token token(*context);
 
     skipJsonWhitespace((*context));
     context->expect_literal('"');
@@ -1387,7 +1386,7 @@ expectJsonObjectUtf8(const std::function<void (const char *, size_t)> & onEntry)
 
 
 Json::Value
-expectJson(Parse_Context & context)
+expectJson(ParseContext & context)
 {
     context.skip_whitespace();
     if (*context == '"')
@@ -1401,7 +1400,7 @@ expectJson(Parse_Context & context)
     else if (*context == '[') {
         Json::Value result(Json::arrayValue);
         expectJsonArray(context,
-                        [&] (int i, Parse_Context & context)
+                        [&] (int i, ParseContext & context)
                         {
                             result[i] = expectJson(context);
                         });
@@ -1409,7 +1408,7 @@ expectJson(Parse_Context & context)
     } else if (*context == '{') {
         Json::Value result(Json::objectValue);
         expectJsonObject(context,
-                         [&] (const std::string & key, Parse_Context & context)
+                         [&] (const std::string & key, ParseContext & context)
                          {
                              result[key] = expectJson(context);
                          });
@@ -1424,13 +1423,13 @@ expectJson(Parse_Context & context)
         case JsonNumber::FLOATING_POINT:
             return number.fp;
         default:
-            throw ML::Exception("logic error in expectJson");
+            throw MLDB::Exception("logic error in expectJson");
         }
     }
 }
 
 Json::Value
-expectJsonAscii(Parse_Context & context)
+expectJsonAscii(ParseContext & context)
 {
     context.skip_whitespace();
     if (*context == '"')
@@ -1444,7 +1443,7 @@ expectJsonAscii(Parse_Context & context)
     else if (*context == '[') {
         Json::Value result(Json::arrayValue);
         expectJsonArray(context,
-                        [&] (int i, Parse_Context & context)
+                        [&] (int i, ParseContext & context)
                         {
                             result[i] = expectJsonAscii(context);
                         });
@@ -1452,7 +1451,7 @@ expectJsonAscii(Parse_Context & context)
     } else if (*context == '{') {
         Json::Value result(Json::objectValue);
         expectJsonObjectAscii(context,
-                         [&] (const char * key, Parse_Context & context)
+                         [&] (const char * key, ParseContext & context)
                          {
                              result[key] = expectJsonAscii(context);
                          });
@@ -1467,7 +1466,7 @@ expectJsonAscii(Parse_Context & context)
         case JsonNumber::FLOATING_POINT:
             return number.fp;
         default:
-            throw ML::Exception("logic error in expectJson");
+            throw MLDB::Exception("logic error in expectJson");
         }
     }
 }
@@ -1490,7 +1489,7 @@ exception(const std::string & message)
     //using namespace std;
     //cerr << *current << endl;
     //cerr << *top << endl;
-    throw ML::Exception("At path " + printPath() + ": "
+    throw MLDB::Exception("At path " + printPath() + ": "
                         + message + " parsing "
                         + trim(top->toString()));
 }

--- a/types/json_parsing.h
+++ b/types/json_parsing.h
@@ -16,12 +16,10 @@ namespace Json {
 struct Value;
 } // namespace Json
 
-namespace ML {
-struct Parse_Context;
-} // namespace ML
 
 namespace MLDB {
 
+struct ParseContext;
 struct JsonParsingContext;
 struct ValueDescription;
 
@@ -45,62 +43,62 @@ struct JsonNumber {
     };    
 };
 
-bool expectJsonBool(ML::Parse_Context & context);
+bool expectJsonBool(ParseContext & context);
 
 /** Expect a JSON number. */
-JsonNumber expectJsonNumber(ML::Parse_Context & context);
+JsonNumber expectJsonNumber(ParseContext & context);
 
 /** Match a JSON number. */
-bool matchJsonNumber(ML::Parse_Context & context, JsonNumber & num);
+bool matchJsonNumber(ParseContext & context, JsonNumber & num);
 
 
 /*
  * If non-ascii characters are found an exception is thrown
  */
-std::string expectJsonStringAscii(ML::Parse_Context & context);
+std::string expectJsonStringAscii(ParseContext & context);
 
 /*
  * If non-ascii characters are found an exception is thrown.
  * Output goes into the given buffer, of the given maximum length.
  * If it doesn't fit, then return zero.
  */
-ssize_t expectJsonStringAscii(ML::Parse_Context & context, char * buf,
+ssize_t expectJsonStringAscii(ParseContext & context, char * buf,
                              size_t maxLength);
 
 /*
  * if non-ascii characters are found we replace them by an ascii character that is supplied
  */
-std::string expectJsonStringAsciiPermissive(ML::Parse_Context & context, char c);
+std::string expectJsonStringAsciiPermissive(ParseContext & context, char c);
 
-bool matchJsonString(ML::Parse_Context & context, std::string & str);
+bool matchJsonString(ParseContext & context, std::string & str);
 
-bool matchJsonNull(ML::Parse_Context & context);
-
-void
-expectJsonArray(ML::Parse_Context & context,
-                const std::function<void (int, ML::Parse_Context &)> & onEntry);
+bool matchJsonNull(ParseContext & context);
 
 void
-expectJsonObject(ML::Parse_Context & context,
-                 const std::function<void (const std::string &, ML::Parse_Context &)> & onEntry);
+expectJsonArray(ParseContext & context,
+                const std::function<void (int, ParseContext &)> & onEntry);
+
+void
+expectJsonObject(ParseContext & context,
+                 const std::function<void (const std::string &, ParseContext &)> & onEntry);
 
 /** Expect a Json object and call the given callback.  The keys are assumed
     to be ASCII which means no embedded nulls, and so the key can be passed
     as a const char *.
 */
 void
-expectJsonObjectAscii(ML::Parse_Context & context,
-                      const std::function<void (const char *, ML::Parse_Context &)> & onEntry);
+expectJsonObjectAscii(ParseContext & context,
+                      const std::function<void (const char *, ParseContext &)> & onEntry);
 
 bool
-matchJsonObject(ML::Parse_Context & context,
-                const std::function<bool (const std::string &, ML::Parse_Context &)> & onEntry);
+matchJsonObject(ParseContext & context,
+                const std::function<bool (const std::string &, ParseContext &)> & onEntry);
 
-void skipJsonWhitespace(ML::Parse_Context & context);
+void skipJsonWhitespace(ParseContext & context);
 
-Json::Value expectJson(ML::Parse_Context & context);
+Json::Value expectJson(ParseContext & context);
 
-Json::Value expectJsonAscii(ML::Parse_Context & context);
+Json::Value expectJsonAscii(ParseContext & context);
 
 
 
@@ -373,8 +371,8 @@ struct StreamingJsonParsingContext
     StreamingJsonParsingContext();
     ~StreamingJsonParsingContext();
 
-    /// Initialize from a general JML Parse_Context object.
-    StreamingJsonParsingContext(ML::Parse_Context & context);
+    /// Initialize from a general JML ParseContext object.
+    StreamingJsonParsingContext(ParseContext & context);
     
     /** Initialize from a filename, loading the file and uncompressing if
         necessary. */
@@ -392,8 +390,8 @@ struct StreamingJsonParsingContext
     StreamingJsonParsingContext(const std::string & filename, const char * start,
                                 size_t length, unsigned line = 1, unsigned col = 1);
     
-    /// Initialize from a general JML Parse_Context object.
-    void init(ML::Parse_Context & context);
+    /// Initialize from a general JML ParseContext object.
+    void init(ParseContext & context);
 
     /** Initialize from a filename, loading the file and uncompressing if
         necessary. */
@@ -411,8 +409,8 @@ struct StreamingJsonParsingContext
                                 unsigned line = 1, unsigned col = 1,
                                 size_t chunk_size = DEFAULT_CHUNK_SIZE);
 
-    ML::Parse_Context * context;
-    std::unique_ptr<ML::Parse_Context> ownedContext;
+    ParseContext * context;
+    std::unique_ptr<ParseContext> ownedContext;
 
     template<typename Fn>
     void forEachMember(const Fn & fn)
@@ -455,7 +453,7 @@ struct StreamingJsonParsingContext
     {
         bool first = true;
 
-        auto onElement = [&] (int index, ML::Parse_Context &)
+        auto onElement = [&] (int index, ParseContext &)
             {
                 if (first)
                     pushPath(index);

--- a/types/json_printing.cc
+++ b/types/json_printing.cc
@@ -77,12 +77,12 @@ char * jsonEscapeCore(const char * str, size_t strLen, char * p, char * end)
                     break;
                 }
                 else if (c == 0) {
-                    throw ML::Exception("JSON strings cannot contain null characters");
+                    throw MLDB::Exception("JSON strings cannot contain null characters");
                 }
                 else {
                     for (auto & c: string(str, str + strLen))
                         cerr << "char " << (int)c << " " << c << endl;
-                    throw ML::Exception("Invalid character in JSON string %d: %s", (int)c,
+                    throw MLDB::Exception("Invalid character in JSON string %d: %s", (int)c,
                                         str);
                 }
             }
@@ -115,7 +115,7 @@ jsonEscape(const std::string & str)
         p = jsonEscapeCore(str.data(), str.length(), p, end);
         
         if (p == BUFFER_TOO_SMALL)
-            throw ML::Exception("To fix: logic error in JSON escaping");
+            throw MLDB::Exception("To fix: logic error in JSON escaping");
         else if (p == NO_ESCAPING)
             return str;
         return string(buf, p);
@@ -127,7 +127,7 @@ jsonEscape(const std::string & str)
         p = jsonEscapeCore(str.data(), str.length(), p, end);
         
         if (p == BUFFER_TOO_SMALL)
-            throw ML::Exception("To fix: logic error in JSON escaping");
+            throw MLDB::Exception("To fix: logic error in JSON escaping");
         else if (p == NO_ESCAPING)
             return str;
         heap_buf.resize(p - heap_buf.data());
@@ -148,7 +148,7 @@ void jsonEscape(const std::string & str, std::ostream & stream)
         p = jsonEscapeCore(str.data(), str.length(), p, end);
 
         if (p == BUFFER_TOO_SMALL)
-            throw ML::Exception("To fix: logic error in JSON escaping");
+            throw MLDB::Exception("To fix: logic error in JSON escaping");
         else if (p == NO_ESCAPING)
             p = buf + str.size();
 
@@ -173,7 +173,7 @@ void jsonEscape(const char * str, size_t len, std::ostream & stream)
         p = jsonEscapeCore(str, len, p, end);
 
         if (p == BUFFER_TOO_SMALL)
-            throw ML::Exception("To fix: logic error in JSON escaping");
+            throw MLDB::Exception("To fix: logic error in JSON escaping");
         else if (p == NO_ESCAPING)
             p = buf + len;
 
@@ -198,7 +198,7 @@ void jsonEscape(const std::string & str, std::string & out)
         p = jsonEscapeCore(str.data(), str.length(), p, end);
 
         if (p == BUFFER_TOO_SMALL)
-            throw ML::Exception("To fix: logic error in JSON escaping");
+            throw MLDB::Exception("To fix: logic error in JSON escaping");
         else if (p == NO_ESCAPING)
             p = buf + str.size();
 
@@ -224,7 +224,7 @@ void jsonEscape(const char * str, size_t len, std::string & out)
         p = jsonEscapeCore(str, len, p, end);
 
         if (p == BUFFER_TOO_SMALL)
-            throw ML::Exception("To fix: logic error in JSON escaping");
+            throw MLDB::Exception("To fix: logic error in JSON escaping");
         else if (p == NO_ESCAPING)
             p = buf + len;
 
@@ -250,7 +250,7 @@ writeStringUtf8(const Utf8String & s)
         else {
             switch (c) {
             case '\0':
-                throw ML::Exception("JSON strings may not contain embedded nulls");
+                throw MLDB::Exception("JSON strings may not contain embedded nulls");
             case '\t': stream << "\\t";  break;
             case '\n': stream << "\\n";  break;
             case '\r': stream << "\\r";  break;
@@ -267,7 +267,7 @@ writeStringUtf8(const Utf8String & s)
                 }
                 else {
                     ExcAssert(c > 0 && c < 65536);
-                    stream << ML::format("\\u%04x", (unsigned)c);
+                    stream << MLDB::format("\\u%04x", (unsigned)c);
                 }
             }
         }
@@ -291,7 +291,7 @@ writeStringUtf8(const char * p, size_t len)
         else {
             switch (c) {
             case '\0':
-                throw ML::Exception("JSON strings may not contain embedded nulls");
+                throw MLDB::Exception("JSON strings may not contain embedded nulls");
             case '\t': stream << "\\t";  break;
             case '\n': stream << "\\n";  break;
             case '\r': stream << "\\r";  break;
@@ -308,7 +308,7 @@ writeStringUtf8(const char * p, size_t len)
                 }
                 else {
                     ExcAssert(c > 0 && c < 65536);
-                    stream << ML::format("\\u%04x", (unsigned)c);
+                    stream << MLDB::format("\\u%04x", (unsigned)c);
                 }
             }
         }
@@ -574,7 +574,7 @@ writeStringUtf8(const Utf8String & s)
                 }
                 else {
                     ExcAssert(c >= 0 && c < 65536);
-                    write(ML::format("\\u%04x", (unsigned)c));
+                    write(MLDB::format("\\u%04x", (unsigned)c));
                 }
             }
         }
@@ -613,7 +613,7 @@ writeStringUtf8(const char * p, size_t len)
                 }
                 else {
                     ExcAssert(c >= 0 && c < 65536);
-                    write(ML::format("\\u%04x", (unsigned)c));
+                    write(MLDB::format("\\u%04x", (unsigned)c));
                 }
             }
         }

--- a/types/localdate.cc
+++ b/types/localdate.cc
@@ -87,7 +87,7 @@ fillTM(struct tm & time) const
     time_t t = secondsSinceEpoch_ + tzOffset_;
 
     if (!gmtime_r(&t, &time))
-        throw ML::Exception("problem with gmtime_r");
+        throw MLDB::Exception("problem with gmtime_r");
 }
 
 int
@@ -144,7 +144,7 @@ static std::string get_link_target(const std::string & link)
         char buf[bufsize];
         int res = readlink(link.c_str(), buf, bufsize);
         if (res == -1)
-            throw ML::Exception(errno, "readlink", "get_link_name()");
+            throw MLDB::Exception(errno, "readlink", "get_link_name()");
         if (res == bufsize) {
             bufsize *= 2;
             continue;
@@ -186,7 +186,7 @@ findTimezoneSpec()
         return specFile;
     }
 
-    throw ML::Exception("timezone spec file not found");    
+    throw MLDB::Exception("timezone spec file not found");    
 }
 
 void
@@ -205,7 +205,7 @@ recomputeTZOffset()
 
         time_zone_ptr tz = tz_db.time_zone_from_region(tzName_);
         if (tz == 0) {
-            throw ML::Exception("time zone named '" + tzName_ + "' is not known");
+            throw MLDB::Exception("time zone named '" + tzName_ + "' is not known");
         }
         time_duration offset = tz->base_utc_offset();
         tzOffset_ = offset.total_seconds();

--- a/types/map_description.h
+++ b/types/map_description.h
@@ -131,7 +131,7 @@ struct MapValueDescription
     virtual const FieldDescription *
     hasField(const void * val, const std::string & name) const override
     {
-        throw ML::Exception("map hasField: needs work");
+        throw MLDB::Exception("map hasField: needs work");
         //auto * val2 = reinterpret_cast<const std::map<std::string, T> *>(val);
         //return val2->count(name);
     }
@@ -139,13 +139,13 @@ struct MapValueDescription
     virtual void forEachField(const void * val,
                               const std::function<void (const FieldDescription &)> & onField) const override
     {
-        throw ML::Exception("map forEachField: needs work");
+        throw MLDB::Exception("map forEachField: needs work");
     }
 
     virtual const FieldDescription & 
     getField(const std::string & field) const override
     {
-        throw ML::Exception("map getField: needs work");
+        throw MLDB::Exception("map getField: needs work");
     }
 
     virtual const ValueDescription & getKeyValueDescription() const override

--- a/types/meta_value_description.cc
+++ b/types/meta_value_description.cc
@@ -111,8 +111,8 @@ getRepr(const ValueDescription & desc, bool detailed)
     ValueDescriptionRepr result;
     result.kind = desc.kind;
     result.typeName = desc.typeName;
-    if (desc.type && ML::demangle(desc.type->name()) != desc.typeName)
-        result.cppType = ML::demangle(desc.type->name());
+    if (desc.type && demangle(desc.type->name()) != desc.typeName)
+        result.cppType = demangle(desc.type->name());
     result.documentationUri = desc.documentationUri;
     //result.parents = desc.parents;
     
@@ -230,7 +230,7 @@ ValueDescriptionPtrDescription::
 parseJsonTyped(std::shared_ptr<ValueDescription> * val,
                     JsonParsingContext & context) const
 {
-    throw ML::Exception("Can't parse value descriptions");
+    throw MLDB::Exception("Can't parse value descriptions");
 }
 
 void
@@ -258,7 +258,7 @@ ValueDescriptionConstPtrDescription::
 parseJsonTyped(std::shared_ptr<const ValueDescription> * val,
                     JsonParsingContext & context) const
 {
-    throw ML::Exception("Can't parse value descriptions");
+    throw MLDB::Exception("Can't parse value descriptions");
 }
 
 void
@@ -287,7 +287,7 @@ ValueDescriptionNakedPtrDescription::
 parseJsonTyped(ValueDescription * * val,
                     JsonParsingContext & context) const
 {
-    throw ML::Exception("Can't parse value descriptions");
+    throw MLDB::Exception("Can't parse value descriptions");
 }
 
 void
@@ -315,7 +315,7 @@ ValueDescriptionNakedConstPtrDescription::
 parseJsonTyped(ValueDescription const * * val,
                     JsonParsingContext & context) const
 {
-    throw ML::Exception("Can't parse value descriptions");
+    throw MLDB::Exception("Can't parse value descriptions");
 }
 
 void

--- a/types/optional_description.h
+++ b/types/optional_description.h
@@ -71,7 +71,7 @@ struct OptionalDescription
     optionalGetValueTyped(const Optional<T> * val) const override
     {
         if (!val->get())
-            throw ML::Exception("no value in optional field");
+            throw MLDB::Exception("no value in optional field");
         return val->get();
     }
 

--- a/types/pair_description.h
+++ b/types/pair_description.h
@@ -56,7 +56,7 @@ struct PairDescription
             return *inner1;
         else if (element == 1)
             return *inner1;
-        else throw ML::Exception("Invalid element number for pair type '"
+        else throw MLDB::Exception("Invalid element number for pair type '"
                                  + this->typeName + "'");
     }
 

--- a/types/periodic_utils.cc
+++ b/types/periodic_utils.cc
@@ -39,7 +39,7 @@ int granularityIndex(TimeGranularity granularity)
         }
     }
 
-    throw ML::Exception("granularity not found");
+    throw MLDB::Exception("granularity not found");
 }
 
 }
@@ -52,12 +52,12 @@ TimeGranularity operator + (TimeGranularity granularity, int steps)
 
     if (steps > 0) {
         if (i + steps >= maxGranularity) {
-            throw ML::Exception("granularity index would be too high");
+            throw MLDB::Exception("granularity index would be too high");
         }
     }
     else if (steps < 0) {
         if (i + steps < 0) {
-            throw ML::Exception("granularity index would be negative");
+            throw MLDB::Exception("granularity index would be negative");
         }
     }
 
@@ -88,7 +88,7 @@ bool canTranslateGranularity(TimeGranularity sourceGranularity,
         return destGranularity == MONTHS;
     }
 
-    throw ML::Exception("we should never get here");
+    throw MLDB::Exception("we should never get here");
 }
 
 /** Number of units of one granularity that first in the other granularity. */
@@ -96,14 +96,14 @@ int granularityMultiplier(TimeGranularity sourceGranularity,
                           TimeGranularity destGranularity)
 {
     if (!canTranslateGranularity(sourceGranularity, destGranularity)) {
-        throw ML::Exception("specified granularities are incompatible with"
+        throw MLDB::Exception("specified granularities are incompatible with"
                             " each other");
     }
 
     int fromIndex = granularityIndex(destGranularity);
     int toIndex = granularityIndex(sourceGranularity);
     if (fromIndex > toIndex) {
-        throw ML::Exception("the source granularity must be bigger that the"
+        throw MLDB::Exception("the source granularity must be bigger that the"
                             " destination");
     }
 
@@ -133,7 +133,7 @@ parsePeriod(const std::string & pattern)
     TimeGranularity granularity;
     double number;
 
-    ML::Parse_Context context(pattern,
+    ParseContext context(pattern,
                               pattern.c_str(),
                               pattern.c_str() + pattern.length());
 
@@ -205,7 +205,7 @@ findPeriod(Date current, TimeGranularity granularity, double number_)
         break;
 
         if (number != 1)
-            throw ML::Exception("only 1d is supported for days");
+            throw MLDB::Exception("only 1d is supported for days");
         // Go to the start of the day
         result.addSeconds(-(3600 * t.tm_hour + 60 * t.tm_min + t.tm_sec));
         
@@ -256,7 +256,7 @@ findPeriod(Date current, TimeGranularity granularity, double number_)
 	break;
 
     default:
-        throw ML::Exception("that granularity is not supported");
+        throw MLDB::Exception("that granularity is not supported");
     }
 
     return make_pair(result, interval);
@@ -309,7 +309,7 @@ std::string
 TimePeriod::
 toString() const
 {
-    string result = boost::lexical_cast<string>(number);//ML::format("%f", number);
+    string result = boost::lexical_cast<string>(number);//MLDB::format("%f", number);
     switch (granularity) {
     case MILLISECONDS:  result += "ms";  return result;
     case SECONDS:       result += 's';   return result;
@@ -320,7 +320,7 @@ toString() const
     case MONTHS:        result += 'M';   return result;
     case YEARS:         result += 'y';   return result;
     default:
-        throw ML::Exception("unknown time period");
+        throw MLDB::Exception("unknown time period");
     }
 }
 

--- a/types/pointer_description.h
+++ b/types/pointer_description.h
@@ -76,7 +76,7 @@ struct PointerDescription
             void* obj, void* value, const ValueDescription* valueDesc) const override
     {
         if (valueDesc->kind != ValueKind::LINK)
-            throw ML::Exception("assignment of non-link type to link type");
+            throw MLDB::Exception("assignment of non-link type to link type");
 
         valueDesc->contained().checkChildOf(&contained());
         cast(obj) = static_cast<T*>(valueDesc->getLink(value));
@@ -174,10 +174,10 @@ struct UniquePtrDescription
             void* obj, void* value, const ValueDescription* valueDesc) const override
     {
         if (valueDesc->kind != ValueKind::LINK)
-            throw ML::Exception("assignment of non-link type to link type");
+            throw MLDB::Exception("assignment of non-link type to link type");
 
         if (valueDesc->getOwnershipModel() != OwnershipModel::NONE)
-            throw ML::Exception("unsafe link assignement");
+            throw MLDB::Exception("unsafe link assignement");
 
         valueDesc->contained().checkChildOf(&contained());
         cast(obj).reset(static_cast<T*>(valueDesc->getLink(value)));
@@ -263,10 +263,10 @@ struct SharedPtrDescription
             void* obj, void* value, const ValueDescription* valueDesc) const override
     {
         if (valueDesc->kind != ValueKind::LINK)
-            throw ML::Exception("assignment of non-link type to link type");
+            throw MLDB::Exception("assignment of non-link type to link type");
 
         if (valueDesc->getOwnershipModel() == OwnershipModel::UNIQUE)
-            throw ML::Exception("unsafe link assignement");
+            throw MLDB::Exception("unsafe link assignement");
 
         valueDesc->contained().checkChildOf(&contained());
 
@@ -302,7 +302,7 @@ struct PointerValueDescription
 
     virtual void parseJsonTyped(T * * val, JsonParsingContext & context) const
     {
-        throw ML::Exception("Can't round-trip a raw pointer through JSON");
+        throw MLDB::Exception("Can't round-trip a raw pointer through JSON");
     }
 
     virtual void printJson(const void * val, JsonPrintingContext & context) const

--- a/types/set_description.h
+++ b/types/set_description.h
@@ -84,7 +84,7 @@ struct SetDescription
 
     virtual void * getArrayElement(void * val, uint32_t element) const override
     {
-        throw ML::Exception("can't mutate set elements");
+        throw MLDB::Exception("can't mutate set elements");
     }
 
     virtual const void * getArrayElement(const void * val,
@@ -92,7 +92,7 @@ struct SetDescription
     {
         const std::set<T> * val2 = reinterpret_cast<const std::set<T> *>(val);
         if (element >= val2->size())
-            throw ML::Exception("Invalid set element number");
+            throw MLDB::Exception("Invalid set element number");
         auto it = val2->begin();
         for (unsigned i = 0;  i < element;  ++i, ++i) ;
         return &*it;
@@ -100,7 +100,7 @@ struct SetDescription
 
     virtual void setArrayLength(void * val, size_t newLength) const override
     {
-        throw ML::Exception("cannot adjust length of a set");
+        throw MLDB::Exception("cannot adjust length of a set");
     }
     
     virtual const ValueDescription & contained() const override

--- a/types/string.cc
+++ b/types/string.cc
@@ -158,7 +158,7 @@ doCheck() const
     string::const_iterator end_it = utf8::find_invalid(data_.begin(), data_.end());
     if (end_it != data_.end())
         {
-            throw ML::Exception("Invalid sequence within utf-8 string");
+            throw MLDB::Exception("Invalid sequence within utf-8 string");
         }
 }
 

--- a/types/structure_description.h
+++ b/types/structure_description.h
@@ -80,7 +80,7 @@ struct StructureDescriptionBase {
 
     std::vector<Fields::const_iterator> orderedFields;
 
-    struct Exception: public ML::Exception {
+    struct Exception: public MLDB::Exception {
         Exception(JsonParsingContext & context,
                   const std::string & message);
         virtual ~Exception() throw ();
@@ -178,7 +178,7 @@ struct StructureDescription
         ExcAssert(description);
 
         if (fields.count(name.c_str()))
-            throw ML::Exception("field '" + name + "' added twice");
+            throw MLDB::Exception("field '" + name + "' added twice");
 
         fieldNames.emplace_back(::strdup(name.c_str()));
         const char * fieldName = fieldNames.back().get();
@@ -210,7 +210,7 @@ struct StructureDescription
                       = getDefaultDescriptionSharedT<V>())
     {
         if (fields.count(name.c_str()))
-            throw ML::Exception("field '" + name + "' added twice");
+            throw MLDB::Exception("field '" + name + "' added twice");
 
         fieldNames.emplace_back(::strdup(name.c_str()));
         const char * fieldName = fieldNames.back().get();
@@ -280,7 +280,7 @@ struct StructureDescription
         auto it = fields.find(field.c_str());
         if (it != fields.end())
             return it->second;
-        throw ML::Exception("structure has no field " + field);
+        throw MLDB::Exception("structure has no field " + field);
     }
 
     virtual void parseJson(void * val, JsonParsingContext & context) const
@@ -348,7 +348,7 @@ addParent(ValueDescriptionT<V> * description_)
         = dynamic_cast<StructureDescription<V> *>(description_);
     if (!desc2) {
         delete description_;
-        throw ML::Exception("parent description is not a structure");
+        throw MLDB::Exception("parent description is not a structure");
     }
 
     std::shared_ptr<StructureDescription<V> > description(desc2);

--- a/types/testing/date_test.cc
+++ b/types/testing/date_test.cc
@@ -15,7 +15,6 @@
 #include <climits>
 
 using namespace std;
-using namespace ML;
 using namespace MLDB;
 
 BOOST_AUTO_TEST_CASE(test_date_parse_iso8601_date_time)
@@ -291,7 +290,7 @@ BOOST_AUTO_TEST_CASE( test_date_parse_roundtrip )
             cerr << "d2:6: " << d2.print(6) << endl;
             cerr << "d1:9: " << d1.print(9) << endl;
             cerr << "d2:9: " << d2.print(9) << endl;
-            cerr << "sec: " << ML::format("%32.10f", sec + frac) << endl;
+            cerr << "sec: " << MLDB::format("%32.10f", sec + frac) << endl;
         }
 
         BOOST_CHECK_EQUAL(d1.print(6), d2.print(6));
@@ -331,7 +330,7 @@ BOOST_AUTO_TEST_CASE( test_date_equality )
 BOOST_AUTO_TEST_CASE( test_date_parse_no_delimiter )
 {
     const char * s = "20120624";
-    Parse_Context context(s, s, s + strlen(s));
+    ParseContext context(s, s, s + strlen(s));
     Date date = Date::expect_date(context, "%y%m%d");
 
     BOOST_CHECK_EQUAL(date, Date(2012, 06, 24));
@@ -378,11 +377,11 @@ BOOST_AUTO_TEST_CASE( test_addFromString )
         bool failureFailed = false;
         try{
             d.addFromString("pwel");
-        }catch(const ML::Exception& e){
+        }catch(const MLDB::Exception& e){
             failureFailed = true;
         }
         if(!failureFailed){
-            throw ML::Exception("Invalid string should fail with a ML exception");
+            throw MLDB::Exception("Invalid string should fail with a ML exception");
         }
     }
 }

--- a/types/testing/decode_uri_test.cc
+++ b/types/testing/decode_uri_test.cc
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(test_invalid_input)
 #if TOLERATE_URL_BAD_ENCODING
     BOOST_CHECK_EQUAL(Url::decodeUri(in), in);
 #else
-    BOOST_CHECK_THROW(Url::decodeUri(in), ML::Exception);
+    BOOST_CHECK_THROW(Url::decodeUri(in), MLDB::Exception);
 #endif
 
 
@@ -79,14 +79,14 @@ BOOST_AUTO_TEST_CASE(test_invalid_input)
 #if TOLERATE_URL_BAD_ENCODING
     BOOST_CHECK_EQUAL(Url::decodeUri(in), in);
 #else
-    BOOST_CHECK_THROW(Url::decodeUri(in), ML::Exception);
+    BOOST_CHECK_THROW(Url::decodeUri(in), MLDB::Exception);
 #endif
 
     in = "%a";
 #if TOLERATE_URL_BAD_ENCODING
     BOOST_CHECK_EQUAL(Url::decodeUri(in), in);
 #else
-    BOOST_CHECK_THROW(Url::decodeUri(in), ML::Exception);
+    BOOST_CHECK_THROW(Url::decodeUri(in), MLDB::Exception);
 #endif
 }
 #endif
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(test_invalid_utf8)
     Utf8String expected = "Ã";
     BOOST_CHECK_EQUAL(Url::decodeUri(in), expected);
 #else
-    BOOST_CHECK_THROW(Url::decodeUri(in), ML::Exception);
+    BOOST_CHECK_THROW(Url::decodeUri(in), MLDB::Exception);
 #endif
 }
 #endif

--- a/types/testing/id_profile.cc
+++ b/types/testing/id_profile.cc
@@ -10,7 +10,6 @@
 #include "mldb/types/id.h"
 #include "mldb/types/date.h"
 
-using namespace ML;
 using namespace std;
 using namespace MLDB;
 

--- a/types/testing/id_test.cc
+++ b/types/testing/id_test.cc
@@ -352,7 +352,7 @@ BOOST_AUTO_TEST_CASE( test_compound_id )
 BOOST_AUTO_TEST_CASE( test_short_string )
 {
     Id id1 ("short1");
-    cerr << "id1.val1 = " << ML::format("%016llx", (long long)id1.val1) << endl;
+    cerr << "id1.val1 = " << MLDB::format("%016llx", (long long)id1.val1) << endl;
     cerr << "id1.val2 = " << id1.val2 << endl;
     BOOST_CHECK_EQUAL(id1.type, Id::SHORTSTR);
     BOOST_CHECK_EQUAL(id1, id1);

--- a/types/testing/json_handling_test.cc
+++ b/types/testing/json_handling_test.cc
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(test_utf8_bad_string)
     const std::string payload = "\"http\\u00253A\\u00252F\\u";
     const char* start = payload.c_str();                                        
     StreamingJsonParsingContext context(payload, start, start + payload.size());
-    BOOST_CHECK_THROW(context.expectStringUtf8(), ML::Parse_Context::Exception);
+    BOOST_CHECK_THROW(context.expectStringUtf8(), ParseContext::Exception);
 }
 
 BOOST_AUTO_TEST_CASE(test_json_encode_decode_long_strings)
@@ -97,5 +97,5 @@ BOOST_AUTO_TEST_CASE(test_json_encode_decode_long_strings)
     const std::string payload = "\"http\\u00253A\\u00252F\\u";
     const char* start = payload.c_str();                                        
     StreamingJsonParsingContext context(payload, start, start + payload.size());
-    BOOST_CHECK_THROW(context.expectStringUtf8(), ML::Parse_Context::Exception);
+    BOOST_CHECK_THROW(context.expectStringUtf8(), ParseContext::Exception);
 }

--- a/types/testing/json_parsing_test.cc
+++ b/types/testing/json_parsing_test.cc
@@ -17,13 +17,12 @@
 #include <math.h>
 
 using namespace MLDB;
-using namespace ML;
 
 using boost::unit_test::test_suite;
 
 void testUnsigned(const std::string & str, unsigned long long expected)
 {
-    Parse_Context context(str, str.c_str(), str.c_str() + str.size());
+    ParseContext context(str, str.c_str(), str.c_str() + str.size());
     auto val = expectJsonNumber(context);
     context.expect_eof();
     BOOST_CHECK_EQUAL(val.uns, expected);
@@ -32,7 +31,7 @@ void testUnsigned(const std::string & str, unsigned long long expected)
 
 void testSigned(const std::string & str, long long expected)
 {
-    Parse_Context context(str, str.c_str(), str.c_str() + str.size());
+    ParseContext context(str, str.c_str(), str.c_str() + str.size());
     auto val = expectJsonNumber(context);
     context.expect_eof();
     BOOST_CHECK_EQUAL(val.uns, expected);
@@ -41,7 +40,7 @@ void testSigned(const std::string & str, long long expected)
 
 void testFp(const std::string & str, double expected)
 {
-    Parse_Context context(str, str.c_str(), str.c_str() + str.size());
+    ParseContext context(str, str.c_str(), str.c_str() + str.size());
     auto val = expectJsonNumber(context);
     context.expect_eof();
     BOOST_CHECK_EQUAL(val.fp, expected);
@@ -50,7 +49,7 @@ void testFp(const std::string & str, double expected)
 
 void testHex4(const std::string & str, long long expected)
 {
-    Parse_Context context(str, str.c_str(), str.c_str() + str.size());
+    ParseContext context(str, str.c_str(), str.c_str() + str.size());
     auto val = context.expect_hex4();
     context.expect_eof();
     BOOST_CHECK_EQUAL(val, expected);
@@ -89,7 +88,7 @@ BOOST_AUTO_TEST_CASE( test1 )
     BOOST_CHECK_THROW(testHex4("002.", 2), std::exception);
 }
 
-void testExpectStringUtf8(ML::Parse_Context * context)
+void testExpectStringUtf8(ParseContext * context)
 {
     skipJsonWhitespace((*context));
     context->expect_literal('"');
@@ -163,6 +162,6 @@ void testExpectStringUtf8(ML::Parse_Context * context)
 BOOST_AUTO_TEST_CASE(test_utf8_bad_string)
 {
     std::string s = "\"http\\u00253A\\u00252F\\u";
-    Parse_Context context(s, s.c_str(), s.c_str() + s.length());
-    BOOST_CHECK_THROW(testExpectStringUtf8(&context), ML::Parse_Context::Exception);
+    ParseContext context(s, s.c_str(), s.c_str() + s.length());
+    BOOST_CHECK_THROW(testExpectStringUtf8(&context), ParseContext::Exception);
 }

--- a/types/testing/localdate_test.cc
+++ b/types/testing/localdate_test.cc
@@ -19,7 +19,7 @@ using namespace MLDB;
 
 BOOST_AUTO_TEST_CASE( test_constructor )
 {
-    ML::Set_Trace_Exceptions trace(false);
+    Set_Trace_Exceptions trace(false);
 
     /* default constructor */
     LocalDate d;
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE( test_constructor )
 
     /* valid and invalid timezone names */
     BOOST_CHECK_THROW(d = LocalDate(0.0, "NoWhereIsNamedLikeThis"),
-                      ML::Exception);
+                      MLDB::Exception);
     BOOST_CHECK_NO_THROW(d = LocalDate(0.0, "America/Montreal"));
 
     /* Jan 1, 1970 00:00 UTC = Dec 31, 1969 19:00 EST */

--- a/types/testing/periodic_utils_test.cc
+++ b/types/testing/periodic_utils_test.cc
@@ -8,7 +8,6 @@
 #include "mldb/arch/exception.h"
 
 using namespace std;
-using namespace ML;
 using namespace MLDB;
 
 BOOST_AUTO_TEST_CASE(time_period_test)
@@ -51,10 +50,10 @@ BOOST_AUTO_TEST_CASE(time_period_granularity_multiplier)
     JML_TRACE_EXCEPTIONS(false);
 
     /* different families */
-    BOOST_CHECK_THROW(granularityMultiplier(YEARS, MINUTES), ML::Exception);
+    BOOST_CHECK_THROW(granularityMultiplier(YEARS, MINUTES), MLDB::Exception);
 
     /* seconds cannot be translated to minutes */
-    BOOST_CHECK_THROW(granularityMultiplier(SECONDS, MINUTES), ML::Exception);
+    BOOST_CHECK_THROW(granularityMultiplier(SECONDS, MINUTES), MLDB::Exception);
 
     int mult = granularityMultiplier(MILLISECONDS, MILLISECONDS);
     BOOST_CHECK_EQUAL(mult, 1);
@@ -139,7 +138,7 @@ BOOST_AUTO_TEST_CASE(time_period_op_plus_equal)
         TimePeriod minutely("2m");
 
         JML_TRACE_EXCEPTIONS(false);
-        BOOST_CHECK_THROW(yearly + minutely, ML::Exception);
+        BOOST_CHECK_THROW(yearly + minutely, MLDB::Exception);
     }
 
     {

--- a/types/testing/string_test.cc
+++ b/types/testing/string_test.cc
@@ -14,7 +14,6 @@
 #include "mldb/arch/format.h"
 
 using namespace std;
-using namespace ML;
 using namespace MLDB;
 
 

--- a/types/testing/value_description_test.cc
+++ b/types/testing/value_description_test.cc
@@ -30,7 +30,6 @@
 
 
 using namespace std;
-using namespace ML;
 using namespace MLDB;
 
 
@@ -369,13 +368,13 @@ BOOST_AUTO_TEST_CASE( test_structure_description )
     desc->printJson(&data, context);
 
     // inline in some other thing
-    std::string value = ML::format("{\"%s\":%s}", desc->typeName, stream.str());
+    std::string value = MLDB::format("{\"%s\":%s}", desc->typeName, stream.str());
 
     // parse it back
     SomeTestStructure result;
-    ML::Parse_Context source("test", value.c_str(), value.size());
+    ParseContext source("test", value.c_str(), value.size());
         expectJsonObject(source, [&](std::string key,
-                                     ML::Parse_Context & context) {
+                                     ParseContext & context) {
             auto desc = ValueDescription::get(key);
             if(desc) {
                 StreamingJsonParsingContext json(context);

--- a/types/tuple_description.h
+++ b/types/tuple_description.h
@@ -169,18 +169,18 @@ struct TupleDescription
 
     virtual void setArrayLength(void * val, size_t newLength) const override
     {
-        throw ML::Exception("tuple array lengths can't be set");
+        throw MLDB::Exception("tuple array lengths can't be set");
     }
     
     virtual const ValueDescription & contained() const override
     {
-        throw ML::Exception("tuple does not have a consistent contained type");
+        throw MLDB::Exception("tuple does not have a consistent contained type");
     }
 
     virtual void set(void* obj, void* value,
                      const ValueDescription* valueDesc) const override
     {
-        throw ML::Exception("tuple type set not done");
+        throw MLDB::Exception("tuple type set not done");
     }
 
     virtual void initialize() override

--- a/types/url.cc
+++ b/types/url.cc
@@ -84,7 +84,7 @@ Url::init(std::string s)
     }
 
     if (s.find("://") == string::npos) {
-        throw ML::Exception("Attempt to create a URL without a scheme: if you mean http:// or file:// then add it explicitly: " + s);
+        throw MLDB::Exception("Attempt to create a URL without a scheme: if you mean http:// or file:// then add it explicitly: " + s);
         //s = "http://" + s;
     }
     url.reset(new GURL(encodeUri(s)));
@@ -246,14 +246,14 @@ uint64_t
 Url::
 urlHash()
 {
-    throw ML::Exception("urlHash");
+    throw MLDB::Exception("urlHash");
 }
 
 uint64_t
 Url::
 hostHash()
 {
-    throw ML::Exception("hostHash");
+    throw MLDB::Exception("hostHash");
 }
 
 #if 0
@@ -340,7 +340,7 @@ decodeUri(Utf8String in)
 
             ++it; // over high
             if (it == in.end() || !isxdigit(*it)) {
-                throw ML::Exception("Invalid encoding on uri fragment: "
+                throw MLDB::Exception("Invalid encoding on uri fragment: "
                                     + inCopy.rawString());
             }
             high = *it;
@@ -348,7 +348,7 @@ decodeUri(Utf8String in)
 
             ++it; // over low
             if (it == in.end() || !isxdigit(*it)) {
-                throw ML::Exception("Invalid encoding on uri fragment: "
+                throw MLDB::Exception("Invalid encoding on uri fragment: "
                                     + inCopy.rawString());
             }
             low = *it;
@@ -371,7 +371,7 @@ decodeUri(Utf8String in)
         }
 
         if (remaining != 0) {
-            throw ML::Exception("Invalid encoding on uri fragment: "
+            throw MLDB::Exception("Invalid encoding on uri fragment: "
                                 + inCopy.rawString());
         }
 

--- a/types/value_description.cc
+++ b/types/value_description.cc
@@ -17,7 +17,6 @@
 
 
 using namespace std;
-using namespace ML;
 
 
 namespace MLDB {
@@ -56,7 +55,7 @@ ValueDescription(ValueKind kind,
                  const std::string & typeName)
     : kind(kind),
       type(type),
-      typeName(typeName.empty() ? ML::demangle(type->name()) : typeName),
+      typeName(typeName.empty() ? demangle(type->name()) : typeName),
       jsConverters(nullptr),
       jsConvertersInitialized(false)
 {
@@ -78,49 +77,49 @@ void *
 ValueDescription::
 optionalMakeValue(void * val) const
 {
-    throw ML::Exception("type is not optional");
+    throw MLDB::Exception("type is not optional");
 }
 
 const void *
 ValueDescription::
 optionalGetValue(const void * val) const
 {
-    throw ML::Exception("type is not optional");
+    throw MLDB::Exception("type is not optional");
 }
 
 size_t
 ValueDescription::
 getArrayLength(void * val) const
 {
-    throw ML::Exception("type is not an array");
+    throw MLDB::Exception("type is not an array");
 }
 
 void *
 ValueDescription::
 getArrayElement(void * val, uint32_t element) const
 {
-    throw ML::Exception("type is not an array");
+    throw MLDB::Exception("type is not an array");
 }
 
 std::vector<std::shared_ptr<const ValueDescription> >
 ValueDescription::
 getTupleElementDescriptions() const
 {
-    throw ML::Exception("type '" + typeName + "' is not a tuple " + ML::type_name(*this));
+    throw MLDB::Exception("type '" + typeName + "' is not a tuple " + MLDB::type_name(*this));
 }
 
 size_t
 ValueDescription::
 getTupleLength() const
 {
-    throw ML::Exception("type '" + typeName + "' is not a tuple " + ML::type_name(*this));
+    throw MLDB::Exception("type '" + typeName + "' is not a tuple " + MLDB::type_name(*this));
 }
 
 const void *
 ValueDescription::
 getArrayElement(const void * val, uint32_t element) const
 {
-    throw ML::Exception("type is not an array");
+    throw MLDB::Exception("type is not an array");
 }
 
 /** Return the value description for the nth array element.  This is
@@ -138,56 +137,56 @@ void
 ValueDescription::
 setArrayLength(void * val, size_t newLength) const
 {
-    throw ML::Exception("type is not an array");
+    throw MLDB::Exception("type is not an array");
 }
 
 const ValueDescription &
 ValueDescription::
 getKeyValueDescription() const
 {
-    throw ML::Exception("type '" + typeName + "' has no key");
+    throw MLDB::Exception("type '" + typeName + "' has no key");
 }
 
 const ValueDescription &
 ValueDescription::
 contained() const
 {
-    throw ML::Exception("type '" + typeName + "' does not contain another");
+    throw MLDB::Exception("type '" + typeName + "' does not contain another");
 }
 
 OwnershipModel
 ValueDescription::
 getOwnershipModel() const
 {
-    throw ML::Exception("type '" + typeName + "' does not define an ownership type");
+    throw MLDB::Exception("type '" + typeName + "' does not define an ownership type");
 }
 
 void*
 ValueDescription::
 getLink(void* obj) const
 {
-    throw ML::Exception("type '" + typeName + "' is not a link");
+    throw MLDB::Exception("type '" + typeName + "' is not a link");
 }
 
 void
 ValueDescription::
 set(void* obj, void* value, const ValueDescription* valueDesc) const
 {
-    throw ML::Exception("type '" + typeName + "' can't be written to");
+    throw MLDB::Exception("type '" + typeName + "' can't be written to");
 }
 
 size_t
 ValueDescription::
 getFieldCount(const void * val) const
 {
-    throw ML::Exception("type '" + typeName + "' doesn't support fields");
+    throw MLDB::Exception("type '" + typeName + "' doesn't support fields");
 }
 
 const ValueDescription::FieldDescription *
 ValueDescription::
 hasField(const void * val, const std::string & name) const
 {
-    throw ML::Exception("type '" + typeName + "' doesn't support fields");
+    throw MLDB::Exception("type '" + typeName + "' doesn't support fields");
 }
 
 void
@@ -195,28 +194,28 @@ ValueDescription::
 forEachField(const void * val,
              const std::function<void (const FieldDescription &)> & onField) const
 {
-    throw ML::Exception("type '" + typeName + "' doesn't support fields");
+    throw MLDB::Exception("type '" + typeName + "' doesn't support fields");
 }
 
 const ValueDescription::FieldDescription & 
 ValueDescription::
 getField(const std::string & field) const
 {
-    throw ML::Exception("type '" + typeName + "' doesn't support fields");
+    throw MLDB::Exception("type '" + typeName + "' doesn't support fields");
 }
 
 const std::vector<std::string>
 ValueDescription::
 getEnumKeys() const
 {
-    throw ML::Exception("type '" + typeName + "' is not an enum");
+    throw MLDB::Exception("type '" + typeName + "' is not an enum");
 }
 
 std::vector<std::tuple<int, std::string, std::string> >
 ValueDescription::
 getEnumValues() const
 {
-    throw ML::Exception("type '" + typeName + "' is not an enum");
+    throw MLDB::Exception("type '" + typeName + "' is not an enum");
 }
 
 bool
@@ -311,16 +310,16 @@ registerValueDescription(const std::type_info & type,
     ExcAssert(desc);
     registry()[desc->typeName] = desc;
     registry()[type.name()] = desc;
-    registry()[ML::demangle(type.name())] = desc;
+    registry()[demangle(type.name())] = desc;
     initFn(*desc);
 #if 0
-    cerr << "type " << ML::demangle(type.name())
+    cerr << "type " << demangle(type.name())
          << " has description "
-         << ML::type_name(*desc) << " default " << isDefault << endl;
+         << MLDB::type_name(*desc) << " default " << isDefault << endl;
 
     if (registry().count(type.name()))
-        throw ML::Exception("attempt to double register "
-                            + ML::demangle(type.name()));
+        throw MLDB::Exception("attempt to double register "
+                            + demangle(type.name()));
 #endif
 }
 
@@ -349,7 +348,7 @@ StructureDescriptionBase(const std::type_info * type,
                          const std::string & structName,
                          bool nullAccepted)
     : type(type),
-      structName(structName.empty() ? ML::demangle(type->name()) : structName),
+      structName(structName.empty() ? demangle(type->name()) : structName),
       nullAccepted(nullAccepted),
       owner(owner)
 {
@@ -394,7 +393,7 @@ operator = (StructureDescriptionBase && other)
 StructureDescriptionBase::Exception::
 Exception(JsonParsingContext & context,
           const std::string & message)
-    : ML::Exception("at " + context.printPath() + ": " + message)
+    : MLDB::Exception("at " + context.printPath() + ": " + message)
 {
 }
 

--- a/types/value_description.h
+++ b/types/value_description.h
@@ -162,9 +162,9 @@ struct ValueDescription {
         auto res
             = std::dynamic_pointer_cast<const ValueDescriptionT<T> >(base);
         if (!res)
-            throw ML::Exception("logic error in registry: wrong type: "
-                                + ML::type_name(*base) + " not convertible to "
-                                + ML::type_name<const ValueDescriptionT<T>>());
+            throw MLDB::Exception("logic error in registry: wrong type: "
+                                + MLDB::type_name(*base) + " not convertible to "
+                                + MLDB::type_name<const ValueDescriptionT<T>>());
         return res;
     }
 
@@ -338,7 +338,7 @@ struct ValueDescriptionT : public ValueDescription {
 
     virtual void * optionalMakeValueTyped(T * val) const
     {
-        throw ML::Exception("type is not optional");
+        throw MLDB::Exception("type is not optional");
     }
 
     virtual const void * optionalGetValue(const void * val) const override
@@ -349,7 +349,7 @@ struct ValueDescriptionT : public ValueDescription {
 
     virtual const void * optionalGetValueTyped(const T * val) const
     {
-        throw ML::Exception("type is not optional");
+        throw MLDB::Exception("type is not optional");
     }
 
 private:
@@ -362,7 +362,7 @@ private:
 
     void copyValue(void* obj, const void* value, std::false_type) const
     {
-        throw ML::Exception("type is not copy assignable");
+        throw MLDB::Exception("type is not copy assignable");
     }
 
 
@@ -374,7 +374,7 @@ private:
 
     void moveValue(void* obj, void* value, std::false_type) const
     {
-        throw ML::Exception("type is not move assignable");
+        throw MLDB::Exception("type is not move assignable");
     }
 
     // Template parameter so not instantiated for types that are not
@@ -387,7 +387,7 @@ private:
 
     void * constructDefault(std::false_type) const
     {
-        throw ML::Exception("type is not default constructible");
+        throw MLDB::Exception("type is not default constructible");
     }
 };
 
@@ -660,11 +660,11 @@ getDefaultDescriptionShared(T *)
                 = dynamic_cast<ValueDescriptionT<T>typename GetDefaultDescriptionType<T>::type *>
                     (&desc);
                 if (!descTyped)
-                    throw ML::Exception("Attempt to initialized description for "
-                                        + ML::type_name<T>() + " of type "
-                                        + ML::type_name<typename GetDefaultDescriptionType<T>::type >()
+                    throw MLDB::Exception("Attempt to initialized description for "
+                                        + MLDB::type_name<T>() + " of type "
+                                        + MLDB::type_name<typename GetDefaultDescriptionType<T>::type >()
                                         + " from value of type "
-                                        + ML::type_name(desc));
+                                        + MLDB::type_name(desc));
                 
                 initializeDefaultDescription(*descTyped);
 #endif
@@ -681,9 +681,9 @@ getDefaultDescriptionShared(T *)
     auto cast = std::dynamic_pointer_cast<const ValueDescriptionT<T> >(res);
 
     if (!cast)
-        throw ML::Exception("logic error in registry: wrong type: "
-                            + ML::type_name(*res) + " not convertible to "
-                            + ML::type_name<ValueDescriptionT<T> >());
+        throw MLDB::Exception("logic error in registry: wrong type: "
+                            + MLDB::type_name(*res) + " not convertible to "
+                            + MLDB::type_name<ValueDescriptionT<T> >());
 
     return cast;
 }

--- a/utils/atomic_shared_ptr.h
+++ b/utils/atomic_shared_ptr.h
@@ -26,19 +26,19 @@ struct atomic_shared_ptr {
     
     std::shared_ptr<T> load() const
     {
-        std::unique_lock<ML::Spinlock> guard(lock);
+        std::unique_lock<Spinlock> guard(lock);
         return ptr;
     }
 
     void store(std::shared_ptr<T> newVal)
     {
-        std::unique_lock<ML::Spinlock> guard(lock);
+        std::unique_lock<Spinlock> guard(lock);
         ptr = std::move(newVal);
     }
 
     std::shared_ptr<T> exchange(std::shared_ptr<T> newVal)
     {
-        std::unique_lock<ML::Spinlock> guard(lock);
+        std::unique_lock<Spinlock> guard(lock);
         std::shared_ptr<T> result = std::move(ptr);
         ptr = std::move(newVal);
         return result;
@@ -47,7 +47,7 @@ struct atomic_shared_ptr {
     bool compare_exchange_strong(std::shared_ptr<T> & expected,
                                  std::shared_ptr<T> desired)
     {
-        std::unique_lock<ML::Spinlock> guard(lock);
+        std::unique_lock<Spinlock> guard(lock);
         if (ptr == expected) {
             expected = std::move(ptr);
             ptr = std::move(desired);
@@ -60,7 +60,7 @@ struct atomic_shared_ptr {
     }
 
 private:
-    mutable ML::Spinlock lock;
+    mutable Spinlock lock;
     std::shared_ptr<T> ptr;
 };
 

--- a/utils/command_expression.cc
+++ b/utils/command_expression.cc
@@ -69,14 +69,14 @@ std::vector<Date> iterDates(Date startDate, Date endDate,
                             TimePeriod step)
 {
     if (endDate < startDate)
-        throw ML::Exception("end date less than start date");
+        throw MLDB::Exception("end date less than start date");
     if (step.number <= 0)
-        throw ML::Exception("time interval goes the wrong way");
+        throw MLDB::Exception("time interval goes the wrong way");
 
     vector<Date> result;
     for (Date d = startDate;  d < endDate;  d += step) {
         if (result.size() > 100000)
-            throw ML::Exception("list of dates is too long");
+            throw MLDB::Exception("list of dates is too long");
         result.push_back(d);
     }
 
@@ -159,10 +159,10 @@ Json::Value csv(const std::vector<Json::Value> & params)
             for (unsigned j = 0;  j < params[i].size();  ++j) {
                 if (j != 0)
                     result += ',';
-                result += ML::csv_escape(stringRender(params[i][j]));
+                result += csv_escape(stringRender(params[i][j]));
             }
         }
-        else result += ML::csv_escape(stringRender(params[i]));
+        else result += csv_escape(stringRender(params[i]));
     }
     return result;
 }
@@ -188,7 +188,7 @@ Json::Value tsv(const std::vector<Json::Value> & params)
 Json::Value hash(const std::vector<Json::Value> & params)
 {
     if (params.size() != 1)
-        throw ML::Exception("hash() function takes exactly one argument");
+        throw MLDB::Exception("hash() function takes exactly one argument");
     return jsonHash(params[0]);
 }
 
@@ -246,13 +246,13 @@ applyFunction(const std::string & functionName,
             using namespace std;
             cerr << "function " << functionName << " is not registered"
                  << endl;
-            throw ML::Exception("function " + functionName + " is not registered");
+            throw MLDB::Exception("function " + functionName + " is not registered");
         }
     }
     try {
         return it->second(functionArgs);
     } catch (const std::exception & exc) {
-        throw ML::Exception("error trying to apply %s to args %s: %s",
+        throw MLDB::Exception("error trying to apply %s to args %s: %s",
                             functionName.c_str(),
                             boost::lexical_cast<std::string>(functionArgs).c_str(),
                             exc.what());
@@ -269,7 +269,7 @@ std::shared_ptr<CommandExpression>
 CommandExpression::
 parse(const std::string & val)
 {
-    ML::Parse_Context context(val, val.c_str(), val.c_str() + val.length());
+    ParseContext context(val, val.c_str(), val.c_str() + val.length());
     
     std::shared_ptr<CommandExpression> res;
     if (context.match_literal("%!"))
@@ -285,7 +285,7 @@ std::shared_ptr<CommandExpression>
 CommandExpression::
 parseArgumentExpression(const std::string & val)
 {
-    ML::Parse_Context context(val, val.c_str(), val.c_str() + val.length());
+    ParseContext context(val, val.c_str(), val.c_str() + val.length());
     
     auto res = parseArgumentExpression(context);
     
@@ -308,7 +308,7 @@ parse(const std::vector<std::string> & vals)
 
 std::shared_ptr<CommandExpression>
 CommandExpression::
-parseExpression(ML::Parse_Context & context, bool stopOnWhitespace)
+parseExpression(ParseContext & context, bool stopOnWhitespace)
 {
     // Default is concat... we stop when we have a percent
 
@@ -316,7 +316,7 @@ parseExpression(ML::Parse_Context & context, bool stopOnWhitespace)
 
     std::shared_ptr<ConcatExpression> expr(new ConcatExpression());
 
-    Parse_Context::Hold_Token token(context);
+    ParseContext::Hold_Token token(context);
 
     auto addContext = [&] (std::shared_ptr<CommandExpression> expr)
         {
@@ -379,9 +379,9 @@ parseExpression(ML::Parse_Context & context, bool stopOnWhitespace)
 
 std::shared_ptr<CommandExpression>
 CommandExpression::
-parseArgumentExpression(ML::Parse_Context & context)
+parseArgumentExpression(ParseContext & context)
 {
-    Parse_Context::Hold_Token token(context);
+    ParseContext::Hold_Token token(context);
 
     auto addContext = [&] (std::shared_ptr<CommandExpression> expr)
         {
@@ -582,7 +582,7 @@ argumentRender(const Json::Value & val)
         return str;
     }
     default:
-        throw ML::Exception("can't render value " + val.toString() + " as string");
+        throw MLDB::Exception("can't render value " + val.toString() + " as string");
     }
 }
 
@@ -608,7 +608,7 @@ commandRender(const Json::Value & val)
         return str;
     }
     default:
-        throw ML::Exception("can't render value " + val.toString() + " as command");
+        throw MLDB::Exception("can't render value " + val.toString() + " as command");
     }
 }
 
@@ -634,7 +634,7 @@ stringRender(const Json::Value & val)
         return str;
     }
     default:
-        throw ML::Exception("can't render value " + val.toString() + " as string");
+        throw MLDB::Exception("can't render value " + val.toString() + " as string");
     }
 }
 
@@ -647,7 +647,7 @@ void
 StringTemplate::
 parse(const std::string & command)
 {
-    ML::Parse_Context context(command,
+    ParseContext context(command,
                               command.c_str(), command.c_str() + command.size());
 
     expr = CommandExpression::parseExpression(context, false /* stop on whitespace */);
@@ -680,7 +680,7 @@ void
 CommandTemplate::
 parse(const std::string & command)
 {
-    ML::Parse_Context context(command,
+    ParseContext context(command,
                               command.c_str(), command.c_str() + command.size());
 
     while (context) {

--- a/utils/command_expression.h
+++ b/utils/command_expression.h
@@ -114,7 +114,7 @@ struct CommandExpressionVariables {
         if (it == values.end()) {
             if (outer)
                 return outer->getValue(variableName);
-            else throw ML::Exception("couldn't find value of " + variableName);
+            else throw MLDB::Exception("couldn't find value of " + variableName);
         }
         return it->second;
     }
@@ -261,10 +261,10 @@ struct CommandExpression {
     std::string surfaceForm;
 
     static std::shared_ptr<CommandExpression>
-    parseExpression(ML::Parse_Context & context, bool stopOnWhitespace = false);
+    parseExpression(ParseContext & context, bool stopOnWhitespace = false);
 
     static std::shared_ptr<CommandExpression>
-    parseArgumentExpression(ML::Parse_Context & context);
+    parseArgumentExpression(ParseContext & context);
 
     static std::shared_ptr<CommandExpression>
     parse(const std::string & val);
@@ -570,7 +570,7 @@ struct PlusExpression: public BinaryArithmeticExpression {
             return result;
         }
         else return stringRender(lhs) + stringRender(rhs);
-        //else throw ML::Exception("don't know how to add %s and %s",
+        //else throw MLDB::Exception("don't know how to add %s and %s",
         //                         lhs.toString().c_str(),
         //                         rhs.toString().c_str());
     }
@@ -593,7 +593,7 @@ struct DivideExpression: public BinaryArithmeticExpression {
             }
             return lhs.asInt() / rhs.asInt();
         }
-        else throw ML::Exception("don't know how to divide %s by %s",
+        else throw MLDB::Exception("don't know how to divide %s by %s",
                                  lhs.toString().c_str(),
                                  rhs.toString().c_str());
     }

--- a/utils/command_expression_impl.h
+++ b/utils/command_expression_impl.h
@@ -36,7 +36,7 @@ bindFunction(const std::function<R ()> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 0)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             return jsonEncode(fn());
         };
 }
@@ -48,7 +48,7 @@ bindFunction(const std::function<void ()> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 0)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             fn();
             return Json::Value();
         };
@@ -63,7 +63,7 @@ bindFunction(const std::function<R (A1)> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 1)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             return jsonEncode(fn(jsonDecode<A1>(args[0])));
         };
 }
@@ -76,7 +76,7 @@ bindFunction(const std::function<void (A1)> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 1)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             fn(jsonDecode<A1>(args[0]));
             return Json::Value();
         };
@@ -90,7 +90,7 @@ bindFunction(const std::function<R (A1, A2)> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 2)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             return jsonEncode(fn(jsonDecode<A1>(args[0]),
                                  jsonDecode<A2>(args[1])));
         };
@@ -104,7 +104,7 @@ bindFunction(const std::function<void (A1, A2)> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 2)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             fn(jsonDecode<A1>(args[0]),
                jsonDecode<A2>(args[1]));
             return Json::Value();
@@ -119,7 +119,7 @@ bindFunction(const std::function<R (A1, A2, A3)> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 3)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             return jsonEncode(fn(jsonDecode<A1>(args[0]),
                                  jsonDecode<A2>(args[1]),
                                  jsonDecode<A3>(args[2])));
@@ -134,7 +134,7 @@ bindFunction(const std::function<void (A1, A2, A3)> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 3)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             fn(jsonDecode<A1>(args[0]),
                jsonDecode<A2>(args[1]),
                jsonDecode<A3>(args[2]));
@@ -150,7 +150,7 @@ bindFunction(const std::function<R (A1, A2, A3, A4)> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 4)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             return jsonEncode(fn(jsonDecode<A1>(args[0]),
                                  jsonDecode<A2>(args[1]),
                                  jsonDecode<A3>(args[2]),
@@ -166,7 +166,7 @@ bindFunction(const std::function<void (A1, A2, A3, A4)> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 4)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             fn(jsonDecode<A1>(args[0]),
                jsonDecode<A2>(args[1]),
                jsonDecode<A3>(args[2]),
@@ -184,7 +184,7 @@ bindFunction(const std::function<R (A1, A2, A3, A4, A5)> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 5)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             return jsonEncode(fn(jsonDecode<A1>(args[0]),
                                  jsonDecode<A2>(args[1]),
                                  jsonDecode<A3>(args[2]),
@@ -201,7 +201,7 @@ bindFunction(const std::function<void (A1, A2, A3, A4, A5)> & fn)
     return [=] (const std::vector<Json::Value> & args)
         {
             if (args.size() != 4)
-                throw ML::Exception("wrong number of args for function");
+                throw MLDB::Exception("wrong number of args for function");
             fn(jsonDecode<A1>(args[0]),
                jsonDecode<A2>(args[1]),
                jsonDecode<A3>(args[2]),
@@ -218,7 +218,7 @@ struct CommandExpressionDescription
                                 JsonParsingContext & context) const
     {
         std::string str = context.expectStringAscii();
-        ML::Parse_Context pcontext(str, str.c_str(), str.c_str() + str.size());
+        ParseContext pcontext(str, str.c_str(), str.c_str() + str.size());
         *val = CommandExpression::parseExpression(pcontext, false);
     }
 

--- a/utils/compact_vector.h
+++ b/utils/compact_vector.h
@@ -279,7 +279,7 @@ public:
     void pop_back()
     {
         if (Safe && empty())
-            throw ML::Exception("popping back empty compact vector");
+            throw MLDB::Exception("popping back empty compact vector");
 
 #if 0 // save space when making smaller
         if (size_ == Internal + 1) {
@@ -346,9 +346,9 @@ public:
     {
         if (Safe) {
             if (first > last)
-                throw ML::Exception("compact_vector::erase(): last before first");
+                throw MLDB::Exception("compact_vector::erase(): last before first");
             if (first < begin() || last > end())
-                throw ML::Exception("compact_vector::erase(): iterators not ours");
+                throw MLDB::Exception("compact_vector::erase(): iterators not ours");
         }
 
         int firstindex = first - begin();
@@ -469,7 +469,7 @@ private:
     void check_index(size_type index) const
     {
         if (index >= size_)
-            throw ML::Exception("compact_vector: index out of range");
+            throw MLDB::Exception("compact_vector: index out of range");
     }
 
     void init(size_t to_alloc)
@@ -477,7 +477,7 @@ private:
         clear();
 
         if (to_alloc > max_size())
-            throw ML::Exception("compact_vector can't grow that big");
+            throw MLDB::Exception("compact_vector can't grow that big");
         
         if (to_alloc > Internal) {
             is_internal_ = false;
@@ -497,7 +497,7 @@ private:
         // Copy the objects across into the uninitialized memory
         for (; first != last;  ++first, ++p, ++size_) {
             if (Safe && size_ > to_alloc)
-                throw ML::Exception("compact_vector: internal logic error in init()");
+                throw MLDB::Exception("compact_vector: internal logic error in init()");
             new (p) Data(*first);
         }
     }
@@ -535,7 +535,7 @@ private:
         int index = pos - begin();
 
         if (Safe && (index < 0 || index > size_))
-            throw ML::Exception("compact_vector insert: invalid index");
+            throw MLDB::Exception("compact_vector insert: invalid index");
 
         using namespace std;
         bool debug JML_UNUSED = false;

--- a/utils/json_diff.cc
+++ b/utils/json_diff.cc
@@ -567,7 +567,7 @@ jsonPatch(const Json::Value * val,
                             current = &(*val)[f.first];
                         }
                         else {
-                            throw ML::Exception("element does not exist");
+                            throw MLDB::Exception("element does not exist");
                         }
 
                         JsonDiff fieldConflicts;
@@ -591,7 +591,7 @@ jsonPatch(const Json::Value * val,
                             }
                         }
                         else if (f.first > oldSize) {
-                            throw ML::Exception("index " + to_string(f.first)
+                            throw MLDB::Exception("index " + to_string(f.first)
                                                 + " is invalid");
                         }
                         (*patchedValue)[f.first] = *f.second.newValue;
@@ -689,7 +689,7 @@ jsonPatch(const Json::Value * val,
         }
     }
     else {
-        throw ML::Exception("logic error");
+        throw MLDB::Exception("logic error");
     }
 
     return make_pair(std::move(patchedValue), std::move(conflicts));

--- a/utils/json_format.cc
+++ b/utils/json_format.cc
@@ -108,7 +108,7 @@ int main(int argc, char ** argv)
         //cerr << "doing file " << f << endl;
         filter_istream stream(f);
         //cerr << "stream = " << (bool)stream << endl;
-        ML::Parse_Context pcontext(f, stream);
+        ParseContext pcontext(f, stream);
         //cerr << "stream = " << (bool)stream << endl;
 
         while (pcontext) {

--- a/utils/json_utils.cc
+++ b/utils/json_utils.cc
@@ -193,7 +193,7 @@ uint64_t jsonHash(const Json::Value & val,
     case Json::nullValue:
         return 1;
     default:
-        throw ML::Exception("unknown value type for jsonHash");
+        throw MLDB::Exception("unknown value type for jsonHash");
     }
 }
 
@@ -219,7 +219,7 @@ Json::Value jsonMin(const Json::Value & v1,
         return v1.asDouble() < v2.asDouble() ? v1 : v2;
     else if (v1.isString() && v2.isString())
         return v1.asString() < v2.asString() ? v1 : v2;
-    else throw ML::Exception("cannot compare " + v1.toString() + " to "
+    else throw MLDB::Exception("cannot compare " + v1.toString() + " to "
                              + v2.toString());
 }
 
@@ -230,7 +230,7 @@ Json::Value jsonMax(const Json::Value & v1,
         return v1.asDouble() < v2.asDouble() ? v2 : v1;
     else if (v1.isString() && v2.isString())
         return v1.asString() < v2.asString() ? v2 : v1;
-    else throw ML::Exception("cannot compare " + v1.toString() + " to "
+    else throw MLDB::Exception("cannot compare " + v1.toString() + " to "
                              + v2.toString());
 }
 

--- a/utils/log.cc
+++ b/utils/log.cc
@@ -21,7 +21,7 @@ namespace {
         else if (level == "error")
             return spdlog::level::err;
         else
-            throw ML::Exception("Unknown level '" + level
+            throw MLDB::Exception("Unknown level '" + level
                                 + "' expected one of \"debug\", \"info\", \"warn\" or \"error\"");
     }
 }

--- a/utils/log_fwd.h
+++ b/utils/log_fwd.h
@@ -27,7 +27,7 @@ std::shared_ptr<spdlog::logger> getServerLog();
 template <typename Class>
 std::string
 getLoggerNameFromClass() {
-    return ML::demangle(typeid(Class));
+    return demangle(typeid(Class));
 }
 
 template <typename Class>

--- a/utils/runner.cc
+++ b/utils/runner.cc
@@ -51,7 +51,7 @@ CreateStdPipe(bool forWriting)
     int fds[2];
     int rc = pipe(fds);
     if (rc == -1) {
-        throw ML::Exception(errno, "CreateStdPipe pipe2");
+        throw MLDB::Exception(errno, "CreateStdPipe pipe2");
     }
 
     if (forWriting) {
@@ -110,7 +110,7 @@ handleChildStatus(const struct epoll_event & event)
                        condition). */
                     break;
                 }
-                throw ML::Exception(errno, "Runner::handleChildStatus read");
+                throw MLDB::Exception(errno, "Runner::handleChildStatus read");
             }
             else if (s == 0) {
                 break;
@@ -163,9 +163,9 @@ handleChildStatus(const struct epoll_event & event)
                 attemptTaskTermination();
                 break;
             case ProcessState::DONE:
-                throw ML::Exception("unexpected status DONE");
+                throw MLDB::Exception("unexpected status DONE");
             case ProcessState::UNKNOWN:
-                throw ML::Exception("unexpected status UNKNOWN");
+                throw MLDB::Exception("unexpected status UNKNOWN");
             }
 
             if (status.launchErrno
@@ -230,7 +230,7 @@ handleOutputStatus(const struct epoll_event & event,
                     break;
                 }
                 else {
-                    throw ML::Exception(errno,
+                    throw MLDB::Exception(errno,
                                         "Runner::handleOutputStatus read");
                 }
             }
@@ -346,7 +346,7 @@ Runner::
 getStdInSink()
 {
     if (stdInSink_) {
-        throw ML::Exception("stdin sink already set");
+        throw MLDB::Exception("stdin sink already set");
     }
     ExcAssertEqual(childStdinFd_, -1);
 
@@ -384,10 +384,10 @@ run(const vector<string> & command,
 {
     if (parent_ == nullptr) {
         LOG(warnings)
-            << ML::format("Runner %p is not connected to any MessageLoop\n", this);
+            << MLDB::format("Runner %p is not connected to any MessageLoop\n", this);
     }
     if (!onTerminate) {
-        throw ML::Exception("'onTerminate' parameter is mandatory");
+        throw MLDB::Exception("'onTerminate' parameter is mandatory");
     }
     ExcAssert(runRequests_ < std::numeric_limits<int>::max());
     runRequests_++;
@@ -476,7 +476,7 @@ doRunImpl(const vector<string> & command,
     activeRequest_++;
     ML::futex_wake(activeRequest_);
     if (oldRunning) {
-        throw ML::Exception("already running");
+        throw MLDB::Exception("already running");
     }
     startDate_ = Date::now();
     endDate_ = Date::negativeInfinity();
@@ -511,7 +511,7 @@ doRunImpl(const vector<string> & command,
     ::funlockfile(stderr);
     ::funlockfile(stdout);
     if (task_.wrapperPid == -1) {
-        throw ML::Exception(savedErrno, "Runner::run fork");
+        throw MLDB::Exception(savedErrno, "Runner::run fork");
     }
     else if (task_.wrapperPid == 0) {
         try {
@@ -559,7 +559,7 @@ kill(int signum, bool mustSucceed) const
 {
     if (childPid_ <= 0) {
         if (mustSucceed)
-            throw ML::Exception("subprocess not available");
+            throw MLDB::Exception("subprocess not available");
         else return false;
     }
 
@@ -574,7 +574,7 @@ signal(int signum, bool mustSucceed)
 {
     if (childPid_ <= 0) {
         if (mustSucceed)
-            throw ML::Exception("subprocess not available");
+            throw MLDB::Exception("subprocess not available");
         else return false;
     }
     
@@ -709,10 +709,10 @@ runWrapper(const vector<string> & command, ProcessFds & fds)
 
     int res = execve(argv[0], argv, envp);
     if (res == -1) {
-        throw ML::Exception(errno, "launching runner helper");
+        throw MLDB::Exception(errno, "launching runner helper");
     }
 
-    throw ML::Exception("You are the King of Time!");
+    throw MLDB::Exception("You are the King of Time!");
 }
 
 string
@@ -743,7 +743,7 @@ findRunnerHelper()
             struct stat sb;
             int res = ::stat(staticHelper.c_str(), &sb);
             if (res != 0) {
-                throw ML::Exception(errno, "checking static helper");
+                throw MLDB::Exception(errno, "checking static helper");
             }
         }
         runnerHelper = staticHelper;
@@ -759,7 +759,7 @@ Runner::Task::
 postTerminate(Runner & runner)
 {
     if (wrapperPid <= 0) {
-        throw ML::Exception("wrapperPid <= 0, has postTerminate been executed before?");
+        throw MLDB::Exception("wrapperPid <= 0, has postTerminate been executed before?");
     }
 
     int wrapperPidStatus;
@@ -770,11 +770,11 @@ postTerminate(Runner & runner)
         }
         else if (res == -1) {
             if (errno != EINTR) {
-                throw ML::Exception(errno, "waitpid");
+                throw MLDB::Exception(errno, "waitpid");
             }
         }
         else {
-            throw ML::Exception("waitpid has not returned the wrappedPid");
+            throw MLDB::Exception("waitpid has not returned the wrappedPid");
         }
     }
     wrapperPid = -1;
@@ -791,7 +791,7 @@ postTerminate(Runner & runner)
             try {
                 runner.removeFd(fd, true);
             }
-            catch (const ML::Exception & exc) {
+            catch (const MLDB::Exception & exc) {
             }
             ::close(fd);
             fd = -1;
@@ -853,7 +853,7 @@ processStatus()
         }
     }
     else
-        throw ML::Exception("unhandled state");
+        throw MLDB::Exception("unhandled state");
 
     return status;
 }
@@ -896,7 +896,7 @@ to_string(const RunResult::State & state)
     case RunResult::PARENT_EXITED: return "PARENT_EXITED";
     }
 
-    return ML::format("RunResult::State(%d)", state);
+    return MLDB::format("RunResult::State(%d)", state);
 }
 
 std::ostream &

--- a/utils/runner_common.cc
+++ b/utils/runner_common.cc
@@ -32,7 +32,7 @@ strLaunchError(LaunchError error)
     case LaunchError::SUBTASK_WAITPID: return "waitpid waiting for subtask";
     case LaunchError::WRONG_CHILD: return "waitpid() returned the wrong child";
     }
-    throw ML::Exception("unknown error launch error code %d",
+    throw MLDB::Exception("unknown error launch error code %d",
                         error);
 }
 
@@ -46,7 +46,7 @@ statusStateAsString(ProcessState statusState)
     case ProcessState::STOPPED: return "STOPPED";
     case ProcessState::DONE: return "DONE";
     }
-    throw ML::Exception("unknown status %d", statusState);
+    throw MLDB::Exception("unknown status %d", statusState);
 }
 
 }
@@ -116,7 +116,7 @@ dupToStdStreams()
         if (oldFd != newFd) {
             int rc = ::dup2(oldFd, newFd);
             if (rc == -1) {
-                throw ML::Exception(errno,
+                throw MLDB::Exception(errno,
                                     "ProcessFds::dupToStdStream dup2");
             }
         }
@@ -152,13 +152,13 @@ encodeToBuffer(char * buffer, size_t bufferSize)
     int written = ::sprintf(buffer, "%.8x/%.8x/%.8x/%.8x",
                             stdIn, stdOut, stdErr, statusFd);
     if (written < 0) {
-        throw ML::Exception("encoding failed");
+        throw MLDB::Exception("encoding failed");
     }
 
     /* bufferSize must be equal to the number of bytes used above, plus 1 for
        '\0' */
     if (written >= bufferSize) {
-        throw ML::Exception("buffer overflow");
+        throw MLDB::Exception("buffer overflow");
     }
 }
 
@@ -169,7 +169,7 @@ decodeFromBuffer(const char * buffer)
     int decoded = ::sscanf(buffer, "%x/%x/%x/%x",
                            &stdIn, &stdOut, &stdErr, &statusFd);
     if (decoded < 0) {
-        throw ML::Exception(errno, "decoding failed");
+        throw MLDB::Exception(errno, "decoding failed");
     }
 }
 
@@ -180,7 +180,7 @@ writeStatus(const ProcessStatus & status)
 {
     int res = ::write(statusFd, &status, sizeof(status));
     if (res == -1)
-        throw ML::Exception(errno, "write");
+        throw MLDB::Exception(errno, "write");
     else if (res != sizeof(status))
-        throw ML::Exception("writing of status is incomplete");
+        throw MLDB::Exception("writing of status is incomplete");
 }

--- a/utils/runner_helper.cc
+++ b/utils/runner_helper.cc
@@ -182,17 +182,17 @@ int main(int argc, char * argv[])
     });
     int res = ::pipe2(childLaunchStatusFd, O_CLOEXEC);
     if (res == -1)
-        throw ML::Exception(errno, "pipe() for status");
+        throw MLDB::Exception(errno, "pipe() for status");
 
     int childPid = fork();
     if (childPid == 0) {
         runChild(execArgs, childLaunchStatusFd, fds);
         /* there is no possible way this code could be executed, because
          * "runChild" calls "execv" */
-        throw ML::Exception("The Alpha became the Omega.");
+        throw MLDB::Exception("The Alpha became the Omega.");
     }
     else if (childPid == -1) {
-        throw ML::Exception(errno, "fork() in runWrapper");
+        throw MLDB::Exception(errno, "fork() in runWrapper");
     }
 
     int exitCode = monitorChild(childPid, childLaunchStatusFd, fds);

--- a/utils/testing/print_utils.h
+++ b/utils/testing/print_utils.h
@@ -33,7 +33,7 @@ printElapsed(double elapsed)
         i++;
     }
 
-    return ML::format("%6.2f%c", elapsed, scaleIndicators[i]);
+    return MLDB::format("%6.2f%c", elapsed, scaleIndicators[i]);
 }
 
 inline std::string
@@ -47,13 +47,13 @@ printValue(double value)
         i++;
     }
 
-    return ML::format("%6.2f%c", value, scaleIndicators[i]);
+    return MLDB::format("%6.2f%c", value, scaleIndicators[i]);
 }
 
 inline std::string
 printPct(double value)
 {
-    return ML::format("%6.2f%%", value * 100.0);
+    return MLDB::format("%6.2f%%", value * 100.0);
 }
 
 

--- a/utils/testing/runner_stress_test.cc
+++ b/utils/testing/runner_stress_test.cc
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE( test_stress_runner )
             }
         }
         else {
-            throw ML::Exception("pid was never set");
+            throw MLDB::Exception("pid was never set");
         }
     }
 }

--- a/utils/testing/runner_test.cc
+++ b/utils/testing/runner_test.cc
@@ -66,7 +66,7 @@ vector<string> pendingSignals()
     sigset_t sigs;
     int res = sigpending(&sigs);
     if (res == -1)
-        throw ML::Exception(errno, "sigpending");
+        throw MLDB::Exception(errno, "sigpending");
     
     vector<string> result;
     for (unsigned i = 1;  i < 32;  ++i)

--- a/utils/testing/runner_test.h
+++ b/utils/testing/runner_test.h
@@ -33,7 +33,7 @@ struct RunnerTestHelperCommands : std::vector<std::string>
         int len = data.size();
         int totalLen = len + 3 + sizeof(int);
         if (totalLen > 16384) {
-            throw ML::Exception("message too large");
+            throw MLDB::Exception("message too large");
         }
         ::sprintf(cmdBuffer, (isStdOut ? "out" : "err"));
         ::memcpy(cmdBuffer + 3, &len, sizeof(int));

--- a/utils/testing/runner_test_helper.cc
+++ b/utils/testing/runner_test_helper.cc
@@ -42,7 +42,7 @@ DoSleep(FILE * in)
 
     size_t r = ::fread(&delay_buf, 1, 4, in);
     if (r != 4) {
-        throw ML::Exception("wrong delay: " + to_string(r));
+        throw MLDB::Exception("wrong delay: " + to_string(r));
     }
 
     long delay = ::strtol(delay_buf, NULL, 16);

--- a/utils/testing/sink_test.cc
+++ b/utils/testing/sink_test.cc
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE( test_asyncfdoutputsink_hup )
 
     int res = pipe(fds);
     if (res == -1) {
-        throw ML::Exception(errno, "pipe");
+        throw MLDB::Exception(errno, "pipe");
     }
 
     bool hup(false), closed(false);
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE( test_asyncfdoutputsink_many_msgs )
 
     int res = pipe(fds);
     if (res == -1) {
-        throw ML::Exception(errno, "pipe");
+        throw MLDB::Exception(errno, "pipe");
     }
 
     bool hup(false), closed(false);
@@ -144,12 +144,12 @@ BOOST_AUTO_TEST_CASE( test_asyncfdoutputsink_many_msgs )
         char buffer[1024];
         int res = ::read(fds[0], buffer, fullmsgsize);
         if (res == -1) {
-            throw ML::Exception(errno, "read");
+            throw MLDB::Exception(errno, "read");
         }
 
         string recvmsg(buffer, fullmsgsize);
         if (recvmsg != message) {
-            throw ML::Exception("message " + to_string(i) + " does not match");
+            throw MLDB::Exception("message " + to_string(i) + " does not match");
         }
     }
     sink.requestClose();

--- a/utils/testing/threaded_test.h
+++ b/utils/testing/threaded_test.h
@@ -96,7 +96,7 @@ struct ThreadedTimedTest
         return configs.size() - 1;
     }
 
-    typedef ML::distribution<double> Dist;
+    typedef distribution<double> Dist;
 
     std::pair<Dist, Dist> distributions(unsigned gr)
     {

--- a/vfs/filter_streams.cc
+++ b/vfs/filter_streams.cc
@@ -210,7 +210,7 @@ void addCompression(streambuf & buf,
         stream.push(lz4_compressor(compressionLevel));
     }
     else if (compression != "" && compression != "none")
-        throw ML::Exception("unknown filter compression " + compression);
+        throw MLDB::Exception("unknown filter compression " + compression);
     
 }
 
@@ -306,7 +306,7 @@ std::ios_base::openmode getMode(const std::map<std::string, std::string> & optio
             result |= ios_base::out;
         else if (el == "trunc")
             result |= ios_base::trunc;
-        else throw ML::Exception("unknown filter_stream open mode " + el);
+        else throw MLDB::Exception("unknown filter_stream open mode " + el);
 
         if (pos == string::npos)
             break;
@@ -446,7 +446,7 @@ open(int fd, const std::map<std::string, std::string> & options)
     if (!header.empty()) {
         ssize_t rc = ::write(fd, header.c_str(), header.size());
         if (rc < 0) {
-            throw ML::Exception(errno, "open", "open");
+            throw MLDB::Exception(errno, "open", "open");
         }
     }
 
@@ -655,7 +655,7 @@ openFromHandler(const UriHandler & handler,
     this->handlerOptions = handler.options;
     this->info_ = handler.info;
     if (!this->info_)
-        throw ML::Exception("Handler for resource '" + resource
+        throw MLDB::Exception("Handler for resource '" + resource
                             + "' didn't set info");
     ExcAssert(this->info_);
     openFromStreambuf(handler.buf, handler.bufOwnership, resource, compression);
@@ -806,7 +806,7 @@ filter_istream::
 info() const
 {
     if (!info_)
-        throw ML::Exception("Resource '" + resource + "' doesn't have info");
+        throw MLDB::Exception("Resource '" + resource + "' doesn't have info");
     return *info_;
 }
 
@@ -826,12 +826,12 @@ void registerUriHandler(const std::string & scheme,
                         const UriHandlerFactory & handler)
 {
     if (!handler)
-        throw ML::Exception("registerUriHandler: null handler passed");
+        throw MLDB::Exception("registerUriHandler: null handler passed");
 
     std::unique_lock<std::mutex> guard(uriHandlersLock);
     auto it = uriHandlers.find(scheme);
     if (it != uriHandlers.end())
-        throw ML::Exception("already have a Uri handler registered for scheme "
+        throw MLDB::Exception("already have a Uri handler registered for scheme "
                             + scheme);
     uriHandlers[scheme] = handler;
 }
@@ -852,7 +852,7 @@ getUriHandler(const std::string & scheme)
             return it->second;
     }
 
-    throw ML::Exception("Uri handler not found for scheme " + scheme);
+    throw MLDB::Exception("Uri handler not found for scheme " + scheme);
 }
 
 struct RegisterFileHandler {
@@ -886,7 +886,7 @@ struct RegisterFileHandler {
                 buf->open(resource, ios_base::openmode(mode));
 
                 if (!buf->is_open())
-                    throw ML::Exception("couldn't open file %s: %s",
+                    throw MLDB::Exception("couldn't open file %s: %s",
                                         resource.c_str(), strerror(errno));
 
                 return UriHandler(buf.get(), buf, info);
@@ -901,7 +901,7 @@ struct RegisterFileHandler {
                     options.mappedSize = source.size();
                     return UriHandler(buf.get(), buf, info, options);
                 } catch (const std::exception & exc) {
-                    throw ML::Exception("Opening file " + resource + ": "
+                    throw MLDB::Exception("Opening file " + resource + ": "
                                         + exc.what());
                 }
             }
@@ -914,12 +914,12 @@ struct RegisterFileHandler {
             buf->open(resource, ios_base::openmode(mode));
 
             if (!buf->is_open())
-                throw ML::Exception("couldn't open file %s: %s",
+                throw MLDB::Exception("couldn't open file %s: %s",
                                     resource.c_str(), strerror(errno));
 
             return UriHandler(buf.get(), buf);
         }
-        else throw ML::Exception("no way to create file handler for non in/out");
+        else throw MLDB::Exception("no way to create file handler for non in/out");
     }
 
     RegisterFileHandler()
@@ -1066,9 +1066,9 @@ struct RegisterMemHandler {
                   const OnUriHandlerException & onException)
     {
         if (scheme != "mem")
-            throw ML::Exception("bad scheme name");
+            throw MLDB::Exception("bad scheme name");
         if (resource == "")
-            throw ML::Exception("bad resource name");
+            throw MLDB::Exception("bad resource name");
 
         unique_lock<mutex> guard(memStringsLock);
 
@@ -1085,7 +1085,7 @@ struct RegisterMemHandler {
                                                                                  4096));
         }
         else {
-            throw ML::Exception("unable to create mem handler");
+            throw MLDB::Exception("unable to create mem handler");
         }
         FsObjectInfo info;
         info.exists = true;

--- a/vfs/fs_utils.cc
+++ b/vfs/fs_utils.cc
@@ -91,14 +91,14 @@ void setGlobalAcceptUrisWithoutScheme(bool accept)
 Url makeUrl(const string & urlStr)
 {
     if (urlStr.empty())
-        throw ML::Exception("can't makeUrl on empty url");
+        throw MLDB::Exception("can't makeUrl on empty url");
 
     /* scheme is specified */
     if (urlStr.find("://") != string::npos) {
         return Url(urlStr);
     }
     else if (!acceptUrisWithoutScheme) {
-        throw ML::Exception("Cannot accept URI without scheme (if you want a file, add file://): " + urlStr);
+        throw MLDB::Exception("Cannot accept URI without scheme (if you want a file, add file://): " + urlStr);
     }
     /* absolute local filenames */
     else if (urlStr[0] == '/') {
@@ -172,7 +172,7 @@ std::string print(FileType type)
     case FT_DIR_INACCESSIBLE: return "DIR_INACCESSIBLE";
     case FT_FILE_INACCESSIBLE: return "FILE_INACCESSIBLE";
     default:
-        return ML::format("FileType(%d)", type);
+        return MLDB::format("FileType(%d)", type);
     }
 }
 
@@ -248,7 +248,7 @@ static void scanFiles(const std::string & path,
     if (res == -1) {
         if (errno == ENOENT)
             return;
-        throw ML::Exception(errno, "ftw");
+        throw MLDB::Exception(errno, "ftw");
     }
 }
 
@@ -267,7 +267,7 @@ struct LocalUrlFsHandler : public UrlFsHandler {
             if (errno == ENOENT) {
                 return FsObjectInfo();
             }
-            throw ML::Exception(errno, "stat");
+            throw MLDB::Exception(errno, "stat");
         }
 
         // TODO: owner ID (uid) and name (uname)
@@ -299,7 +299,7 @@ struct LocalUrlFsHandler : public UrlFsHandler {
         // code.
         fs::create_directories(path, ec);
         if (ec.value() != boost::system::errc::success) {
-            throw ML::Exception(ec.message());
+            throw MLDB::Exception(ec.message());
         }
     }
 
@@ -309,7 +309,7 @@ struct LocalUrlFsHandler : public UrlFsHandler {
         int res = ::unlink(path.c_str());
         if (res == -1) {
             if (throwException) {
-                throw ML::Exception(errno, "unlink");
+                throw MLDB::Exception(errno, "unlink");
             }
             else return false;
         }
@@ -322,12 +322,10 @@ struct LocalUrlFsHandler : public UrlFsHandler {
                          const std::string & delimiter,
                          const std::string & startAt) const
     {
-        using namespace ML;
-
         if (startAt != "")
-            throw ML::Exception("not implemented: startAt for local files");
+            throw MLDB::Exception("not implemented: startAt for local files");
         if (delimiter != "/")
-            throw ML::Exception("not implemented: delimiters other than '/' "
+            throw MLDB::Exception("not implemented: delimiters other than '/' "
                                 "for local files");
         
 
@@ -345,7 +343,7 @@ struct LocalUrlFsHandler : public UrlFsHandler {
                     -> UriHandler
                     {
                         if (!options.empty())
-                            throw ML::Exception("Options not accepted by S3");
+                            throw MLDB::Exception("Options not accepted by S3");
 
                         std::shared_ptr<std::istream> result(new filter_istream(filename, options));
                         return UriHandler(result->rdbuf(), std::move(result),
@@ -399,7 +397,7 @@ const UrlFsHandler * findFsHandler(const string & scheme)
     if (handler != registry.handlers.end())
         return handler->second.get();
     
-    throw ML::Exception("no handler found for scheme: " + scheme);
+    throw MLDB::Exception("no handler found for scheme: " + scheme);
 }
 
 
@@ -438,7 +436,7 @@ void registerUrlFsHandler(const std::string & scheme,
     auto& registry = getRegistry();
 
     if (registry.handlers.find(scheme) != registry.handlers.end()) {
-        throw ML::Exception("fs handler already registered");
+        throw MLDB::Exception("fs handler already registered");
     }
 
     /* this enables googleuri to parse our urls properly */
@@ -481,7 +479,7 @@ makeUriDirectory(const std::string & url)
     string dirUrl(url);
     size_t slashIdx = dirUrl.rfind('/');
     if (slashIdx == string::npos) {
-        throw ML::Exception("makeUriDirectory cannot work on filenames: instead of " + url + " you should probably write file://" + url);
+        throw MLDB::Exception("makeUriDirectory cannot work on filenames: instead of " + url + " you should probably write file://" + url);
     }
     dirUrl.resize(slashIdx);
 
@@ -549,7 +547,7 @@ checkWritability(const std::string & url, const std::string & parameterName)
     try {
         makeUriDirectory(url);
     } catch ( std::exception const& ex) {
-        throw ML::Exception(ML::format("Error when trying to create folder specified "
+        throw MLDB::Exception(MLDB::format("Error when trying to create folder specified "
                 "in parameter '%s'. Value: '%s'. Exception: %s",
                 parameterName, url, ex.what()));
     }
@@ -557,7 +555,7 @@ checkWritability(const std::string & url, const std::string & parameterName)
     try {
         filter_ostream writer(url);
     } catch (std::exception const& ex) {
-        throw ML::Exception(ML::format("Error when trying to write to file specified "
+        throw MLDB::Exception(MLDB::format("Error when trying to write to file specified "
                 "in parameter '%s'. Value: '%s'. Exception: %s",
                 parameterName, url, ex.what()));
     }

--- a/vfs/http_streambuf.cc
+++ b/vfs/http_streambuf.cc
@@ -103,7 +103,7 @@ struct HttpStreamingDownloadSource {
                 if (o.first == "http-set-cookie")
                     proxy.setCookie(o.second);
                 else if (o.first.find("http-") == 0)
-                    throw ML::Exception("Unknown HTTP stream parameter " + o.first + " = " + o.second);
+                    throw MLDB::Exception("Unknown HTTP stream parameter " + o.first + " = " + o.second);
             }
 
             reset();
@@ -265,7 +265,7 @@ struct HttpStreamingDownloadSource {
                     return;
 
                 if (resp.code() != 200) {
-                    throw ML::Exception("HTTP code %d reading %s\n\n%s",
+                    throw MLDB::Exception("HTTP code %d reading %s\n\n%s",
                                         resp.code(), urlStr.c_str(),
                                         string(errorBody, 0, 1024).c_str());
                 }
@@ -320,7 +320,7 @@ struct HttpUrlFsHandler: UrlFsHandler {
     {
         auto info = tryGetInfo(url);
         if (!info)
-            throw ML::Exception("Couldn't get URI info for " + url.toString());
+            throw MLDB::Exception("Couldn't get URI info for " + url.toString());
         return info;
     }
 
@@ -380,7 +380,7 @@ struct HttpUrlFsHandler: UrlFsHandler {
                  << " from HEAD" << endl;
         }
 
-        throw ML::Exception("Couldn't reach server to determine HEAD of '"
+        throw MLDB::Exception("Couldn't reach server to determine HEAD of '"
                             + url.toString() + "': HTTP code "
                             + (didGetHeader ? to_string(header.responseCode()) : string("(unknown)"))
                             + " " + resp.errorMessage());
@@ -410,7 +410,7 @@ struct HttpUrlFsHandler: UrlFsHandler {
 
     virtual bool erase(const Url & url, bool throwException) const
     {
-        throw ML::Exception("Http URIs don't support DELETE");
+        throw MLDB::Exception("Http URIs don't support DELETE");
     }
 
     /** For each object under the given prefix (object or subdirectory),
@@ -422,7 +422,7 @@ struct HttpUrlFsHandler: UrlFsHandler {
                          const std::string & delimiter,
                          const std::string & startAt) const
     {
-        throw ML::Exception("Http URIs don't support listing");
+        throw MLDB::Exception("Http URIs don't support listing");
     }
 };
 
@@ -439,7 +439,7 @@ struct RegisterHttpHandler {
     {
         string::size_type pos = resource.find('/');
         if (pos == string::npos)
-            throw ML::Exception("unable to find http bucket name in resource "
+            throw MLDB::Exception("unable to find http bucket name in resource "
                                 + resource);
         string bucket(resource, 0, pos);
 
@@ -450,9 +450,9 @@ struct RegisterHttpHandler {
             return UriHandler(buf.get(), buf, sb_info.second);
         }
         else if (mode == ios::out) {
-            throw ML::Exception("Can't currently upload files via HTTP/HTTPs");
+            throw MLDB::Exception("Can't currently upload files via HTTP/HTTPs");
         }
-        else throw ML::Exception("no way to create http handler for non in/out");
+        else throw MLDB::Exception("no way to create http handler for non in/out");
     }
     
     RegisterHttpHandler()

--- a/vfs/testing/filter_streams_test.cc
+++ b/vfs/testing/filter_streams_test.cc
@@ -59,9 +59,9 @@ void system(const std::string & command)
 {
     int res = ::system(command.c_str());
     if (res == -1)
-        throw ML::Exception(errno, "system(): system");
+        throw MLDB::Exception(errno, "system(): system");
     if (res != 0)
-        throw ML::Exception("command %s returned code %d",
+        throw MLDB::Exception("command %s returned code %d",
                             command.c_str(), res);
 }
 
@@ -413,7 +413,7 @@ struct ExceptionSource {
     std::streamsize write(const char_type* s, std::streamsize n)
     {
         if (throwType_ == ThrowType::ThrowOnWrite) {
-            throw ML::Exception("throwing when writing");
+            throw MLDB::Exception("throwing when writing");
         }
         return n;
     }
@@ -421,7 +421,7 @@ struct ExceptionSource {
     std::streamsize read(char_type* s, std::streamsize n)
     {
         if (throwType_ == ThrowType::ThrowOnRead) {
-            throw ML::Exception("throwing when reading");
+            throw MLDB::Exception("throwing when reading");
         }
         char randomdata[n];
         ::memcpy(s, randomdata, n);
@@ -506,7 +506,7 @@ BOOST_AUTO_TEST_CASE(test_filter_stream_exceptions_read)
         stream >> data;
     };
 
-    BOOST_CHECK_THROW(action(), ML::Exception);
+    BOOST_CHECK_THROW(action(), MLDB::Exception);
 }
 
 BOOST_AUTO_TEST_CASE(test_filter_stream_exceptions_write)
@@ -523,7 +523,7 @@ BOOST_AUTO_TEST_CASE(test_filter_stream_exceptions_write)
         }
     };
 
-    BOOST_CHECK_THROW(action(), ML::Exception);
+    BOOST_CHECK_THROW(action(), MLDB::Exception);
 }
 
 BOOST_AUTO_TEST_CASE(test_filter_stream_exceptions_close)

--- a/vfs_handlers/archive.cc
+++ b/vfs_handlers/archive.cc
@@ -119,7 +119,7 @@ bool iterateArchive(std::streambuf * archive,
           
                         while (r != ARCHIVE_EOF) {
                             if (r < ARCHIVE_OK)
-                                throw ML::Exception("Error extracting file");
+                                throw MLDB::Exception("Error extracting file");
                             stream.write(buff, size);
                             r = archive_read_data_block
                                 (a, (const void **)&buff,
@@ -156,7 +156,7 @@ struct ArchiveUrlFsHandler: UrlFsHandler {
     {
         auto info = tryGetInfo(url);
         if (!info)
-            throw ML::Exception("Couldn't get URI info for archive " + url.toString());
+            throw MLDB::Exception("Couldn't get URI info for archive " + url.toString());
         return info;
     }
 
@@ -164,12 +164,12 @@ struct ArchiveUrlFsHandler: UrlFsHandler {
     {
         Utf8String archiveSource(url.toDecodedString());
         if (!archiveSource.removePrefix("archive+"))
-            throw ML::Exception("archive URI '" + url.toString() + "' doesn't start with 'archive+' when getting object info");
+            throw MLDB::Exception("archive URI '" + url.toString() + "' doesn't start with 'archive+' when getting object info");
 
         // Look for a # to get the filename
         auto it = archiveSource.rfind('#');
         if (it == archiveSource.end())
-            throw ML::Exception("Extracting a file from an archive requires a # between archive URI and path within archive");
+            throw MLDB::Exception("Extracting a file from an archive requires a # between archive URI and path within archive");
 
         Utf8String archiveUri(archiveSource.begin(), it);
 
@@ -208,12 +208,12 @@ struct ArchiveUrlFsHandler: UrlFsHandler {
 
     virtual void makeDirectory(const Url & url) const
     {
-        throw ML::Exception("Archive URIs don't support creating directories");
+        throw MLDB::Exception("Archive URIs don't support creating directories");
     }
 
     virtual bool erase(const Url & url, bool throwException) const
     {
-        throw ML::Exception("Archive URIs don't support DELETE");
+        throw MLDB::Exception("Archive URIs don't support DELETE");
     }
 
     /** For each object under the given prefix (object or subdirectory),
@@ -227,7 +227,7 @@ struct ArchiveUrlFsHandler: UrlFsHandler {
     {
         Utf8String archiveSource(prefix.toString());
         if (!archiveSource.removePrefix("archive+"))
-            throw ML::Exception("archive URI '" + archiveSource.rawString() + "' doesn't start with 'archive+' when listing archive contents");
+            throw MLDB::Exception("archive URI '" + archiveSource.rawString() + "' doesn't start with 'archive+' when listing archive contents");
 
         filter_istream archiveStream(archiveSource.rawString());
 
@@ -257,7 +257,7 @@ struct RegisterArchiveHandler {
                       const OnUriHandlerException & onException)
     {
         if (mode != ios::in) {
-            throw ML::Exception("Only input is accepted for archives");
+            throw MLDB::Exception("Only input is accepted for archives");
         }
 
         Utf8String uri = scheme + "://" + resource;
@@ -266,7 +266,7 @@ struct RegisterArchiveHandler {
 
         Utf8String archiveSource = uri;
         if (!archiveSource.removePrefix("archive+"))
-            throw ML::Exception("archive URI '" + uri.rawString() + "' doesn't start with 'archive+' when opening archive member");
+            throw MLDB::Exception("archive URI '" + uri.rawString() + "' doesn't start with 'archive+' when opening archive member");
 
         //cerr << "archiveSource = " << archiveSource << endl;
 
@@ -278,7 +278,7 @@ struct RegisterArchiveHandler {
                 foundIt = it;
         
         if (foundIt == archiveSource.end())
-            throw ML::Exception("Extracting a file from an archive requires a # between archive URI and path within archive");
+            throw MLDB::Exception("Extracting a file from an archive requires a # between archive URI and path within archive");
 
         Utf8String archiveUri(archiveSource.begin(), foundIt);
 
@@ -310,7 +310,7 @@ struct RegisterArchiveHandler {
         forEachUriObject("archive+" + archiveUri.rawString(), onObject, {},
                          "/" /* delimiter */, "" /* startAt */);
         if (!result.buf)
-            throw ML::Exception("Couldn't find resource " + toExtractPath.rawString()
+            throw MLDB::Exception("Couldn't find resource " + toExtractPath.rawString()
                                 + " in archive " + archiveUri.rawString());
         
         return result;

--- a/vfs_handlers/docker.cc
+++ b/vfs_handlers/docker.cc
@@ -59,7 +59,7 @@ struct DockerUriComponents {
             repo = rt[0];
             tag = rt[1];
         }
-        else throw ML::Exception("didn't understand tag name");
+        else throw MLDB::Exception("didn't understand tag name");
 
         for (unsigned i = 3;  i < components.size();  ++i) {
             object += '/' + components[i];
@@ -101,7 +101,7 @@ struct DockerLayersUrlFsHandler: UrlFsHandler {
     {
         auto info = tryGetInfo(url);
         if (!info)
-            throw ML::Exception("Couldn't get URI info for docker " + url.toString());
+            throw MLDB::Exception("Couldn't get URI info for docker " + url.toString());
         return info;
     }
 
@@ -112,12 +112,12 @@ struct DockerLayersUrlFsHandler: UrlFsHandler {
 #if 0        
         Utf8String dockerSource(url.toString());
         if (!dockerSource.removePrefix("docker@"))
-            throw ML::Exception("docker doesn't start with docker@");
+            throw MLDB::Exception("docker doesn't start with docker@");
 
         // Look for a # to get the filename
         auto it = dockerSource.rfind('#');
         if (it == dockerSource.end())
-            throw ML::Exception("Extracting a file from an docker requires a # between docker URI and path within docker");
+            throw MLDB::Exception("Extracting a file from an docker requires a # between docker URI and path within docker");
 
         Utf8String dockerUri(dockerSource.begin(), it);
 
@@ -156,12 +156,12 @@ struct DockerLayersUrlFsHandler: UrlFsHandler {
 
     virtual void makeDirectory(const Url & url) const
     {
-        throw ML::Exception("Docker URIs don't support creating directories");
+        throw MLDB::Exception("Docker URIs don't support creating directories");
     }
 
     virtual bool erase(const Url & url, bool throwException) const
     {
-        throw ML::Exception("Docker URIs don't support DELETE");
+        throw MLDB::Exception("Docker URIs don't support DELETE");
     }
 
     /** For each object under the given prefix (object or subdirectory),
@@ -214,7 +214,7 @@ struct DockerLayersUrlFsHandler: UrlFsHandler {
             info->size = md["Size"].asUInt();
             info->lastModified = jsonDecode<Date>(md["created"]);
 
-            string uri = prefix.toString() + "/layer" + ML::format("%03d", layerNum);
+            string uri = prefix.toString() + "/layer" + MLDB::format("%03d", layerNum);
             string setCookie = resp4.getHeader("set-cookie");
             string directUri = "https://" + c.registry + "/v1/images/" + image + "/layer";
             info->objectMetadata["directUri"] = directUri;
@@ -257,7 +257,7 @@ struct DockerUrlFsHandler: UrlFsHandler {
     {
         auto info = tryGetInfo(url);
         if (!info)
-            throw ML::Exception("Couldn't get URI info for docker " + url.toString());
+            throw MLDB::Exception("Couldn't get URI info for docker " + url.toString());
         return info;
     }
 
@@ -265,12 +265,12 @@ struct DockerUrlFsHandler: UrlFsHandler {
     {
         Utf8String dockerSource(url.toDecodedString());
         if (!dockerSource.removePrefix("docker@"))
-            throw ML::Exception("docker doesn't start with docker@");
+            throw MLDB::Exception("docker doesn't start with docker@");
 
         // Look for a # to get the filename
         auto it = dockerSource.rfind('#');
         if (it == dockerSource.end())
-            throw ML::Exception("Extracting a file from an docker requires a # between docker URI and path within docker");
+            throw MLDB::Exception("Extracting a file from an docker requires a # between docker URI and path within docker");
 
         Utf8String dockerUri(dockerSource.begin(), it);
 
@@ -309,12 +309,12 @@ struct DockerUrlFsHandler: UrlFsHandler {
 
     virtual void makeDirectory(const Url & url) const
     {
-        throw ML::Exception("Docker URIs don't support creating directories");
+        throw MLDB::Exception("Docker URIs don't support creating directories");
     }
 
     virtual bool erase(const Url & url, bool throwException) const
     {
-        throw ML::Exception("Docker URIs don't support DELETE");
+        throw MLDB::Exception("Docker URIs don't support DELETE");
     }
 
     /** For each object under the given prefix (object or subdirectory),
@@ -422,7 +422,7 @@ struct RegisterDockerHandler {
                      const OnUriHandlerException & onException)
     {
         if (mode != ios::in) {
-            throw ML::Exception("Cannot write to docker containers, only read");
+            throw MLDB::Exception("Cannot write to docker containers, only read");
         }
 
         string uriToFind = scheme + "://" + resource;
@@ -451,7 +451,7 @@ struct RegisterDockerHandler {
         handler.forEach(Url(repoUri), onObject, nullptr, "", "");
 
         if (!result.buf)
-            throw ML::Exception("Couldn't find resource " + scheme + "://" + resource
+            throw MLDB::Exception("Couldn't find resource " + scheme + "://" + resource
                                 + " in docker repo");
         
         return result;

--- a/vfs_handlers/hdfs.cc
+++ b/vfs_handlers/hdfs.cc
@@ -77,7 +77,7 @@ HDFSSourceImpl(const string & urlStr, int mode)
 
     /* "hdfsExists" returns the opposite of what it means */
     if ((mode & O_WRONLY) == 0 && hdfsExists(fsHandle_, filename.c_str())) {
-        throw ML::Exception("file does not exist");
+        throw MLDB::Exception("file does not exist");
     }
 
     fileHandle_ = hdfsOpenFile(fsHandle_, filename.c_str(), mode, 0,
@@ -105,7 +105,7 @@ read(char * s, streamsize n)
         readRes = hdfsRead(fsHandle_, fileHandle_, s, n);
     }
     if (readRes == -1) {
-        throw ML::Exception(errno, "hdfsRead");
+        throw MLDB::Exception(errno, "hdfsRead");
     }
 
     return readRes > 0 ? readRes : -1;
@@ -119,7 +119,7 @@ write(const char* s, streamsize n)
 
     tSize writeRes = hdfsWrite(fsHandle_, fileHandle_, s, n);
     if (writeRes == -1) {
-        throw ML::Exception(errno, "hdfsWrite");
+        throw MLDB::Exception(errno, "hdfsWrite");
     }
 
     return writeRes;
@@ -252,7 +252,7 @@ struct RegisterHDFSHandler {
 
         string::size_type pos = scheme.find("hdfs://");
         if (pos != string::npos)
-            throw ML::Exception("malformed hdfs url");
+            throw MLDB::Exception("malformed hdfs url");
         string url = "hdfs://" + resource;
 
         if (mode == ios::in) {
@@ -264,7 +264,7 @@ struct RegisterHDFSHandler {
                                                                    131072);
         }
         else {
-            throw ML::Exception("no way to create HDFS handler for non in/out");
+            throw MLDB::Exception("no way to create HDFS handler for non in/out");
         }
         return make_pair(result, true);
     }

--- a/vfs_handlers/s3_handlers.cc
+++ b/vfs_handlers/s3_handlers.cc
@@ -85,7 +85,7 @@ struct S3UrlFsHandler : public UrlFsHandler {
                 OpenUriObject open = [=] (const std::map<std::string, std::string> & options) -> UriHandler
                 {
                     if (!options.empty())
-                        throw ML::Exception("Options not accepted by S3");
+                        throw MLDB::Exception("Options not accepted by S3");
 
                     std::shared_ptr<std::istream> result(new filter_istream(filename));
                     auto into = getInfo(Url(filename));
@@ -152,7 +152,7 @@ struct S3Downloader {
     {
         fileInfo = api->getObjectInfo(bucket, resource.substr(1));
         if (!fileInfo) {
-            throw ML::Exception("missing object: " + resource);
+            throw MLDB::Exception("missing object: " + resource);
         }
 
         if (endOffset == -1 || endOffset > fileInfo.size) {
@@ -195,7 +195,7 @@ struct S3Downloader {
     std::streamsize read(char * s, std::streamsize n)
     {
         if (closed) {
-            throw ML::Exception("invoking read() on a closed download");
+            throw MLDB::Exception("invoking read() on a closed download");
         }
 
         if (endOfDownload()) {
@@ -392,7 +392,7 @@ private:
             }
 
             if (response.code_ != 200 && response.code_ != 206) {
-                throw ML::Exception("http error "
+                throw MLDB::Exception("http error "
                                     + to_string(response.code_)
                                     + " while getting chunk "
                                     + response.bodyXmlStr());
@@ -403,7 +403,7 @@ private:
                and throw an appropriate exception. */
             string chunkEtag = response.getHeader("etag");
             if (chunkEtag != fileInfo.etag) {
-                throw ML::Exception("chunk etag '%s' differs from original"
+                throw MLDB::Exception("chunk etag '%s' differs from original"
                                     " etag '%s' of file '%s'",
                                     chunkEtag.c_str(), fileInfo.etag.c_str(),
                                     resource.c_str());
@@ -646,7 +646,7 @@ struct S3Uploader {
 
         activeRqs++;
         api->putAsync(onResponse, bucket, resource,
-                      ML::format("partNumber=%d&uploadId=%s",
+                      MLDB::format("partNumber=%d&uploadId=%s",
                                  partNumber, uploadId),
                       {}, {}, current);
 
@@ -668,7 +668,7 @@ struct S3Uploader {
 
             if (response.code_ != 200) {
                 cerr << response.bodyXmlStr() << endl;
-                throw ML::Exception("put didn't work: %d", (int)response.code_);
+                throw MLDB::Exception("put didn't work: %d", (int)response.code_);
             }
 
             string etag = response.getHeader("etag");
@@ -807,7 +807,7 @@ struct RegisterS3Handler {
     {
         string::size_type pos = resource.find('/');
         if (pos == string::npos)
-            throw ML::Exception("unable to find s3 bucket name in resource "
+            throw MLDB::Exception("unable to find s3 bucket name in resource "
                                 + resource);
         string bucket(resource, 0, pos);
 
@@ -831,7 +831,7 @@ struct RegisterS3Handler {
                         md.redundancy = S3Api::REDUNDANCY_STANDARD;
                     else if (value == "REDUCED")
                         md.redundancy = S3Api::REDUNDANCY_REDUCED;
-                    else throw ML::Exception("unknown redundancy value " + value
+                    else throw MLDB::Exception("unknown redundancy value " + value
                                              + " writing S3 object " + resource);
                 }
                 else if (name == "contentType" || name == "aws-contentType") {
@@ -848,7 +848,7 @@ struct RegisterS3Handler {
                     // do nothing
                 }
                 else if (name.find("aws-") == 0) {
-                    throw ML::Exception("unknown aws option " + name + "=" + value
+                    throw MLDB::Exception("unknown aws option " + name + "=" + value
                                         + " opening S3 object " + resource);
                 }
                 else if(name == "num-threads")
@@ -871,7 +871,7 @@ struct RegisterS3Handler {
                 (makeStreamingUpload("s3://" + resource, onException, md).release());
             return UriHandler(buf.get(), buf);
         }
-        else throw ML::Exception("no way to create s3 handler for non in/out");
+        else throw MLDB::Exception("no way to create s3 handler for non in/out");
     }
 
     RegisterS3Handler()

--- a/vfs_handlers/s3_multipart_cmd.cc
+++ b/vfs_handlers/s3_multipart_cmd.cc
@@ -21,7 +21,6 @@ namespace po = boost::program_options;
 
 using namespace std;
 using namespace MLDB;
-using namespace ML;
 
 int main(int argc, char* argv[])
 {

--- a/vfs_handlers/s3cat.cc
+++ b/vfs_handlers/s3cat.cc
@@ -23,7 +23,6 @@ namespace po = boost::program_options;
 
 using namespace std;
 using namespace MLDB;
-using namespace ML;
 
 int main(int argc, char* argv[])
 {
@@ -104,7 +103,7 @@ int main(int argc, char* argv[])
                 if (res == -1 && errno == EINTR)
                     continue;
                 if (res == -1)
-                    throw ML::Exception(errno, "read");
+                    throw MLDB::Exception(errno, "read");
                 for (unsigned s = 0;  s < outStreams.size();  ++s) {
                     if (outputFiles[s] == "-") {
                         //res = write(0, buf, bufSize);

--- a/vfs_handlers/s3cp.cc
+++ b/vfs_handlers/s3cp.cc
@@ -20,7 +20,6 @@ namespace po = boost::program_options;
 
 using namespace std;
 using namespace MLDB;
-using namespace ML;
 
 int main(int argc, char* argv[])
 {

--- a/vfs_handlers/s3tee.cc
+++ b/vfs_handlers/s3tee.cc
@@ -23,7 +23,6 @@ namespace po = boost::program_options;
 
 using namespace std;
 using namespace MLDB;
-using namespace ML;
 
 int main(int argc, char* argv[])
 {
@@ -92,7 +91,7 @@ int main(int argc, char* argv[])
         if (res == -1 && errno == EINTR)
             continue;
         if (res == -1)
-            throw ML::Exception(errno, "read");
+            throw MLDB::Exception(errno, "read");
         for (unsigned s = 0;  s < streams.size();  ++s)
             streams[s].write(buf, res);
         streams[0] << std::flush;

--- a/vfs_handlers/sftp.cc
+++ b/vfs_handlers/sftp.cc
@@ -31,7 +31,6 @@
 
 
 using namespace std;
-using namespace ML;
 
 
 namespace MLDB {
@@ -70,7 +69,7 @@ connect(const std::string & hostname,
 
     int res = getaddrinfo(hostname.c_str(), port.c_str(), &hints, &result);
     if (res != 0)
-        throw ML::Exception("getaddrinfo: %s", gai_strerror(res));
+        throw MLDB::Exception("getaddrinfo: %s", gai_strerror(res));
 
     cerr << "res = " << res << endl;
     cerr << "result = " << result << endl;
@@ -104,7 +103,7 @@ connect(const std::string & hostname,
     }
         
     if (!rp)
-        throw ML::Exception("couldn't connect anywhere");
+        throw MLDB::Exception("couldn't connect anywhere");
         
     freeaddrinfo(result);           /* No longer needed */
 }
@@ -145,7 +144,7 @@ connect(const std::string & hostname,
     session = libssh2_session_init();
 
     if(!session)
-        throw ML::Exception("couldn't get libssh2 session");
+        throw MLDB::Exception("couldn't get libssh2 session");
  
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
@@ -153,7 +152,7 @@ connect(const std::string & hostname,
     int rc = libssh2_session_handshake(session, sock);
 
     if(rc) {
-        throw ML::Exception("error establishing session");
+        throw MLDB::Exception("error establishing session");
     }
  
     /* At this point we havn't yet authenticated.  The first thing to do
@@ -181,7 +180,7 @@ passwordAuth(const std::string & username,
                                   username.c_str(),
                                   password.c_str())) {
 
-        throw ML::Exception("password authentication failed: " + lastError());
+        throw MLDB::Exception("password authentication failed: " + lastError());
     }
 }
 
@@ -196,7 +195,7 @@ publicKeyAuth(const std::string & username,
                                             publicKeyFile.c_str(),
                                             privateKeyFile.c_str(),
                                             "")) {
-        throw ML::Exception("public key authentication failed: " + lastError());
+        throw MLDB::Exception("public key authentication failed: " + lastError());
     }
 }
  
@@ -360,7 +359,7 @@ getAttr() const
     Attributes result;
     int res = libssh2_sftp_fstat_ex(handle, &result, 0);
     if (res == -1)
-        throw ML::Exception("getAttr(): " + owner->lastError());
+        throw MLDB::Exception("getAttr(): " + owner->lastError());
     return result;
 }
 
@@ -390,7 +389,7 @@ downloadTo(const std::string & filename) const
         ssize_t numRead = libssh2_sftp_read(handle, buf, bufSize);
         //cerr << "read " << numRead << " bytes" << endl;
         if (numRead < 0) {
-            throw ML::Exception("read(): " + owner->lastError());
+            throw MLDB::Exception("read(): " + owner->lastError());
         }
         if (numRead == 0) break;
 
@@ -443,7 +442,7 @@ connectPasswordAuth(const std::string & hostname,
     sftp_session = libssh2_sftp_init(session);
  
     if (!sftp_session) {
-        throw ML::Exception("can't initialize SFTP session: "
+        throw MLDB::Exception("can't initialize SFTP session: "
                             + lastError());
     }
 
@@ -463,7 +462,7 @@ connectPublicKeyAuth(const std::string & hostname,
     sftp_session = libssh2_sftp_init(session);
  
     if (!sftp_session) {
-        throw ML::Exception("can't initialize SFTP session: "
+        throw MLDB::Exception("can't initialize SFTP session: "
                             + lastError());
     }
 
@@ -477,7 +476,7 @@ getDirectory(const std::string & path) const
         = libssh2_sftp_opendir(sftp_session, path.c_str());
         
     if (!handle) {
-        throw ML::Exception("couldn't open path: " + lastError());
+        throw MLDB::Exception("couldn't open path: " + lastError());
     }
 
     return Directory(path, handle, this);
@@ -493,7 +492,7 @@ openFile(const std::string & path)
                                LIBSSH2_SFTP_OPENFILE);
         
     if (!handle) {
-        throw ML::Exception("couldn't open path: " + lastError());
+        throw MLDB::Exception("couldn't open path: " + lastError());
     }
 
     return File(path, handle, this);
@@ -536,7 +535,7 @@ uploadFile(const char * start,
                           LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IROTH);
     
     if (!handle) {
-        throw ML::Exception("couldn't open path: " + lastError());
+        throw MLDB::Exception("couldn't open path: " + lastError());
     }
 
     Date started = Date::now();
@@ -555,7 +554,7 @@ uploadFile(const char * start,
                                         toSend);
         
         if (rc == -1)
-            throw ML::Exception("couldn't upload file: " + lastError());
+            throw MLDB::Exception("couldn't upload file: " + lastError());
 
         offset += rc;
         
@@ -571,7 +570,7 @@ uploadFile(const char * start,
             double elapsedSince = now.secondsSince(lastTime);
             double mbSecInst = (offset - lastPrint) / mb / elapsedSince;
 
-            cerr << ML::format("done %.2fMB of %.2fMB (%.2f%%) at %.2fMB/sec inst and %.2fMB/sec overall",
+            cerr << MLDB::format("done %.2fMB of %.2fMB (%.2f%%) at %.2fMB/sec inst and %.2fMB/sec overall",
                                doneMb, totalMb,
                                100.0 * doneMb / totalMb,
                                mbSecInst,
@@ -647,7 +646,7 @@ struct SftpStreamingDownloadSource {
                                        LIBSSH2_SFTP_OPENFILE);
             
             if (!handle) {
-                throw ML::Exception("couldn't open path: "
+                throw MLDB::Exception("couldn't open path: "
                                     + owner->lastError());
             }
         }
@@ -663,7 +662,7 @@ struct SftpStreamingDownloadSource {
 
             ssize_t numRead = libssh2_sftp_read(handle, s, n);
             if (numRead < 0) {
-                throw ML::Exception("read(): " + owner->lastError());
+                throw MLDB::Exception("read(): " + owner->lastError());
             }
             
             return numRead;
@@ -750,7 +749,7 @@ struct SftpStreamingUploadSource {
             
             if (!handle) {
                 onException();
-                throw ML::Exception("couldn't open path: " + owner->lastError());
+                throw MLDB::Exception("couldn't open path: " + owner->lastError());
             }
 
             startDate = Date::now();
@@ -771,7 +770,7 @@ struct SftpStreamingUploadSource {
             
                 if (rc == -1) {
                     onException();
-                    throw ML::Exception("couldn't upload file: " + owner->lastError());
+                    throw MLDB::Exception("couldn't upload file: " + owner->lastError());
                 }
             
                 offset += rc;
@@ -788,7 +787,7 @@ struct SftpStreamingUploadSource {
                     double elapsedSince = now.secondsSince(lastTime);
                     double mbSecInst = (offset - lastPrint) / mb / elapsedSince;
                 
-                    cerr << ML::format("done %.2fMB at %.2fMB/sec inst and %.2fMB/sec overall",
+                    cerr << MLDB::format("done %.2fMB at %.2fMB/sec inst and %.2fMB/sec overall",
                                        doneMb, 
                                        mbSecInst,
                                        mbSecOverall)
@@ -965,7 +964,7 @@ struct RegisterSftpHandler {
     {
         string::size_type pos = resource.find('/');
         if (pos == string::npos)
-            throw ML::Exception("unable to find sftp host name in resource "
+            throw MLDB::Exception("unable to find sftp host name in resource "
                                 + resource);
         string connStr(resource, 0, pos);
 
@@ -977,7 +976,7 @@ struct RegisterSftpHandler {
 
             SftpConnection::Attributes attr;
             if (!connection.getAttributes(path, attr)) {
-                throw ML::Exception("Couldn't read attributes for sftp "
+                throw MLDB::Exception("Couldn't read attributes for sftp "
                                     "resource");
             }
 
@@ -995,7 +994,7 @@ struct RegisterSftpHandler {
                  .release());
             return UriHandler(buf.get(), buf);
         }
-        throw ML::Exception("no way to create sftp handler for non in/out");
+        throw MLDB::Exception("no way to create sftp handler for non in/out");
     }
 
     RegisterSftpHandler()
@@ -1041,7 +1040,7 @@ string connStrFromUri(const string & uri) {
     ExcAssert(uri.find("sftp://") == 0);
     const auto pos = uri.find("/", 7);
     if (pos == string::npos) {
-        throw ML::Exception("Couldn't find sftp hostname in %s", uri.c_str());
+        throw MLDB::Exception("Couldn't find sftp hostname in %s", uri.c_str());
     }
     return uri.substr(7, pos - 7);
 };
@@ -1070,7 +1069,7 @@ struct SftpUrlFsHandler : public UrlFsHandler {
             const auto handler = getUriHandler(url);
             return std::move(*(handler.info.get()));
         }
-        catch (const ML::Exception & exc) {
+        catch (const MLDB::Exception & exc) {
         }
         return FsObjectInfo();
     }
@@ -1122,7 +1121,7 @@ struct SftpUrlFsHandler : public UrlFsHandler {
                     OpenUriObject open = [=] (const std::map<std::string, std::string> & options) -> UriHandler
                     {
                         if (!options.empty()) {
-                            throw ML::Exception("Options not accepted by S3");
+                            throw MLDB::Exception("Options not accepted by S3");
                         }
 
                         std::shared_ptr<std::istream> result(

--- a/vfs_handlers/sftp.h
+++ b/vfs_handlers/sftp.h
@@ -175,10 +175,10 @@ struct SftpConnection : public SshConnection {
     and you can open it directly from s3 using the sftp:// syntax.
 */
 
-class HostAlreadyRegistered : public ML::Exception {
+class HostAlreadyRegistered : public MLDB::Exception {
 public:
     HostAlreadyRegistered(const std::string & bucketName) : 
-        ML::Exception("sftp host %s already registered",
+        MLDB::Exception("sftp host %s already registered",
                       bucketName.c_str())
     {
     }

--- a/watch/watch.cc
+++ b/watch/watch.cc
@@ -79,7 +79,7 @@ void
 AllOutputDescription::
 parseJsonTyped(AllOutput * val, JsonParsingContext & context) const
 {
-    throw ML::Exception("AllOutputDescription::parseJsonTyped(): not impl");
+    throw MLDB::Exception("AllOutputDescription::parseJsonTyped(): not impl");
 }
 
 void
@@ -87,7 +87,7 @@ AllOutputDescription::
 printJsonTyped(const AllOutput * val,
                JsonPrintingContext & context) const
 {
-    throw ML::Exception("AllOutputDescription::printJsonTyped(): not impl");
+    throw MLDB::Exception("AllOutputDescription::printJsonTyped(): not impl");
 }
 
 ValueDescriptionT<AllOutput> *
@@ -203,7 +203,7 @@ waitGeneric(double timeToWait)
     std::tie(found, res) = tryWaitGeneric(timeToWait);
 
     if (!found)
-        throw ML::Exception("No event found before timeout");
+        throw MLDB::Exception("No event found before timeout");
         
     return res;
 }
@@ -311,7 +311,7 @@ UnknownTypeWatchData::
 tryWaitMaybeGeneric(double timeToWait)
 {
     if (boundFn)
-        throw ML::Exception("cannot wait on a bound watch");
+        throw MLDB::Exception("cannot wait on a bound watch");
 
     Date limit = Date::now().plusSeconds(timeToWait);
         
@@ -619,7 +619,7 @@ throwException(WatchErrorKind kind, const char * msg, ...) const
     va_list ap;
     va_start(ap, msg);
     try {
-        std::string message = ML::vformat(msg, ap);
+        std::string message = vformat(msg, ap);
         va_end(ap);
         WatchError error(kind, message);
         throw WatchException(std::move(error));
@@ -705,16 +705,16 @@ bindType(std::shared_ptr<const ValueDescription> boundDesc,
     std::unique_lock<std::mutex> guard(mutex);
 
     if (this->boundType_ || this->boundValueDescription_)
-        throw ML::Exception("Watches already have a bound type");
+        throw MLDB::Exception("Watches already have a bound type");
 
     this->boundValueDescription_ = std::move(boundDesc);
     this->boundType_ = boundType;
     if (!boundType_ && boundValueDescription_)
         boundType_ = boundValueDescription_->type;
 
-    std::string typeName = ML::demangle(*boundType_);
+    std::string typeName = demangle(*boundType_);
     if (typeName.find("std::tuple<") != 0)
-        throw ML::Exception("Watches must always be bound to a tuple type: '%s'",
+        throw MLDB::Exception("Watches must always be bound to a tuple type: '%s'",
                             typeName.c_str());
 }
 
@@ -737,7 +737,7 @@ Watches::
 releaseWatchWithData(WatchData * data)
 {
     if (!data)
-        throw ML::Exception("can't release null data");
+        throw MLDB::Exception("can't release null data");
 
     if (data->holder)
         data->holder->data = nullptr;
@@ -758,7 +758,7 @@ releaseWatchWithData(WatchData * data)
         }
     }
         
-    throw ML::Exception("Watch %p not found in watch set when releasing",
+    throw MLDB::Exception("Watch %p not found in watch set when releasing",
                         data);
 }
 
@@ -789,7 +789,7 @@ throwException(WatchErrorKind kind, const char * msg, ...) const
     va_list ap;
     va_start(ap, msg);
     try {
-        std::string message = ML::vformat(msg, ap);
+        std::string message = vformat(msg, ap);
         va_end(ap);
         WatchError error(kind, message);
         throw WatchException(std::move(error));

--- a/watch/watch.h
+++ b/watch/watch.h
@@ -345,8 +345,8 @@ struct Watches {
             throwException(WATCH_ERR_TYPE,
                            "attempt to trigger watch bound to type '%s' "
                            "with parameters of type '%s'",
-                           ML::demangle(*boundType()).c_str(),
-                           ML::type_name<std::tuple<T...> >().c_str());
+                           demangle(*boundType()).c_str(),
+                           MLDB::type_name<std::tuple<T...> >().c_str());
         }
 
         return this->triggerGeneric(Any(std::move(tupl)));
@@ -939,8 +939,8 @@ struct UnpackToTuple {
         } catch (const std::exception & exc) {
             using namespace std;
             cerr << "trying to unpack element " << start << " of tuple "
-                 << "with type " << ML::demangle(vec[start].type())
-                 << " to type " << ML::type_name<elType>()
+                 << "with type " << demangle(vec[start].type())
+                 << " to type " << MLDB::type_name<elType>()
                  << endl;
             throw;
         }
@@ -956,8 +956,8 @@ struct UnpackToTuple {
         } catch (const std::exception & exc) {
             using namespace std;
             cerr << "trying to unpack element " << start << " of tuple "
-                 << "with type " << ML::demangle(vec[start].type())
-                 << " to type " << ML::type_name<elType>()
+                 << "with type " << demangle(vec[start].type())
+                 << " to type " << MLDB::type_name<elType>()
                  << endl;
             throw;
         }
@@ -1014,8 +1014,8 @@ tryWaitTuple(double timeToWait)
     if (boundType() && boundType() != &typeid(std::tuple<T...>))
         throwException(WATCH_ERR_TYPE,
                        "waiting for %s but got %s",
-                       ML::demangle(*boundType()).c_str(),
-                       ML::type_name<std::tuple<T...> >().c_str());
+                       demangle(*boundType()).c_str(),
+                       MLDB::type_name<std::tuple<T...> >().c_str());
 
     
 

--- a/watch/watch_impl.h
+++ b/watch/watch_impl.h
@@ -422,8 +422,8 @@ operator = (Watch && other)
         && other.boundType() != &typeid(std::tuple<T...>))
         throwException(WATCH_ERR_TYPE,
                        "Attempt to bind watch of type '%s' from watch of type '%s'",
-                       ML::type_name<std::tuple<T...> >().c_str(),
-                       ML::demangle(*other.boundType()).c_str());
+                       MLDB::type_name<std::tuple<T...> >().c_str(),
+                       demangle(*other.boundType()).c_str());
 
 
     if (other.data)
@@ -525,8 +525,8 @@ waitTuple(double timeToWait)
     if (&a.type() != &typeid(std::tuple<T...>))
         throwException(WATCH_ERR_TYPE,
                        "waiting for %s but got %s",
-                       ML::type_name<std::tuple<T...> >().c_str(),
-                       ML::demangle(a.type().name()).c_str());
+                       MLDB::type_name<std::tuple<T...> >().c_str(),
+                       demangle(a.type().name()).c_str());
         
     return a.as<std::tuple<T...> >();
 }


### PR DESCRIPTION
Entirely removes namespace ML from the API headers, by moving a bunch of code into namespace MLDB.  Also renames some of the ML types to better reflect the conventions in MLDB.

Much of the work was done with the following commands:

```
 2862  jml/src_tools/ident_replace_all.sh Parse_Context ParseContext
 2864  jml/src_tools/ident_replace_all.sh ML::Exception MLDB::Exception
 2865  jml/src_tools/ident_replace_all.sh ML::ParseContext ParseContext
 2869  jml/src_tools/ident_replace_all.sh ML::format MLDB::format
 2871  jml/src_tools/ident_replace_all.sh ML::demangle demangle
 2873  jml/src_tools/ident_replace_all.sh ML::Assertion_Failure Assertion_Failure
 2874  jml/src_tools/ident_replace_all.sh Assertion_Failure AssertionFailure
 2878  jml/src_tools/ident_replace_all.sh ML::forwardForPrintf forwardForPrintf
 2880  jml/src_tools/ident_replace_all.sh ML::type_name MLDB::type_name
 2883  jml/src_tools/ident_replace_all.sh ML::getExceptionString getExceptionString
 2885  jml/src_tools/ident_replace_all.sh ML::vformat vformat
 2887  jml/src_tools/ident_replace_all.sh ML::Lightweight_Hash Lightweight_Hash
 2889  jml/src_tools/ident_replace_all.sh ML::Timer Timer
 2891  jml/src_tools/ident_replace_all.sh Env_Option EnvOption
 2892  jml/src_tools/ident_replace_all.sh ML::Env_Option EnvOption
 2893  jml/src_tools/ident_replace_all.sh ML::EnvOption EnvOption
 2908  jml/src_tools/ident_replace_all.sh ML::Spinlock Spinlock
 2921  jml/src_tools/ident_replace_all.sh ML::distribution distribution
```

Should be merged pretty quickly, as it's the kind of patch that conflicts with everything and gets stale immediately.