### PR TITLE
Mldb 2040 pipeline join refactor

### DIFF
--- a/sql/execution_pipeline_impl.cc
+++ b/sql/execution_pipeline_impl.cc
@@ -901,6 +901,12 @@ bind() const
 
 /*****************************************************************************/
 /* CROSS JOIN EXECUTOR                                                       */
+/* We cannot output a row as an outer row until its been tested against      */
+/* every single other row it could match with.                               */
+/* For left or right cross joins, we choose the proper side to loop          */
+/* on first to be efficient                                                  */
+/* (for example if its a right join, we loop on right first).                */
+/* This way we avoid having to cache all rows.                               */
 /*****************************************************************************/
     
 JoinElement::CrossJoinExecutor::
@@ -993,7 +999,7 @@ take()
 
                 return result;
             }
-	        wasOutput = false;
+            wasOutput = false;
             l = this->left->take();
         }
 
@@ -1004,8 +1010,8 @@ take()
         ExpressionValue lEmbedding = l->values.back();
         ExpressionValue rEmbedding = r->values.back();
 
-	    auto result = l;
-	    if (scanLeftFirst)
+        auto result = l;
+        if (scanLeftFirst)
             result = make_shared<PipelineResults>(*l);	
 
         // Pop the selected join condition from l
@@ -1050,6 +1056,8 @@ restart()
 
 /*****************************************************************************/
 /* CROSS JOIN EXECUTOR                                                       */
+/* For a full cross join, we dont have a choice but                          */
+/* to cache all rows on one side and remember if they've ever been output.   */
 /*****************************************************************************/
     
 JoinElement::FullCrossJoinExecutor::
@@ -1064,7 +1072,7 @@ FullCrossJoinExecutor(const Bound * parent,
       left(std::move(left)),
       right(std::move(right)),
       firstSpin(true),
-      wasOutput(false),
+      rightRowWasOutputted(false),
       leftAdded(leftAdded),
       rightAdded(rightAdded)
 {
@@ -1088,7 +1096,7 @@ take()
             l = bufferedLeftValues.begin();
 
             //outer right
-            if (!wasOutput) {
+            if (!rightRowWasOutputted) {
 
                 auto result = std::make_shared<PipelineResults>(*(l->first));
 
@@ -1111,7 +1119,7 @@ take()
             }
 
             firstSpin = false;
-            wasOutput = false;
+            rightRowWasOutputted = false;
             r = this->right->take();
         }
 
@@ -1153,7 +1161,7 @@ take()
         if (!crossCondition)
             continue;       
 
-        wasOutput = true;
+        rightRowWasOutputted = true;
 
         return result;
     }
@@ -1196,12 +1204,15 @@ restart()
     l = bufferedLeftValues.begin();
     r = right->take();
     firstSpin = true;
-    wasOutput = false;
+    rightRowWasOutputted = false;
 }
 
 
 /*****************************************************************************/
 /* EQUI JOIN EXECUTOR                                                        */
+/* For equi joins, we have a sliding window row cache for the left side,     */
+/* so we now also keep track of whether each row was ever matched,           */
+/* and selectively output an outer row then it gets removed from the cache.  */
 /*****************************************************************************/
 
 JoinElement::EquiJoinExecutor::
@@ -1379,12 +1390,12 @@ take()
 
                 // return a copy since we are buffering the original left value
                 auto result = make_shared<PipelineResults>(*(*l).first);
-			    result->values.clear();
+                result->values.clear();
                 for (int i = 0; i < leftAdded; ++i)
-				    result->values.emplace_back(ExpressionValue::null(Date::notADate()));
-			    			
-			    for (int i = 0; i < rightAdded;++i)
-				    result->values.push_back(r->values[i]);
+                result->values.emplace_back(ExpressionValue::null(Date::notADate()));
+
+                for (int i = 0; i < rightAdded;++i)
+                    result->values.push_back(r->values[i]);
                           
                 r = right->take();
                 DEBUG_MSG(logger) << "returning right outer row ["

--- a/sql/execution_pipeline_impl.cc
+++ b/sql/execution_pipeline_impl.cc
@@ -907,11 +907,16 @@ JoinElement::CrossJoinExecutor::
 CrossJoinExecutor(const Bound * parent,
                   std::shared_ptr<ElementExecutor> root,
                   std::shared_ptr<ElementExecutor> left,
-                  std::shared_ptr<ElementExecutor> right)
+                  std::shared_ptr<ElementExecutor> right,
+                  size_t leftAdded,
+                size_t rightAdded)
     : parent(parent),
       root(std::move(root)),
       left(std::move(left)),
