### PR TITLE
Added JSONTestSuite tests (MLDB-2032)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "ext/pffft"]
 	path = ext/pffft
 	url = https://github.com/mldbai/pffft.git
+[submodule "ext/JSONTestSuite"]
+	path = ext/JSONTestSuite
+	url = https://github.com/mldbai/JSONTestSuite.git

--- a/testing/run_json_test_suite.cc
+++ b/testing/run_json_test_suite.cc
@@ -1,0 +1,133 @@
+/** run_json_test_suite.cc
+    Jeremy Barnes, 26 October 2016
+    Copyright (c) 2016 Datacratic Inc.  All rights reserved.
+    
+    Run the JSON test suite.
+*/
+
+#include "mldb/types/json_parsing.h"
+#include "mldb/types/json_printing.h"
+#include "mldb/ext/jsoncpp/json.h"
+#include "mldb/vfs/fs_utils.h"
+#include "mldb/vfs/filter_streams.h"
+#include "mldb/arch/exception.h"
+#include <sstream>
+#include <set>
+#include <glob.h>
+
+using namespace std;
+using namespace MLDB;
+
+size_t expectedPasses = 0;
+size_t unexpectedPasses = 0;
+size_t expectedFailures = 0;
+size_t unexpectedFailures = 0;
+size_t optionalPasses = 0;
+size_t optionalFailures = 0;
+size_t reserializationErrors = 0;
+
+// These are invalid tests (they say they should be supported but include byte
+// order marks which don't have to be supported according to JSON).
+std::set<std::string> skippedTests = { "y_string_utf16.json" };
+
+void testFile(const std::string & filename)
+{
+    std::ostringstream str;
+    filter_istream stream(filename);
+    
+    str << stream.rdbuf();
+
+    auto pos = filename.rfind('/');
+    string rest(filename, pos + 1);
+
+    if (skippedTests.count(rest))
+        return;
+
+    char test = rest.at(0);
+    cerr << "test " << rest << endl;
+
+    Json::Value val, other;
+
+    if (test == 'y') {
+        try {
+            StringJsonParsingContext context(str.str());
+            val = context.expectJson();
+            context.expectEof();
+            other = Json::parse(str.str());
+            ++expectedPasses;
+        } catch (const std::exception & exc) {
+            cerr << "BAD FAILURE " << exc.what() << endl;
+            ++unexpectedFailures;
+            cerr << "<<<<<<<<<<<<<<<<<<<" << endl;
+            cerr << str.str() << endl;
+            cerr << "<<<<<<<<<<<<<<<<<<<" << endl;
+        }
+    }
+    else if (test == 'n') {
+        try {
+            MLDB_TRACE_EXCEPTIONS(false);
+            StringJsonParsingContext context(str.str());
+            val = context.expectJson();
+            context.expectEof();
+            cerr << "SHOULD HAVE FAILED" << endl;
+            ++unexpectedPasses;
+        } catch (const std::exception & exc) {
+            ++expectedFailures;
+        }
+    }
+    else if (test == 'i') {
+        try {
+            MLDB_TRACE_EXCEPTIONS(false);
+            StringJsonParsingContext context(str.str());
+            val = context.expectJson();
+            context.expectEof();
+            cerr << "OPTIONAL PASSED" << endl;
+            ++optionalPasses;
+        } catch (const std::exception & exc) {
+            cerr << "OPTIONAL FAILURE" << endl;
+            ++optionalFailures;
+        }
+    }
+
+    if (!val.isNull()) {
+        Utf8String str;
+        Utf8StringJsonPrintingContext context(str);
+        context.writeJson(val);
+        
+        StringJsonParsingContext context2(str.rawString());
+        auto val2 = context2.expectJson();
+
+        if (val != val2 && val.toString() != val2.toString()) {
+            cerr << "Invalid JSON serialization/reserialization" << endl;
+            cerr << "val: " << val << endl;
+            cerr << "val2: " << val2 << endl;
+            ++reserializationErrors;
+        }
+    }
+}
+
+int main(int argc, char ** argv)
+{
+    auto onFile = [&] (const std::string & uri,
+                       const FsObjectInfo & info,
+                       const OpenUriObject & open,
+                       int depth)
+        -> bool
+        {
+            testFile(uri);
+            return true;
+        };
+    
+    forEachUriObject("mldb/ext/JSONTestSuite/test_parsing",
+                     onFile);
+
+    cerr << "y tests: passed " << expectedPasses << " failed "
+         << unexpectedFailures << endl;
+    cerr << "n tests: passed " << unexpectedPasses << " failed "
+         << expectedFailures << endl;
+    cerr << "i tests: passed " << optionalPasses << " failed "
+         << optionalFailures << endl;
+    cerr << "reserialization errors: " << reserializationErrors << endl;
+    
+    return unexpectedFailures || reserializationErrors ? 1 : 0;
+}

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -16,6 +16,7 @@ $(eval $(call include_sub_make,cookbook))
 
 $(eval $(call library,mldb_test_function,test_function.cc,mldb mldb_builtin_plugins))
 
