### PR TITLE
Mldb 2074 empty outer join

### DIFF
--- a/sql/execution_pipeline_impl.cc
+++ b/sql/execution_pipeline_impl.cc
@@ -939,7 +939,7 @@ take()
     //or "for each left {for each right}"
     bool scanLeftFirst = outerLeft;
 
-    for (;;) {
+    while ((l && scanLeftFirst) || (r && !scanLeftFirst)) {
 
         if (!l && !scanLeftFirst) { 
 
@@ -948,7 +948,7 @@ take()
 
             if (!wasOutput && outerRight) {
 
-                auto result = std::make_shared<PipelineResults>(*l);
+                auto result = std::make_shared<PipelineResults>(*r);
 
                 //empty values for left without the selected join condition
                 result->values.clear();
@@ -1035,6 +1035,8 @@ take()
 
         return result;
     }
+
+    return nullptr;
 }
 
 void

--- a/sql/execution_pipeline_impl.cc
+++ b/sql/execution_pipeline_impl.cc
@@ -1272,7 +1272,7 @@ take()
     };
 
     //first check if we can pop something from the cached left list
-    while (bufferedLeftValues.size() > 0 && firstDuplicate != bufferedLeftValues.begin()) {
+    while (bufferedLeftValues.size() > 0 && firstDuplicate != bufferedLeftValues.begin() && l != bufferedLeftValues.begin()) {
         if (outerLeft) {
             auto leftiter = bufferedLeftValues.begin();
             if (!leftiter->second) {

--- a/sql/execution_pipeline_impl.cc
+++ b/sql/execution_pipeline_impl.cc
@@ -1221,8 +1221,13 @@ EquiJoinExecutor(const Bound * parent,
       rightAdded(rightAdded)
 {
     auto lresult = this->left->take();
-    bufferedLeftValues.push_back({lresult, 0});
-    l = bufferedLeftValues.begin();
+    if (lresult) {
+        bufferedLeftValues.push_back({lresult, 0});
+        l = bufferedLeftValues.begin();
+    }
+    else {
+        l = bufferedLeftValues.end();
+    }
     firstDuplicate = l;
     r = this->right->take();
 }
@@ -1515,8 +1520,13 @@ restart()
     right->restart();
     bufferedLeftValues.resize(0);
     auto lresult = this->left->take();
-    bufferedLeftValues.push_back({lresult, 0});
-    l = bufferedLeftValues.begin();
+    if (lresult) {
+        bufferedLeftValues.push_back({lresult, 0});
+        l = bufferedLeftValues.begin();
+    }
+    else {
+        l = bufferedLeftValues.end();
+    }
     firstDuplicate = l;
     r = right->take();
 }

--- a/testing/MLDB-2074-empty-join.py
+++ b/testing/MLDB-2074-empty-join.py
@@ -178,5 +178,33 @@ class Mldb2074JoinTests(MldbUnitTest):  # noqa
             ["[]-[row4]", 2, 2]
         ])
 
+    def test_full_join_cross_pipeline(self):
+        res = mldb.query("""
+            SELECT * FROM a
+            FULL JOIN empty ON a.one <= empty.one AND a.two <= empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[row1]-[]", 1, 1],
+            ["[row2]-[]", 1, 2],
+            ["[row3]-[]", 2, 1],
+            ["[row4]-[]", 2, 2]
+        ])
+
+    def test_full_join_cross_pipeline_reverse(self):
+        res = mldb.query("""
+            SELECT * FROM empty
+            FULL JOIN a ON a.one <= empty.one AND a.two <= empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[]-[row1]", 1, 1],
+            ["[]-[row2]", 1, 2],
+            ["[]-[row3]", 2, 1],
+            ["[]-[row4]", 2, 2]
+        ])
+
 if __name__ == '__main__':
     mldb.run_tests()

--- a/testing/MLDB-2074-empty-join.py
+++ b/testing/MLDB-2074-empty-join.py
@@ -99,5 +99,33 @@ class Mldb2074JoinTests(MldbUnitTest):  # noqa
             ["[]-[row4]", 2, 2]
         ])
 
+    def test_full_join_equi_pipeline(self):
+        res = mldb.query("""
+            SELECT * FROM a
+            FULL JOIN empty ON a.one = empty.one AND a.two = empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[row1]-[]", 1, 1],
+            ["[row2]-[]", 1, 2],
+            ["[row3]-[]", 2, 1],
+            ["[row4]-[]", 2, 2]
+        ])
+
+    def test_full_join_equi_pipeline_reverse(self):
+        res = mldb.query("""
+            SELECT * FROM empty
+            FULL JOIN a ON a.one = empty.one AND a.two = empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[]-[row1]", 1, 1],
+            ["[]-[row2]", 1, 2],
+            ["[]-[row3]", 2, 1],
+            ["[]-[row4]", 2, 2]
+        ])
+
 if __name__ == '__main__':
     mldb.run_tests()

