### PR TITLE
Removed boost_thread as dependency (MLDB-2029)

### DIFF
--- a/base/base.mk
+++ b/base/base.mk
@@ -7,7 +7,7 @@ LIBBASE_SOURCES := \
 	parallel.cc \
 	optimized_path.cc
 
-LIBBASE_LINK :=	arch boost_thread gc
+LIBBASE_LINK :=	arch gc
 
 $(eval $(call library,base,$(LIBBASE_SOURCES),$(LIBBASE_LINK)))
 

--- a/mldb_base/docker_create_mldb_base.sh
+++ b/mldb_base/docker_create_mldb_base.sh
@@ -70,7 +70,6 @@ apt-get install -y \
     libboost-serialization1.54.0 \
     libboost-program-options1.54.0 \
     libboost-system1.54.0 \
-    libboost-thread1.54.0 \
     libboost-regex1.54.0 \
     libboost-locale1.54.0 \
     libboost-date-time1.54.0 \


### PR DESCRIPTION
... it's not needed anymore (we use the standard library)