### PR TITLE
Build for multiple CUDA architectures (MLDB-2085)

### DIFF
--- a/tensorflow/tensorflow.mk
+++ b/tensorflow/tensorflow.mk
@@ -4,9 +4,7 @@
 LIBMLDB_TENSORFLOW_PLUGIN_SOURCES:= \
 	tensorflow_plugin.cc \
 
-#	test.cu.cc
-
-$(eval $(call set_compile_option,$(LIBMLDB_TENSORFLOW_PLUGIN_SOURCES),$(TENSORFLOW_COMPILE_FLAGS) -Imldb/ext/tensorflow))
+$(eval $(call set_compile_option,$(LIBMLDB_TENSORFLOW_PLUGIN_SOURCES),$$(TENSORFLOW_COMPILE_FLAGS) -Imldb/ext/tensorflow))
 
 # Make these depend upon Tensorflow's version of the protobuf compiler
 # since the headers that they need are installed with it.


### PR DESCRIPTION
Before this patch, the Tensorflow plugin needed to be rebuilt for each GPU architecture.  Now it should work out of the box on basically any deployed server architecture (see list below).

This enables multiple architectures to be built for CUDA, and makes a default list that covers the vast majority of deployed server CUDA architectures:

```
   Compute/shader model   Cards
   6.1			  P4, P40, Titan X
   6.0                    P100
   5.2                    M40
   3.7                    K80
   3.5                    K40, K20
   3.0                    K10, Grid K520 (AWS G2)
```

It's a Makefile-only fix, and has basically no effect unless `WITH_CUDA=1` is passed.  Passes all tests on a build with that flag set.