-      right(std::move(right))
+      right(std::move(right)),
+      wasOutput(false),
+      leftAdded(leftAdded),
+      rightAdded(rightAdded)
 {
     ExcAssert(parent && this->root && this->left && this->right);
     l = this->left->take();
@@ -922,100 +927,111 @@ std::shared_ptr<PipelineResults>
 JoinElement::CrossJoinExecutor::
 take()
 {
-    bool outerLeft = parent->joinQualification_ == JOIN_LEFT
-        || parent->joinQualification_ == JOIN_FULL;
-    bool outerRight = parent->joinQualification_ == JOIN_RIGHT
-        || parent->joinQualification_ == JOIN_FULL;
+    //Full cross joins should be handled by the FullCrossJoinExecutor
+    ExcAssert(parent->joinQualification_ != JOIN_FULL);
+
+    bool outerLeft = parent->joinQualification_ == JOIN_LEFT;
+    bool outerRight = parent->joinQualification_ == JOIN_RIGHT;
+
+    //optimization: if we have a LEFT Join (but not full join)
+    //we switch the loop order
+    //as in "for each right {for each left}"
+    //or "for each left {for each right}"
+    bool scanLeftFirst = outerLeft;
 
     for (;;) {
 
-        if (!l) {
+        if (!l && !scanLeftFirst) { 
+
             this->left->restart();
             l = this->left->take();
+
+            if (!wasOutput && outerRight) {
+
+                auto result = std::make_shared<PipelineResults>(*l);
+
+                //empty values for left without the selected join condition
+                result->values.clear();
+                for (int i = 0; i < leftAdded; ++i) {
+                    result->values.emplace_back(ExpressionValue());
+                }
+
+                // Add r
+                for (auto & v: r->values)
+                    result->values.emplace_back(v);
+
+                // Pop the selected join condition from r
+                result->values.pop_back();
+
+                r = this->right->take();
+
+                return result;
+            }
+
             r = this->right->take();
         }
-        if (!l || !r)
-            return nullptr;
+        else if (!r && scanLeftFirst) {
+            this->right->restart();
+            r = this->right->take();
+            ExcAssert(outerLeft);
 
-        // Got a row!
-        //cerr << "Cross join got a row" << endl;
-        //cerr << "l = " << jsonEncode(l) << endl;
-        //cerr << "r = " << jsonEncode(r) << endl;
-
-        ExpressionValue & lEmbedding = l->values.back();
-        ExpressionValue & rEmbedding = r->values.back();
-
-        if (outerLeft){
-            ExpressionValue where = lEmbedding.getColumn(1, GET_ALL);
-            if (!where.asBool()) {
+            if (!wasOutput){
 
                 //take left
                 // Pop the selected join condition from left
                 l->values.pop_back();
 
                 //empty values for right without the selected join condition
-                size_t numR = r->values.size();
-                for (int i = 0; i < numR - 1; ++i) {
+          
+                for (int i = 0; i < rightAdded; ++i) {
                     l->values.emplace_back(ExpressionValue());
                 }
 
-                auto result = l;
-
+                std::shared_ptr<PipelineResults> result = l;
+                wasOutput = false;
                 l = this->left->take();
-
-                //cerr << "cross outer left returning " << jsonEncode(result) << endl;
 
                 return result;
             }
+	        wasOutput = false;
+            l = this->left->take();
         }
 
-        if (outerRight){
-            ExpressionValue where = rEmbedding.getColumn(1, GET_ALL);
-            if (!where.asBool()) {
+        if (!l || !r)
+            return nullptr;
 
-                size_t numL = l->values.size();
+        // Got a row!       
+        ExpressionValue lEmbedding = l->values.back();
+        ExpressionValue rEmbedding = r->values.back();
 
-                //empty values for left without the selected join condition
-                l->values.clear();
-                for (int i = 0; i < numL - 1; ++i) {
-                    l->values.emplace_back(ExpressionValue());
-                }
-
-                // Add r
-                for (auto & v: r->values)
-                    l->values.emplace_back(v);
-
-                // Pop the selected join condition from r
-                l->values.pop_back();
-
-                auto result = l;
-
-                l = this->left->take();
-
-                //cerr << "cross outer right returning " << jsonEncode(result) << endl;
-
-                return result;
-            }
-        }
+	    auto result = l;
+	    if (scanLeftFirst)
+            result = make_shared<PipelineResults>(*l);	
 
         // Pop the selected join condition from l
-        l->values.pop_back();
+        result->values.pop_back();
 
         for (auto & v: r->values)
-            l->values.emplace_back(v);
+            result->values.emplace_back(v);
 
         // Pop the selected join condition from r
-        l->values.pop_back();
-
-        //cerr << "cross returning " << jsonEncode(l) << endl;
-
-        auto result = l;
-
-        l = this->left->take();
+        result->values.pop_back();
 
         ExpressionValue storage;
-        if (!parent->crossWhere_(*result, storage, GET_LATEST).isTrue())
+
+        bool crossCondition = parent->crossWhere_(*result, storage, GET_LATEST).isTrue() 
+                                && (lEmbedding.getColumn(1, GET_ALL).asBool() || !outerLeft)
+                                && (rEmbedding.getColumn(1, GET_ALL).asBool() || !outerRight);
+
+        if (scanLeftFirst)
+            r = this->right->take();
+        else
+            l = this->left->take();
+       
+        if (!crossCondition)
             continue;
+
+        wasOutput = true; //this row was outputed at least once, dont return an outer entry for it.
 
         return result;
     }
@@ -1029,6 +1045,158 @@ restart()
     right->restart();
     l = left->take();
     r = right->take();
+    wasOutput = false;
+}
+
+/*****************************************************************************/
+/* CROSS JOIN EXECUTOR                                                       */
+/*****************************************************************************/
+    
+JoinElement::FullCrossJoinExecutor::
+FullCrossJoinExecutor(const Bound * parent,
+                  std::shared_ptr<ElementExecutor> root,
+                  std::shared_ptr<ElementExecutor> left,
+                  std::shared_ptr<ElementExecutor> right,
+                  size_t leftAdded,
+                  size_t rightAdded)
+    : parent(parent),
+      root(std::move(root)),
+      left(std::move(left)),
+      right(std::move(right)),
+      firstSpin(true),
+      wasOutput(false),
+      leftAdded(leftAdded),
+      rightAdded(rightAdded)
+{
+    ExcAssert(parent && this->root && this->left && this->right);
+    auto lResult = this->left->take();
+    bufferedLeftValues.push_back({lResult, 0});
+    l = bufferedLeftValues.begin();
+    r = this->right->take();
+}
+
+std::shared_ptr<PipelineResults>
+JoinElement::FullCrossJoinExecutor::
+take()
+{
+    //this executor is always "for each right {for each left}"
+    //we need to cache all left rows and note whether it was output at least once.
+
+    while (r) {
+        if (l == bufferedLeftValues.end()) {            
+
+            l = bufferedLeftValues.begin();
+
+            //outer right
+            if (!wasOutput) {
+
+                auto result = std::make_shared<PipelineResults>(*(l->first));
+
+                //empty values for left without the selected join condition
+                result->values.clear();
+                for (int i = 0; i < leftAdded; ++i) {
+                    result->values.emplace_back(ExpressionValue());
+                }
+
+                // Add r
+                for (auto & v: r->values)
+                    result->values.emplace_back(v);
+
+                // Pop the selected join condition from r
+                result->values.pop_back();
+
+                r = this->right->take();
+
+                return result;
+            }
+
+            firstSpin = false;
+            wasOutput = false;
+            r = this->right->take();
+        }
+
+        if (!r)
+            break;
+
+        ExpressionValue lEmbedding = l->first->values.back();
+        ExpressionValue rEmbedding = r->values.back();        
+
+        auto result = std::make_shared<PipelineResults>(*(l->first));
+
+        // Pop the selected join condition from l
+        result->values.pop_back();
+
+        for (auto & v: r->values)
+            result->values.emplace_back(v);
+
+        // Pop the selected join condition from r
+        result->values.pop_back();
+
+        //auto result = l;
+        ExpressionValue storage;
+
+        bool crossCondition = parent->crossWhere_(*result, storage, GET_LATEST).isTrue() 
+                                && (lEmbedding.getColumn(1, GET_ALL).asBool())
+                                && (rEmbedding.getColumn(1, GET_ALL).asBool());
+     
+        if (crossCondition)
+            l->second = 1;
+
+        if (firstSpin) {
+            auto lResult = this->left->take();
+            if (lResult)
+                bufferedLeftValues.push_back({lResult, 0});
+        }
+
+        ++l;
+
+        if (!crossCondition)
+            continue;       
+
+        wasOutput = true;
+
+        return result;
+    }
+
+    //Return the left rows that were never matched
+    while (l != bufferedLeftValues.end()) {
+
+        if (l->second != 0) {
+            ++l;
+            continue;
+        }
+
+        //outer left
+
+        // Pop the selected join condition from left
+        l->first->values.pop_back();
+
+        for (int i = 0; i < rightAdded; ++i) {
+            l->first->values.emplace_back(ExpressionValue());
+        }
+
+        std::shared_ptr<PipelineResults> result = l->first;
+        
+        ++l;
+
+        return result;
+    }
+
+    return nullptr;
+}
+
+void
+JoinElement::FullCrossJoinExecutor::
+restart()
+{
+    left->restart();
+    right->restart();
+    auto lResult = left->take();
+    bufferedLeftValues.clear();
+    l = bufferedLeftValues.begin();
+    r = right->take();
+    firstSpin = true;
+    wasOutput = false;
 }
 
 
@@ -1040,16 +1208,20 @@ JoinElement::EquiJoinExecutor::
 EquiJoinExecutor(const Bound * parent,
                  std::shared_ptr<ElementExecutor> root,
                  std::shared_ptr<ElementExecutor> left,
-                 std::shared_ptr<ElementExecutor> right)
+                 std::shared_ptr<ElementExecutor> right,
+                 size_t leftAdded,
+                 size_t rightAdded)
     : parent(parent),
       root(std::move(root)),
       left(std::move(left)),
       right(std::move(right)),
-      alreadySeenLeftRow(false),
-      logger(getMldbLog<EquiJoinExecutor>())
+      wasOutput(false),
+      logger(getMldbLog<EquiJoinExecutor>()),
+      leftAdded(leftAdded),
+      rightAdded(rightAdded)
 {
     auto lresult = this->left->take();
-    bufferedLeftValues.push_back(lresult);
+    bufferedLeftValues.push_back({lresult, 0});
     l = bufferedLeftValues.begin();
     firstDuplicate = l;
     r = this->right->take();
@@ -1081,7 +1253,7 @@ take()
                 auto lresult = this->left->take();
                 if (lresult) {
                     // buffer the next element and return a pointer to it
-                    bufferedLeftValues.push_back(lresult);
+                    bufferedLeftValues.push_back({lresult, 0});
                     l = --bufferedLeftValues.end();
                     return l;
                 }
@@ -1099,50 +1271,52 @@ take()
         }
     };
 
+    //first check if we can pop something from the cached left list
+    while (bufferedLeftValues.size() > 0 && firstDuplicate != bufferedLeftValues.begin()) {
+        if (outerLeft) {
+            auto leftiter = bufferedLeftValues.begin();
+            if (leftiter->second == 0) {
+                auto result = leftiter->first;
+                // Pop the selected join conditions from left
+                result->values.pop_back();
+
+                for (auto i = 0; i < rightAdded; i++)
+                    result->values.push_back(ExpressionValue());
+
+                bufferedLeftValues.pop_front();
+                return result;
+            }
+        }
+
+        bufferedLeftValues.pop_front();
+    }
+
     while (l != bufferedLeftValues.end() && r) {
-        ExpressionValue & lEmbedding = (*l)->values.back();
+
+        ExpressionValue & lEmbedding = (*l).first->values.back();
         ExpressionValue & rEmbedding = r->values.back();
 
         ExpressionValue lField = lEmbedding.getColumn(0, GET_ALL);
         ExpressionValue rField = rEmbedding.getColumn(0, GET_ALL);
         DEBUG_MSG(logger) << "++++++";
-        DEBUG_MSG(logger) << "comparing left row [" << (*l)->values[0].coerceToPath() << 
-            "] with right row [" << r->values[0].coerceToPath() << "]";
-
-        //in case of outer join
-        //check the where condition that we took out and put in the embedding instead
-        auto checkOuterWhere = [] ( std::shared_ptr<PipelineResults>& s,
-                                    std::shared_ptr<ElementExecutor>& executor,
-                                    ExpressionValue& field,
-                                    ExpressionValue & embedding) -> bool
-        {
-            ExpressionValue where = embedding.getColumn(1, GET_ALL);
-            //if the condition would have failed, or the select value is null, return the row.
-            if (field.empty() || !where.asBool())
-            {
-                s->values.pop_back();
-                s->values.emplace_back(ExpressionValue::null(Date::notADate()));
-                s->values.emplace_back(ExpressionValue::null(Date::notADate()));
-                return true;
-            }
-
-            return false;
-        };    
+        DEBUG_MSG(logger) << "comparing left row [" << (*l).first->values[0].coerceToPath() << 
+                             "] with right row [" << r->values[0].coerceToPath() << "]";
 
         if (lField == rField) {
             auto setLastLeftValue = ScopeSuccess([&]() noexcept {lastLeftValue = lField;});
+            
             // Got a row!
-            DEBUG_MSG(logger) << "left and right rows are matching on value " << lField.toString();
+    	    if (lField.empty())
+    	        DEBUG_MSG(logger) << "left and right rows are matching on value NULL";
+            else
+                DEBUG_MSG(logger) << "left and right rows are matching on value " << lField.toString();
          
             // return a copy since we are buffering the original left value
-            auto result = make_shared<PipelineResults>(**l);
+            auto result = make_shared<PipelineResults>(*(*l).first);
             // Pop the selected join conditions from left
             result->values.pop_back();
 
-            auto numL = result->values.size();
-            auto numR = r->values.size() - 1;
-
-            for (auto i = 0; i < numR; ++i)
+            for (auto i = 0; i < rightAdded; ++i)
                 result->values.push_back(r->values[i]);
 
             ExpressionValue storage;
@@ -1150,86 +1324,81 @@ take()
                 && lEmbedding.getColumn(1, GET_ALL).isTrue()
                 && rEmbedding.getColumn(1, GET_ALL).isTrue();
 
-            if (!whereCondition && outerLeft) {
-                for (auto i = 0; i < numR; i++)
-                    result->values.pop_back();
-                for (auto i = 0; i < numR; i++)
-                    result->values.push_back(ExpressionValue());
-            }
-            else if (!whereCondition && outerRight) {
-                for (auto i = 0; i < numL; i++)
-                    result->values[i] = ExpressionValue();
-            }
-            else if (!whereCondition && !outerRight && !outerLeft) {
+           if (!whereCondition) {
                 l = takeFromBuffer(l);
                 DEBUG_MSG(logger) << "skipping row - the where condition is false";
                 if (l == bufferedLeftValues.end()) {
                     DEBUG_MSG(logger) << "reached the left-side end - rewinding";
+                    wasOutput = false;
                     r = right->take();
                     l = firstDuplicate;
-                    alreadySeenLeftRow = true;
                 }
                 continue;
             }
 
-            if (lastLeftValue != lField) {
+            if (lastLeftValue != lField)
                 firstDuplicate = l;
-                alreadySeenLeftRow = false;
-            }
 
+            l->second = 1; //we outputed that row, dont "outer" it
             l = takeFromBuffer(l);
 
-            bool setAlreadySeen = false;
             if (l == bufferedLeftValues.end() && firstDuplicate != --bufferedLeftValues.end()) {
                 DEBUG_MSG(logger) << "reached the left-side end - rewinding";
+                wasOutput = false;
                 r = right->take();
                 l = firstDuplicate;
-                setAlreadySeen = true;
             }
-
-            if (outerLeft && !whereCondition && alreadySeenLeftRow) {
-                DEBUG_MSG(logger) << "skipping row - this row was already outputed";
-                continue;
-            }
-
-            if (setAlreadySeen)
-                alreadySeenLeftRow = true;
 
             DEBUG_MSG(logger) << "returning the row";
+            wasOutput = true;
             return result;
         }
         else if (lField < rField) {
             // loop until left field value is equal to the right field value
             // returning nulls if left outer
             do {
-                auto result = make_shared<PipelineResults>(**l);
+                auto result = make_shared<PipelineResults>(*(*l).first);
                 DEBUG_MSG(logger) << "++++++";
                 DEBUG_MSG(logger) << "comparing left row [" << result->values[0].coerceToPath() 
                                   << "] with right row [" << r->values[0].coerceToPath() << "]";
-                if (outerLeft && checkOuterWhere(result, left, lField, rEmbedding)) {
-                    l = takeFromBuffer(l);
-                    DEBUG_MSG(logger) << "returning left outer row [" 
-                                      << result->values[0].coerceToPath()
-                                      << "]";
-                    return result;
-                } else {
-                    DEBUG_MSG(logger) << "skipping left row [" 
-                                      << result->values[0].coerceToPath()
-                                      << "]";
-                    l = takeFromBuffer(l);
-                }     
-            } while (l != bufferedLeftValues.end()  && (*l)->values.back().getColumn(0, GET_ALL) < rField);
-            if (l == bufferedLeftValues.end())
-                return nullptr;
+
+                DEBUG_MSG(logger) << "skipping left row [" 
+                                  << result->values[0].coerceToPath()
+                                  << "]";
+                l = takeFromBuffer(l);
+
+            } while (l != bufferedLeftValues.end()  && (*l).first->values.back().getColumn(0, GET_ALL) < rField);
+
         }
-        else {  
+        else {
+
+            //Take from the right and reset the left.            
             ExcAssert(lField > rField);
+
+            if (outerRight && !wasOutput) {                              
+
+                // return a copy since we are buffering the original left value
+                auto result = make_shared<PipelineResults>(*(*l).first);
+			    result->values.clear();
+                for (int i = 0; i < leftAdded; ++i)
+				    result->values.emplace_back(ExpressionValue::null(Date::notADate()));
+			    			
+			    for (int i = 0; i < rightAdded;++i)
+				    result->values.push_back(r->values[i]);
+                          
+                r = right->take();
+                DEBUG_MSG(logger) << "returning right outer row ["
+                                  << result->values[0].coerceToPath()
+                                  << "]";
+                return result;
+            }
+
+            wasOutput = false;
             r = right->take();
             if (r) {
                 if (r->values.back().getColumn(0, GET_ALL) == lastLeftValue) {
                     DEBUG_MSG(logger) << "newly fetched row from the right matches the last left value - rewinding";
                     l = firstDuplicate;
-                    alreadySeenLeftRow = true;
                     continue;
                 }
                 else {
@@ -1237,21 +1406,29 @@ take()
                     // returning nulls if right outer
                     while (r && r->values.back().getColumn(0, GET_ALL) < lField) {
                         DEBUG_MSG(logger) << "++++++";
-                        DEBUG_MSG(logger) << "comparing left row [" << (*l)->values[0].coerceToPath() 
+                        DEBUG_MSG(logger) << "comparing left row [" << (*l).first->values[0].coerceToPath() 
                                           << "] with right row [" << r->values[0].coerceToPath() << "]";
-                        if (outerRight && checkOuterWhere(r, right, rField, lEmbedding)) {
-                            auto result = std::move(r);
-                            r = right->take();
-                            DEBUG_MSG(logger) << "returning right outer row [" 
+                        if (outerRight) {
+
+                           auto result = make_shared<PipelineResults>(*(*l).first);
+                           result->values.clear();
+                           for (int i = 0; i < leftAdded; ++i)
+                               result->values.emplace_back(ExpressionValue::null(Date::notADate()));
+                                        
+                           for (int i = 0; i < rightAdded;++i)
+                               result->values.push_back(r->values[i]);
+                                      
+                           r = right->take();
+                           DEBUG_MSG(logger) << "returning right outer row ["
                                               << result->values[0].coerceToPath()
                                               << "]";
-                            return result;
-                        } else {
-                            DEBUG_MSG(logger) << "skipping right row [" 
-                                              << r->values[0].coerceToPath()
-                                              << "]";
-                            r = right->take();
+                           return result;
                         }
+                        
+                        DEBUG_MSG(logger) << "skipping right row [" 
+                                          << r->values[0].coerceToPath()
+                                          << "]";
+                        r = right->take();                        
                     }
                 }
             }
@@ -1259,19 +1436,56 @@ take()
     }
 
     //Return unmatched rows if we have a LEFT/RIGHT/OUTER join
+
+    firstDuplicate = bufferedLeftValues.end();
+
     //Fill unmatched with empty values
-    if (outerLeft && l != bufferedLeftValues.end() && !alreadySeenLeftRow)
+    if (outerLeft && l != bufferedLeftValues.end())
     {
-        auto result = shared_ptr<PipelineResults>(new PipelineResults(**l));
-        result->values.pop_back();
-        result->values.emplace_back(ExpressionValue::null(Date::notADate()));
-        result->values.emplace_back(ExpressionValue::null(Date::notADate()));
-        l = takeFromBuffer(l);
-        DEBUG_MSG(logger) << "++++++";
-        DEBUG_MSG(logger) << "returning left outer row [" 
-                          << result->values[0].coerceToPath()
-                          << "]";
-        return result;
+        while (l != bufferedLeftValues.end() && !bufferedLeftValues.empty()) {
+
+            if (l->second > 0) {
+                l = takeFromBuffer(l);
+                continue;
+            }
+
+            auto result = shared_ptr<PipelineResults>(new PipelineResults(*(*l).first));
+            result->values.pop_back();
+            result->values.emplace_back(ExpressionValue::null(Date::notADate()));
+            result->values.emplace_back(ExpressionValue::null(Date::notADate()));
+            l->second = 1;
+            l = takeFromBuffer(l);
+            DEBUG_MSG(logger) << "++++++";
+            DEBUG_MSG(logger) << "returning left outer row [" 
+                              << result->values[0].coerceToPath()
+                              << "]";
+            return result;
+        }
+    }
+
+    l = bufferedLeftValues.end();
+
+    while (bufferedLeftValues.size() > 0 ) {
+        if (outerLeft) {
+            auto leftiter = bufferedLeftValues.begin();
+            if (leftiter->second == 0) {
+                auto result = leftiter->first;
+
+                // Pop the selected join conditions from left
+                result->values.pop_back();
+                for (auto i = 0; i < rightAdded; i++)
+                    result->values.push_back(ExpressionValue());
+
+                bufferedLeftValues.pop_front();
+                return result;
+            }
+
+            bufferedLeftValues.pop_front();
+        }
+        else {
+            bufferedLeftValues.clear();
+            l = bufferedLeftValues.end();
+        }
     }
 
     if (outerRight && r)
@@ -1301,7 +1515,7 @@ restart()
     right->restart();
     bufferedLeftValues.resize(0);
     auto lresult = this->left->take();
-    bufferedLeftValues.push_back(lresult);
+    bufferedLeftValues.push_back({lresult, 0});
     l = bufferedLeftValues.begin();
     firstDuplicate = l;
     r = right->take();
@@ -1364,21 +1578,41 @@ std::shared_ptr<ElementExecutor>
 JoinElement::Bound::
 start(const BoundParameters & getParam) const
 {
+    size_t leftAdded = left_->outputScope()->defaultScope()->outputAdded().size();
+    size_t rightAdded = right_->outputScope()->defaultScope()->outputAdded().size();
+
     switch (condition_.style) {
 
-    case AnnotatedJoinCondition::CROSS_JOIN:
-        return std::make_shared<CrossJoinExecutor>
+    case AnnotatedJoinCondition::CROSS_JOIN: 
+    {
+        if (joinQualification_ == JOIN_FULL) {
+            return std::make_shared<FullCrossJoinExecutor>
             (this,
              root_->start(getParam),
              left_->start(getParam),
-             right_->start(getParam));
+             right_->start(getParam),
+             leftAdded,
+             rightAdded);
+        }
+        else {
+            return std::make_shared<CrossJoinExecutor>
+            (this,
+             root_->start(getParam),
+             left_->start(getParam),
+             right_->start(getParam),
+             leftAdded,
+             rightAdded);
+        }        
+    }
 
     case AnnotatedJoinCondition::EQUIJOIN:
         return std::make_shared<EquiJoinExecutor>
             (this,
              root_->start(getParam),
              left_->start(getParam),
-             right_->start(getParam));
+             right_->start(getParam),
+             leftAdded,
+             rightAdded);
 
     default:
         throw HttpReturnException(400, "Can't execute that kind of join",

--- a/sql/execution_pipeline_impl.h
+++ b/sql/execution_pipeline_impl.h
@@ -374,7 +374,7 @@ struct JoinElement: public PipelineElement {
         bufferType bufferedLeftValues;
         bufferType::iterator l;
         bool firstSpin;
-        bool wasOutput;
+        bool rightRowWasOutputted;
        
         const size_t leftAdded, rightAdded;
 

--- a/sql/execution_pipeline_impl.h
+++ b/sql/execution_pipeline_impl.h
@@ -370,7 +370,7 @@ struct JoinElement: public PipelineElement {
         virtual std::shared_ptr<PipelineResults> take();
 
         std::shared_ptr<PipelineResults> r;
-        typedef std::list<std::pair<std::shared_ptr<PipelineResults>, int > > bufferType;
+        typedef std::list<std::pair<std::shared_ptr<PipelineResults>, bool > > bufferType;
         bufferType bufferedLeftValues;
         bufferType::iterator l;
         bool firstSpin;
@@ -402,7 +402,7 @@ struct JoinElement: public PipelineElement {
         std::shared_ptr<ElementExecutor> root, left, right;
         
         std::shared_ptr<PipelineResults> r;
-        typedef std::list<std::pair<std::shared_ptr<PipelineResults>, int > > bufferType;
+        typedef std::list<std::pair<std::shared_ptr<PipelineResults>, bool > > bufferType;
         bufferType bufferedLeftValues;
         /** Note that the left-side values are buffered so that we can
             backtrack when we need to form the cross product on matching 

--- a/testing/MLDB-2040_join_tests.py
+++ b/testing/MLDB-2040_join_tests.py
@@ -1,0 +1,340 @@
+#
+# MLDB-2040_join_tests.py
+# Francois-Michel L'Heureux, 2016-11-02
+# This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+#
+
+mldb = mldb_wrapper.wrap(mldb)  # noqa
+
+class Mldb2040JoinTests(MldbUnitTest):  # noqa
+
+    @classmethod
+    def setUpClass(cls):
+        ds = mldb.create_dataset({'id' : 'a', 'type' : 'sparse.mutable'})
+        ds.record_row('row1', [['one', 1, 0], ['two', 1, 0]])
+        ds.record_row('row2', [['one', 1, 0], ['two', 2, 0]])
+        ds.record_row('row3', [['one', 2, 0], ['two', 1, 0]])
+        ds.record_row('row4', [['one', 2, 0], ['two', 2, 0]])
+        ds.commit()
+
+        ds = mldb.create_dataset({'id' : 'b', 'type' : 'sparse.mutable'})
+        ds.record_row('row0', [['one', 0, 0]])
+        ds.record_row('row1', [['one', 1, 0]])
+        ds.record_row('row2', [['one', 2, 0]])
+        ds.commit()
+
+
+    def test_left_join_no_rhs(self):
+        ds = mldb.create_dataset({'id' : 'no_rhs', 'type' : 'sparse.mutable'})
+        ds.commit()
+        res = mldb.query("""
+            SELECT * FROM a
+            LEFT JOIN no_rhs ON a.one = no_rhs.one
+            ORDER BY rowName()""")
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[row1]-[]", 1, 1],
+            ["[row2]-[]", 1, 2],
+            ["[row3]-[]", 2, 1],
+            ["[row4]-[]", 2, 2]
+        ])
+
+    def test_left_join_rsh(self):
+        ds = mldb.create_dataset({'id' : 'rhs', 'type' : 'sparse.mutable'})
+        ds.record_row('row1', [['one', 1, 0], ['two', 1, 0]])
+        ds.record_row('row2', [['one', 1, 0], ['two', 2, 0]])
+        ds.commit()
+        res = mldb.query("""
+            SELECT * FROM a
+            LEFT JOIN rhs ON a.one = rhs.one AND a.two = rhs.two
+            ORDER BY rowName()""")
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "rhs.one", "rhs.two"],
+            ["[row1]-[row1]", 1, 1, 1, 1],
+            ["[row2]-[row2]", 1, 2, 1, 2],
+            ["[row3]-[]", 2, 1, None, None],
+            ["[row4]-[]", 2, 2, None, None]
+        ])
+
+    def test_left_join_rsh_multi_match(self):
+        ds = mldb.create_dataset({
+            'id' : 'rhs_multi_match',
+            'type' : 'sparse.mutable'
+        })
+        ds.record_row('row1', [['one', 1, 0], ['two', 1, 0]])
+        ds.record_row('row2', [['one', 1, 0], ['two', 2, 0]])
+        ds.record_row('row22', [['one', 1, 0], ['two', 2, 0]])
+        ds.record_row('row11', [['one', 1, 0], ['two', 1, 0]])
+        ds.commit()
+        res = mldb.query("""
+            SELECT * FROM a
+            LEFT JOIN rhs_multi_match
+                ON a.one = rhs_multi_match.one AND a.two = rhs_multi_match.two
+            ORDER BY rowName()""")
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "rhs_multi_match.one", "rhs_multi_match.two"],
+            ["[row1]-[row11]", 1, 1, 1, 1],
+            ["[row1]-[row1]", 1, 1, 1, 1],
+            ["[row2]-[row22]", 1, 2, 1, 2],
+            ["[row2]-[row2]", 1, 2, 1, 2],
+            ["[row3]-[]", 2, 1, None, None],
+            ["[row4]-[]", 2, 2, None, None]
+        ])
+
+    def test_right_join_no_rhs(self):
+        ds = mldb.create_dataset({
+            'id' : 'rj_no_rhs',
+            'type' : 'sparse.mutable'
+        })
+        ds.commit()
+        res = mldb.query("""
+            SELECT * FROM a
+            RIGHT JOIN rj_no_rhs ON a.one = rj_no_rhs.one
+            ORDER BY rowName()""")
+        self.assertTableResultEquals(res, [
+            ["_rowName"]
+        ])
+
+    def test_right_join_rsh(self):
+        ds = mldb.create_dataset({'id' : 'rj_rhs', 'type' : 'sparse.mutable'})
+        ds.record_row('row1', [['one', 1, 0], ['two', 1, 0]])
+        ds.record_row('row2', [['one', 1, 0], ['two', 2, 0]])
+        ds.commit()
+        res = mldb.query("""
+            SELECT * FROM a
+            RIGHT JOIN rj_rhs ON a.one = rj_rhs.one AND a.two = rj_rhs.two
+            ORDER BY rowName()""")
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "rj_rhs.one", "rj_rhs.two"],
+            ["[row1]-[row1]", 1, 1, 1, 1],
+            ["[row2]-[row2]", 1, 2, 1, 2]
+        ])
+
+    def test_right_join_rsh_multi_match(self):
+        ds = mldb.create_dataset({
+            'id' : 'rj_rhs_multi_match',
+            'type' : 'sparse.mutable'
+        })
+        ds.record_row('row1', [['one', 1, 0], ['two', 1, 0]])
+        ds.record_row('row2', [['one', 1, 0], ['two', 2, 0]])
+        ds.record_row('row22', [['one', 1, 0], ['two', 2, 0]])
+        ds.record_row('row11', [['one', 1, 0], ['two', 1, 0]])
+        ds.commit()
+        res = mldb.query("""
+            SELECT * FROM a
+            RIGHT JOIN rj_rhs_multi_match
+                ON a.one = rj_rhs_multi_match.one
+                AND a.two = rj_rhs_multi_match.two
+            ORDER BY rowName()""")
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "rj_rhs_multi_match.one", "rj_rhs_multi_match.two"],
+            ["[row1]-[row11]", 1, 1, 1, 1],
+            ["[row1]-[row1]", 1, 1, 1, 1],
+            ["[row2]-[row22]", 1, 2, 1, 2],
+            ["[row2]-[row2]", 1, 2, 1, 2]
+        ])
+
+    def test_left_join_gt(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one > b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "b.one"],
+            ["[row1]-[row0]", 1, 1, 0],
+            ["[row2]-[row0]", 1, 2, 0],
+            ["[row3]-[row0]", 2, 1, 0],
+            ["[row3]-[row1]", 2, 1, 1],
+            ["[row4]-[row0]", 2, 2, 0],
+            ["[row4]-[row1]", 2, 2, 1]
+        ])
+
+    def test_left_join_gte(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one >= b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "b.one"],
+            ["[row1]-[row0]", 1, 1, 0],
+            ["[row1]-[row1]", 1, 1, 1],
+            ["[row2]-[row0]", 1, 2, 0],
+            ["[row2]-[row1]", 1, 2, 1],
+            ["[row3]-[row0]", 2, 1, 0],
+            ["[row3]-[row1]", 2, 1, 1],
+            ["[row3]-[row2]", 2, 1, 2],
+            ["[row4]-[row0]", 2, 2, 0],
+            ["[row4]-[row1]", 2, 2, 1],
+            ["[row4]-[row2]", 2, 2, 2]
+        ])
+
+    def test_left_join_lt(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one < b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "b.one"],
+            ["[row1]-[row2]", 1, 1, 2],
+            ["[row2]-[row2]", 1, 2, 2],
+            ["[row3]-[]",2,1,None],
+            ["[row4]-[]",2,2,None]
+        ])
+
+    def test_left_join_lte(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one <= b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "b.one"],
+            ["[row1]-[row1]", 1, 1, 1],
+            ["[row1]-[row2]", 1, 1, 2],
+            ["[row2]-[row1]", 1, 2, 1],
+            ["[row2]-[row2]", 1, 2, 2],
+            ["[row3]-[row2]", 2, 1, 2],
+            ["[row4]-[row2]", 2, 2, 2]
+        ])
+
+    def test_left_join_no_match(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one - 100 > b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[row1]-[]", 1, 1],
+            ["[row2]-[]", 1, 2],
+            ["[row3]-[]", 2, 1],
+            ["[row4]-[]", 2, 2]
+        ])
+
+    def test_left_join_gt_dual(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one > b.one AND a.two > b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "b.one"],
+            ["[row1]-[row0]", 1, 1, 0],
+            ["[row2]-[row0]", 1, 2, 0],
+            ["[row3]-[row0]", 2, 1, 0],
+            ["[row4]-[row0]", 2, 2, 0],
+            ["[row4]-[row1]", 2, 2, 1]
+        ])
+
+    def test_left_join_lt_with_op(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one > b.one AND a.two - 1 <  b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "b.one"],
+            ["[row1]-[]", 1, 1, None],
+            ["[row2]-[]", 1, 2, None],
+            ["[row3]-[row1]", 2, 1, 1],
+            ["[row4]-[]", 2, 2, None]
+        ])
+
+    def test_left_join_gte_dual(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one >= b.one AND a.two >= b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "b.one"],
+            ["[row1]-[row0]", 1, 1, 0],
+            ["[row1]-[row1]", 1, 1, 1],
+            ["[row2]-[row0]", 1, 2, 0],
+            ["[row2]-[row1]", 1, 2, 1],
+            ["[row3]-[row0]", 2, 1, 0],
+            ["[row3]-[row1]", 2, 1, 1],
+            ["[row4]-[row0]", 2, 2, 0],
+            ["[row4]-[row1]", 2, 2, 1],
+            ["[row4]-[row2]", 2, 2, 2]
+        ])
+
+    def test_left_join_mix_dual(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one >= b.one AND a.two <= b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "b.one"],
+            ["[row1]-[row1]", 1, 1, 1],
+            ["[row2]-[]", 1, 2, None],
+            ["[row3]-[row1]", 2, 1, 1],
+            ["[row3]-[row2]", 2, 1, 2],
+            ["[row4]-[row2]", 2, 2, 2]
+        ])
+
+    def test_left_join_lt_dual(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one < b.one AND a.two < b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "b.one"],
+            ["[row1]-[row2]", 1, 1, 2],
+            ["[row2]-[]", 1, 2, None],
+            ["[row3]-[]", 2, 1, None],
+            ["[row4]-[]", 2, 2, None]
+        ])
+
+    def test_left_join_lte_dual(self):
+        res = mldb.query("""
+            SELECT * FROM a LEFT JOIN b ON a.one <= b.one AND a.two <= b.one
+            ORDER BY rowName()
+        """)
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two", "b.one"],
+            ["[row1]-[row1]", 1, 1, 1],
+            ["[row1]-[row2]", 1, 1, 2],
+            ["[row2]-[row2]", 1, 2, 2],
+            ["[row3]-[row2]", 2, 1, 2],
+            ["[row4]-[row2]", 2, 2, 2]
+        ])
+
+    def test_cross_full_nothing(self):
+
+        ds = mldb.create_dataset({'id' : 'cross_rhs', 'type' : 'sparse.mutable'})
+        ds.record_row('row1', [['one', 1, 0], ['two', 9, 0]])
+        ds.record_row('row2', [['one', 1, 0], ['two', 9, 0]])
+        ds.commit()
+
+        res = mldb.query("""
+            SELECT * FROM b FULL JOIN cross_rhs ON b.one < cross_rhs.one AND cross_rhs.two < b.one
+            ORDER BY rowName()
+        """)
+
+        self.assertTableResultEquals(res, 
+            [["_rowName", "cross_rhs.one", "cross_rhs.two", "b.one"],
+             ["[]-[row1]", 1, 9, None],
+             ["[]-[row2]", 1, 9, None],
+             ["[row0]-[]", None, None, 0],
+             ["[row1]-[]", None, None, 1],
+             ["[row2]-[]", None, None, 2]
+        ])
+
+    def test_cross_full_something(self):
+
+        ds = mldb.create_dataset({'id' : 'cross_rhs_2', 'type' : 'sparse.mutable'})
+        ds.record_row('row1', [['one', 1, 0], ['two', 0, 0]])
+        ds.record_row('row2', [['one', 1, 0], ['two', 1, 0]])
+        ds.commit()
+
+        res = mldb.query("""
+            SELECT * FROM b FULL JOIN cross_rhs_2 ON b.one > cross_rhs_2.one AND b.one > cross_rhs_2.two
+            ORDER BY rowName()
+        """)
+
+        self.assertTableResultEquals(res, 
+            [["_rowName", "b.one", "cross_rhs_2.one", "cross_rhs_2.two"],
+             ["[row0]-[]", 0, None, None],
+             ["[row1]-[]", 1, None, None],
+             ["[row2]-[row1]", 2, 1, 0],
+             ["[row2]-[row2]", 2, 1, 1]
+        ])
+
+if __name__ == '__main__':
+    mldb.run_tests()

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -448,5 +448,6 @@ $(eval $(call mldb_unit_test,union_dataset_test.py))
 $(eval $(call mldb_unit_test,deepteach_test.py,tensorflow,manual))
 $(eval $(call mldb_unit_test,post_run_and_track_procedure_test.py))
 $(eval $(call mldb_unit_test,MLDB-2022-multiple-prediction-example.js))
-
 $(eval $(call mldb_unit_test,MLDB-2043_tabular_big_int.py))
+$(eval $(call mldb_unit_test,MLDB-2040_join_tests.py))
+


### PR DESCRIPTION
Refactor both the equi and cross join pipeline executor to better handle left, right and full outer joins.

We cannot output a row as an outer row until its been tested against every single other row it could match with.
For left or right cross joins, we choose the proper side to loop on first to be efficient (for example if its a right join, we loop on right first). This way we avoid having to cache all rows. For a full cross join, we dont have a choice but to cache all rows on one side and remember if they've ever been output.

For equi joins, we already had a sliding window row cache for the left side, so we now also keep track of whether each row was ever matched, and selectively output an outer row then it gets removed from the cache. This will also help with memory in many cases, as the cache was not emptied until the end, while not its size will be kept at a minimum.

Finally, we use the left and right pipeline scopes to determine how many empty elements to add when we output outer rows.