### PR TITLE
Fix some clang build errors

### DIFF
--- a/ml/algebra/least_squares.h
+++ b/ml/algebra/least_squares.h
@@ -17,6 +17,7 @@
 #include <iostream>
 #include "mldb/jml/db/persistent.h"
 #include "mldb/jml/utils/enum_info.h"
+#include "matrix_ops.h"
 
 namespace ML {
 

--- a/sql/expression_value_conversions.cc
+++ b/sql/expression_value_conversions.cc
@@ -865,7 +865,7 @@ uint64_t storageBufferBytes(const DimsVector & size, StorageType storage)
     size_t sz = 1;
     for (auto & s: size)
         sz *= s;
-    return storageBufferBytes(size, storage);
+    return storageBufferBytes(sz, storage);
 }
 
 void * addOfs(void * p, ssize_t n)


### PR DESCRIPTION
Remaining error with... TF.
```
./mldb/ext/tensorflow/tensorflow/cc/framework/scope.cc:25:8: error: constructor for 'tensorflow::Scope' must explicitly initialize the const member 'colocation_constraints_'
Scope::Scope(Graph* graph, Status* status, Scope::NameMap* name_map)
       ^
mldb/ext/tensorflow/tensorflow/cc/framework/scope.h:245:36: note: 'colocation_constraints_' declared here
  const std::unordered_set<string> colocation_constraints_;
```