### PR TITLE
Allow customization of Eigen kernel launch failure behavior (MLDB-2115)

### DIFF
--- a/ext/tensorflow.mk
+++ b/ext/tensorflow.mk
@@ -222,7 +222,18 @@ TENSORFLOW_CUDA_NVCC_BUILD:=$(sort $(TENSORFLOW_CUDA_NVCC_FILES:$(CWD)/%=%))
 # - EIGEN_HAS_VARIADIC_TEMPLATES is required for cross-compiling, where
 #   Eigen disables needed std::initializer_list constructors in its arrays
 #   because it doesn't properly detect that this feature is available
-TENSORFLOW_COMMON_CUDA_FLAGS=-DGOOGLE_CUDA=1 -I$(CUDA_BASE_DIR)/include -DEIGEN_AVOID_STL_ARRAY=1 -DTF_EXTRA_CUDA_CAPABILITIES=$(TF_CUDA_CAPABILITIES) -DEIGEN_HAS_VARIADIC_TEMPLATES=1 -I$(INC)/third_party/gpus
+# - -DEigenCudaErrorFunctionDeclaration,-DcheckForCudaSuccess are to
+#   install a custom error handler that doesn't crash MLDB on a transient
+#   CUDA failure
+TENSORFLOW_COMMON_CUDA_FLAGS=\
+	-DGOOGLE_CUDA=1 \
+	-I$(CUDA_BASE_DIR)/include \
+	-DTF_EXTRA_CUDA_CAPABILITIES=$(TF_CUDA_CAPABILITIES) \
+	-DEIGEN_AVOID_STL_ARRAY=1 \
+	-DEIGEN_HAS_VARIADIC_TEMPLATES=1 \
+	-DEigenCudaErrorFunctionDeclaration="void mldbCheckForCudaSuccess(cudaError_t);" \
+	-DcheckForCudaSuccess="mldbCheckForCudaSuccess" \
+	-I$(INC)/third_party/gpus 
 
 # Here are the flags we need to pass to NVCC to compile TensorFlow's CUDA
 # files.
@@ -311,15 +322,15 @@ TENSORFLOW_CC_BUILD:=$(sort $(TENSORFLOW_CC_FILES:$(CWD)/%=%))
 
 # We need to set up include paths and turn off a bunch of warnings.  Most of
 # them are triggered by the (3rd party) Eigen library.
-$(eval $(call set_compile_option,$(TENSORFLOW_CC_BUILD) $(TENSORFLOW_PROTOBUF_BUILD),$$(TENSORFLOW_COMPILE_FLAGS)))
+$(eval $(call set_compile_option,$(TENSORFLOW_CC_BUILD) $(TENSORFLOW_PROTOBUF_BUILD) ../tf_cuda_handlers.cc,$$(TENSORFLOW_COMPILE_FLAGS)))
 
 # Libraries that the core of TensorFlow relies on.  We need the CUDA
 # libraries, if support is included, since the core includes the
 # functionality to set up the CUDA support.
-TENSORFLOW_CORE_LINK := protobuf3 re2 png jpeg farmhash giflib $(TENSORFLOW_CUDA_LINK)
+TENSORFLOW_CORE_LINK := protobuf3 re2 png jpeg farmhash giflib $(TENSORFLOW_CUDA_LINK) http
 
 # Finally, build a library with the tensorflow functionality inside
-$(eval $(call library,tensorflow-core,$(TENSORFLOW_CC_BUILD) $(TENSORFLOW_PROTOBUF_BUILD),$(TENSORFLOW_CORE_LINK),,,,,$(TENSORFLOW_CUDA_LINKER_FLAGS)))
+$(eval $(call library,tensorflow-core,$(TENSORFLOW_CC_BUILD) $(TENSORFLOW_PROTOBUF_BUILD) $(if $(WITH_CUDA),../tf_cuda_handlers.cc),$(TENSORFLOW_CORE_LINK),,,,,$(TENSORFLOW_CUDA_LINKER_FLAGS)))
 
 
 # Part of the C++ interface to TensorFlow is created using an automatic

--- a/ext/tf_cuda_handlers.cc
+++ b/ext/tf_cuda_handlers.cc
@@ -1,0 +1,26 @@
+/** tf_cuda_handlers.cc
+    Jeremy Barnes, 17 January 2017
+    Copyright (c) 2017 mldb.ai Inc.  All rights reserved.
+
+*/
+
+#include "mldb/http/http_exception.h"
+#include <cuda_runtime.h>
+
+using namespace MLDB;
+
+// When Eigen launches a CUDA kernel, it will call this function
+// to check if the kernel succeeded or not.  We override the
+// default behaviour of crashing the entire program here, as there
+// are transient events that cause failures temporarily (eg too
+// many jobs submitted in parallel) that can be retried; crashing
+// leads to a very poor user experience.
+void mldbCheckForCudaSuccess(cudaError_t status)
+{
+    if (status == cudaSuccess)
+        return;
+
+    throw HttpReturnException(500, "CUDA kernel launch error: "
+                              + std::string(cudaGetErrorName(status))
+                              + std::string(cudaGetErrorString(status)));
+}


### PR DESCRIPTION
Modifies the default behaviour from assert() to throw so that a CUDA launch failure is recoverable.  This requires a change to the Eigen library too (behind the submodule).
