### PR TITLE
[MLDB-2086] passing the config to mldb_runner in debug and release

### DIFF
--- a/container_files/init/mldb_runner.sh
+++ b/container_files/init/mldb_runner.sh
@@ -20,5 +20,6 @@ exec /sbin/setuser _mldb \
         --plugin-directory {{MLDB_GLOBAL_PLUGINS_PATH}} \
         --plugin-directory {{MLDB_LOCAL_PLUGINS_PATH}} \
         --http-base-url "${HTTP_BASE_URL}" \
+        --config-path=/etc/mldb.conf \
         {{MLDB_EXTRA_FLAGS}} \
         $MLDB_RUNNER_ARGS

--- a/container_files/template_vars.mk
+++ b/container_files/template_vars.mk
@@ -9,7 +9,8 @@ export IPYTHON_NB_LISTEN_PORT = 13020
 export IPYTHON_NB_PREFIX = ipy
 export MLDB_CREDENTIALS_PATH = file://$(MLDB_DATA_DIR)/.mldb_credentials
 export MLDB_DATA_DIR = /mldb_data
-export MLDB_EXTRA_FLAGS =  # these flags will be passed as-is to the mldb_runner executable
+#extra flags that varies for release / debug build are specified in release.mk
+export MLDB_EXTRA_FLAGS = # passed as-is to the mldb_runner executable
 export MLDB_GLOBAL_PLUGINS_PATH = file:///opt/mldb/plugins
 export MLDB_LOCAL_PLUGINS_PATH = file:///mldb_data/plugins/autoload
 export MLDB_LOGFILE = /var/log/mldb_runner.log