+$(eval $(call test,run_json_test_suite,types vfs,normal))
 
 $(eval $(call mldb_unit_test,MLDBFB-336-sample_test.py,,manual))
 
@@ -447,3 +448,4 @@ $(eval $(call mldb_unit_test,union_dataset_test.py))
 $(eval $(call mldb_unit_test,deepteach_test.py,tensorflow,manual))
 $(eval $(call mldb_unit_test,post_run_and_track_procedure_test.py))
 $(eval $(call mldb_unit_test,MLDB-2022-multiple-prediction-example.js))
+

--- a/types/json_parsing.h
+++ b/types/json_parsing.h
@@ -208,7 +208,7 @@ struct JsonParsingContext {
 
     /// Format an exception with the current context within the object so that
     /// a reasonable error message can be provided to the user.
-    virtual void exception(const std::string & message) = 0;
+    virtual void exception(const std::string & message) const = 0;
 
     /** Return a string that gives the context of where the parsing is
         at, for example line number and column.
@@ -349,6 +349,13 @@ struct JsonParsingContext {
     /// The current array element number can be obtained by counting or
     /// by asking for path.back().index.
     virtual void forEachElement(const std::function<void ()> & fn) = 0;
+
+    /// Is it at the EOF?
+    virtual bool eof() const = 0;
+
+    /// Expect that we are at an EOF position, or throw an exception if not.
+    /// Default uses eof() and exception().
+    virtual void expectEof() const;
 };
 
 
@@ -524,7 +531,7 @@ struct StreamingJsonParsingContext
 
     virtual bool isNull() const;
 
-    virtual void exception(const std::string & message);
+    virtual void exception(const std::string & message) const;
 
     virtual std::string getContext() const;
 
@@ -533,6 +540,8 @@ struct StreamingJsonParsingContext
     virtual std::string printCurrent();
 
     void expectJsonObjectUtf8(const std::function<void (const char *, size_t)> & onEntry);
+
+    virtual bool eof() const;
 };
 
 
@@ -550,7 +559,7 @@ struct StructuredJsonParsingContext: public JsonParsingContext {
     const Json::Value * current;
     const Json::Value * top;
 
-    virtual void exception(const std::string & message);
+    virtual void exception(const std::string & message) const;
     
     virtual std::string getContext() const;
 
@@ -613,6 +622,8 @@ struct StructuredJsonParsingContext: public JsonParsingContext {
     virtual void forEachElement(const std::function<void ()> & fn);
 
     virtual std::string printCurrent();
+
+    virtual bool eof() const;
 };
 
 


### PR DESCRIPTION
This adds a large JSON test suite, and fixes the handling of UTF-16 surrogate pairs (which are the way that characters out of the basic multilingual plane are handled).  It also makes handling of extremely large numbers more robust (if they are too big for a long, they become a double, and if they are too big for a double, they become infinity rather than crashing as before).

The test failure is spurious.
