### PR TITLE
Band aid: MLDB-2065 prevents segfault on nullptr over transposed ds

### DIFF
--- a/builtin/transposed_dataset.cc
+++ b/builtin/transposed_dataset.cc
@@ -50,8 +50,14 @@ struct TransposedDataset::Itl
     std::shared_ptr<ColumnIndex> index;
     size_t columnCount;
 
+    static const shared_ptr<Dataset> & testDatasetPtr(const shared_ptr<Dataset> & dataset)
+    {
+        ExcAssert(dataset);
+        return dataset;
+    }
+
     Itl(MldbServer * server, std::shared_ptr<Dataset> dataset)
-        : dataset(dataset),
+        : dataset(testDatasetPtr(dataset)),
           matrix(dataset->getMatrixView()),
           index(dataset->getColumnIndex()),
           columnCount(dataset->getFlattenedColumnCount())


### PR DESCRIPTION
At least it prevents MLDB to segfault.