--- a/mldb_macros.mk
+++ b/mldb_macros.mk
@@ -17,7 +17,7 @@ TEST_$(1)_SETUP := $$(if $$(findstring .py,$(1))$$(findstring virtualenv,$(3)),.
 
 # Command to actually run for the test.  Constructs the call to mldb_runner and the
 # command line options to pass to it.
-TEST_$(1)_RAW_COMMAND := $(call TEST_PRE_OPTIONS,$(3)) $$(BIN)/mldb_runner -h localhost -p '11700-12700' $$(foreach plugin,$(2),--plugin-directory file://$(PLUGINS)/$$(plugin)) --run-script $(CWD)/$(1) --mute-final-output
+TEST_$(1)_RAW_COMMAND := $(call TEST_PRE_OPTIONS,$(3)) $$(BIN)/mldb_runner -h localhost -p '11700-12700' $$(foreach plugin,$(2),--plugin-directory file://$(PLUGINS)/$$(plugin)) --run-script $(CWD)/$(1) --mute-final-output $(MLDB_EXTRA_FLAGS)
 
 # Command that is run in the shell.  This takes care of printing the right message
 # out and capturing the output in the right place.

--- a/mldb_macros.mk
+++ b/mldb_macros.mk
@@ -17,7 +17,7 @@ TEST_$(1)_SETUP := $$(if $$(findstring .py,$(1))$$(findstring virtualenv,$(3)),.
 
 # Command to actually run for the test.  Constructs the call to mldb_runner and the
 # command line options to pass to it.
-TEST_$(1)_RAW_COMMAND := $(call TEST_PRE_OPTIONS,$(3)) $$(BIN)/mldb_runner -h localhost -p '11700-12700' $$(foreach plugin,$(2),--plugin-directory file://$(PLUGINS)/$$(plugin)) --run-script $(CWD)/$(1) --mute-final-output $(MLDB_EXTRA_FLAGS)
+TEST_$(1)_RAW_COMMAND := $(call TEST_PRE_OPTIONS,$(3)) $$(BIN)/mldb_runner -h localhost -p '11700-12700' $$(foreach plugin,$(2),--plugin-directory file://$(PLUGINS)/$$(plugin)) --run-script $(CWD)/$(1) --mute-final-output --config-path mldb/container_files/mldb.conf $(MLDB_EXTRA_FLAGS)
 
 # Command that is run in the shell.  This takes care of printing the right message
 # out and capturing the output in the right place.

--- a/release.mk
+++ b/release.mk
@@ -34,8 +34,10 @@ docker_mldb: \
 
 ifdef VERSION_NAME
   # Release related flags and options
-	MLDB_EXTRA_FLAGS+= --hide-internal-entities
+	MLDB_EXTRA_FLAGS+= --hide-internal-entities --config-path=$(ETC)/service/mldb_runner/run/mldb.conf
   DOCKER_POST_INSTALL_ARGS="-s"
+else
+	MLDB_EXTRA_FLAGS+= --config-path=mldb/container_files/mldb.conf
 endif
 
 docker_mldb: \

--- a/release.mk
+++ b/release.mk
@@ -34,7 +34,7 @@ docker_mldb: \
 
 ifdef VERSION_NAME
   # Release related flags and options
-	MLDB_EXTRA_FLAGS+= --hide-internal-entities --config-path=$(ETC)/service/mldb_runner/run/mldb.conf
+	MLDB_EXTRA_FLAGS+= --hide-internal-entities --config-path=$(ETC)/mldb.conf
   DOCKER_POST_INSTALL_ARGS="-s"
 else
 	MLDB_EXTRA_FLAGS+= --config-path=mldb/container_files/mldb.conf

--- a/release.mk
+++ b/release.mk
@@ -34,10 +34,8 @@ docker_mldb: \
 
 ifdef VERSION_NAME
   # Release related flags and options
-	MLDB_EXTRA_FLAGS+= --hide-internal-entities --config-path=$(ETC)/mldb.conf
+	MLDB_EXTRA_FLAGS+= --hide-internal-entities
   DOCKER_POST_INSTALL_ARGS="-s"
-else
-	MLDB_EXTRA_FLAGS+= --config-path=mldb/container_files/mldb.conf
 endif
 
 docker_mldb: \

--- a/server/mldb_runner.cc
+++ b/server/mldb_runner.cc
@@ -23,6 +23,7 @@
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/variables_map.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/exception/diagnostic_information.hpp> 
 #include <signal.h>
 
 
@@ -205,11 +206,17 @@ int main(int argc, char ** argv)
 
     variables_map vm;
     // command line has precendence over config
-    store(command_line_parser(argc, argv)
-          .options(all_opt)
-          //.positional(p)
-          .run(),
-          vm);
+    try {
+        store(command_line_parser(argc, argv)
+              .options(all_opt)
+              //.positional(p)
+              .run(),
+              vm);
+    }
+    catch (const boost::exception & exc) {
+        cerr << boost::diagnostic_information(exc) << endl;
+        return 1;
+    }
 
     notify(vm);
 

--- a/templated_files.mk
+++ b/templated_files.mk
@@ -10,7 +10,7 @@ $(eval $(call mldb_install_templated_directory,mldb/container_files/public_html/
 
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/05-mldb-id-mapping.sh,$(ETC)/my_init.d/05-mldb-id-mapping.sh,555))
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/mldb_runner.sh,$(ETC)/service/mldb_runner/run,555))
-$(eval $(call mldb_install_templated_file,mldb/container_files/mldb.conf,$(ETC)/service/mldb_runner/run,664))
+$(eval $(call mldb_install_templated_file,mldb/container_files/mldb.conf,$(ETC),0664))
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/nginx_runner.sh,$(ETC)/service/nginx/run,555))
 $(eval $(call mldb_install_templated_file,mldb/container_files/mldb_nginx_site.conf,$(ETC)/nginx/sites-enabled/mldb))
 $(eval $(call mldb_install_templated_file,mldb/container_files/nginx.conf,$(ETC)/nginx/nginx.conf))

--- a/templated_files.mk
+++ b/templated_files.mk
@@ -10,6 +10,7 @@ $(eval $(call mldb_install_templated_directory,mldb/container_files/public_html/
 
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/05-mldb-id-mapping.sh,$(ETC)/my_init.d/05-mldb-id-mapping.sh,555))
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/mldb_runner.sh,$(ETC)/service/mldb_runner/run,555))
+$(eval $(call mldb_install_templated_file,mldb/container_files/mldb.conf,$(ETC)/service/mldb_runner/run,664))
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/nginx_runner.sh,$(ETC)/service/nginx/run,555))
 $(eval $(call mldb_install_templated_file,mldb/container_files/mldb_nginx_site.conf,$(ETC)/nginx/sites-enabled/mldb))
 $(eval $(call mldb_install_templated_file,mldb/container_files/nginx.conf,$(ETC)/nginx/nginx.conf))

--- a/templated_files.mk
+++ b/templated_files.mk
@@ -10,7 +10,7 @@ $(eval $(call mldb_install_templated_directory,mldb/container_files/public_html/
 
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/05-mldb-id-mapping.sh,$(ETC)/my_init.d/05-mldb-id-mapping.sh,555))
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/mldb_runner.sh,$(ETC)/service/mldb_runner/run,555))
-$(eval $(call mldb_install_templated_file,mldb/container_files/mldb.conf,$(ETC),0664))
+$(eval $(call mldb_install_templated_file,mldb/container_files/mldb.conf,$(ETC)/mldb.conf,0644))
 $(eval $(call mldb_install_templated_file,mldb/container_files/init/nginx_runner.sh,$(ETC)/service/nginx/run,555))
 $(eval $(call mldb_install_templated_file,mldb/container_files/mldb_nginx_site.conf,$(ETC)/nginx/sites-enabled/mldb))
 $(eval $(call mldb_install_templated_file,mldb/container_files/nginx.conf,$(ETC)/nginx/nginx.conf))


### PR DESCRIPTION
- passing the mldb.conf when doing make <test> to allow logging
- storing the mldb.conf in the docker image and passing it to mldb_runner
- fix a crash when failing to parse the command line