--- a/testing/MLDB-2074-empty-join.py
+++ b/testing/MLDB-2074-empty-join.py
@@ -1,0 +1,53 @@
+#
+# MLDB-2074-empty-join.py
+# Francois-Michel L'Heureux, 2016-11-02
+# This file is part of MLDB. Copyright 2016 Datacratic. All rights reserved.
+#
+
+mldb = mldb_wrapper.wrap(mldb)  # noqa
+
+class Mldb2074JoinTests(MldbUnitTest):  # noqa
+
+    @classmethod
+    def setUpClass(cls):
+        ds = mldb.create_dataset({'id' : 'a', 'type' : 'sparse.mutable'})
+        ds.record_row('row1', [['one', 1, 0], ['two', 1, 0]])
+        ds.record_row('row2', [['one', 1, 0], ['two', 2, 0]])
+        ds.record_row('row3', [['one', 2, 0], ['two', 1, 0]])
+        ds.record_row('row4', [['one', 2, 0], ['two', 2, 0]])
+        ds.commit()
+
+        ds = mldb.create_dataset({'id' : 'empty', 'type' : 'sparse.mutable'})
+        ds.commit()
+
+
+    def test_left_join_constant_where(self):        
+        res = mldb.query("""
+            SELECT * FROM a
+            LEFT JOIN empty ON a.one = empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[row1]-[]", 1, 1],
+            ["[row2]-[]", 1, 2],
+            ["[row3]-[]", 2, 1],
+            ["[row4]-[]", 2, 2]
+        ])
+
+    def test_left_join_equi_pipeline(self):
+        res = mldb.query("""
+            SELECT * FROM a
+            LEFT JOIN empty ON a.one = empty.one AND a.two = empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[row1]-[]", 1, 1],
+            ["[row2]-[]", 1, 2],
+            ["[row3]-[]", 2, 1],
+            ["[row4]-[]", 2, 2]
+        ])
+
+if __name__ == '__main__':
+    mldb.run_tests()

--- a/testing/MLDB-2074-empty-join.py
+++ b/testing/MLDB-2074-empty-join.py
@@ -49,5 +49,17 @@ class Mldb2074JoinTests(MldbUnitTest):  # noqa
             ["[row4]-[]", 2, 2]
         ])
 
+    def test_left_join_equi_pipeline_reverse(self):
+        res = mldb.query("""
+            SELECT * FROM empty
+            LEFT JOIN a ON a.one = empty.one AND a.two = empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            [
+                "_rowName"
+            ]
+        ])
+
 if __name__ == '__main__':
     mldb.run_tests()

--- a/testing/MLDB-2074-empty-join.py
+++ b/testing/MLDB-2074-empty-join.py
@@ -61,5 +61,43 @@ class Mldb2074JoinTests(MldbUnitTest):  # noqa
             ]
         ])
 
+    def test_right_join_constant_where(self):        
+        res = mldb.query("""
+            SELECT * FROM a
+            RIGHT JOIN empty ON a.one = empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            [
+                "_rowName"
+            ]
+        ])
+
+    def test_right_join_equi_pipeline(self):
+        res = mldb.query("""
+            SELECT * FROM a
+            RIGHT JOIN empty ON a.one = empty.one AND a.two = empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            [
+                "_rowName"
+            ]
+        ])
+
+    def test_right_join_equi_pipeline_reverse(self):
+        res = mldb.query("""
+            SELECT * FROM empty
+            RIGHT JOIN a ON a.one = empty.one AND a.two = empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[]-[row1]", 1, 1],
+            ["[]-[row2]", 1, 2],
+            ["[]-[row3]", 2, 1],
+            ["[]-[row4]", 2, 2]
+        ])
+
 if __name__ == '__main__':
     mldb.run_tests()

--- a/testing/MLDB-2074-empty-join.py
+++ b/testing/MLDB-2074-empty-join.py
@@ -127,5 +127,56 @@ class Mldb2074JoinTests(MldbUnitTest):  # noqa
             ["[]-[row4]", 2, 2]
         ])
 
+    def test_left_join_cross_pipeline(self):
+        res = mldb.query("""
+            SELECT * FROM a
+            LEFT JOIN empty ON a.one <= empty.one AND a.two <= empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[row1]-[]", 1, 1],
+            ["[row2]-[]", 1, 2],
+            ["[row3]-[]", 2, 1],
+            ["[row4]-[]", 2, 2]
+        ])
+
+    def test_left_join_cross_pipeline_reverse(self):
+        res = mldb.query("""
+            SELECT * FROM empty
+            LEFT JOIN a ON a.one <= empty.one AND a.two <= empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            [
+                "_rowName"
+            ]
+        ])
+
+    def test_right_join_cross_pipeline(self):
+        res = mldb.query("""
+            SELECT * FROM a
+            RIGHT JOIN empty ON a.one <= empty.one AND a.two <= empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            [
+                "_rowName"
+            ]
+        ])
+    def test_right_join_cross_pipeline_reverse(self):
+        res = mldb.query("""
+            SELECT * FROM empty
+            RIGHT JOIN a ON a.one <= empty.one AND a.two <= empty.one
+            ORDER BY rowName()""")
+
+        self.assertTableResultEquals(res, [
+            ["_rowName", "a.one", "a.two"],
+            ["[]-[row1]", 1, 1],
+            ["[]-[row2]", 1, 2],
+            ["[]-[row3]", 2, 1],
+            ["[]-[row4]", 2, 2]
+        ])
+
 if __name__ == '__main__':
     mldb.run_tests()

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -449,5 +449,6 @@ $(eval $(call mldb_unit_test,deepteach_test.py,tensorflow,manual))
 $(eval $(call mldb_unit_test,post_run_and_track_procedure_test.py))
 $(eval $(call mldb_unit_test,MLDB-2022-multiple-prediction-example.js))
 $(eval $(call mldb_unit_test,MLDB-2043_tabular_big_int.py))
+$(eval $(call mldb_unit_test,MLDB-2074-empty-join.py))
 $(eval $(call mldb_unit_test,MLDB-2040_join_tests.py))
 


### PR DESCRIPTION
Create tests and fix issues for full outer joins in the pipeline executor when one of the dataset is empty.