### PR TITLE
Made libgit2 an internal dependency fixing several portability errors and crashes (MLDB-2024)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,6 @@
 [submodule "ext/easyexif"]
 	path = ext/easyexif
 	url = https://github.com/mldbai/easyexif.git
+[submodule "ext/libgit2"]
+	path = ext/libgit2
+	url = https://github.com/mldbai/libgit2.git

--- a/Building.md
+++ b/Building.md
@@ -22,7 +22,6 @@ apt-get install -y \
   libcurl4-openssl-dev \
   libffi-dev \
   libfreetype6-dev \
-  libgit2-dev \
   libgoogle-perftools-dev \
   liblapack-dev \
   liblzma-dev \

--- a/ext/ext.mk
+++ b/ext/ext.mk
@@ -24,3 +24,4 @@ $(eval $(call include_sub_make,s2,s2-geometry-library/geometry,../../s2.mk))
 EASYEXIF_CC_FILES:= easyexif/exif.cpp
 $(eval $(call set_compile_option,$(EASYEXIF_CC_FILES),$(EASYEXIF_WARNING_OPTIONS)))
 $(eval $(call library,easyexif,$(EASYEXIF_CC_FILES)))
+$(eval $(call include_sub_make,libgit2,libgit2,../libgit2.mk))

--- a/ext/libgit2.mk
+++ b/ext/libgit2.mk
@@ -1,0 +1,167 @@
+LIBGIT2_FILES := $(wildcard ext/libgit2/src/*.c ext/libgit2/src/*/*.c)
+LIBGIT2_SOURCE:=$(LIBGIT2_FILES:ext/libgit2/%=%)
+$(warning LIBGIT2_SOURCE=$(LIBGIT2_SOURCE))
+
+LIBGIT2_SOURCE:= \
+	src/annotated_commit.c \
+	src/apply.c \
+	src/attr.c \
+	src/attrcache.c \
+	src/attr_file.c \
+	src/blame.c \
+	src/blame_git.c \
+	src/blob.c \
+	src/branch.c \
+	src/buffer.c \
+	src/buf_text.c \
+	src/cache.c \
+	src/checkout.c \
+	src/cherrypick.c \
+	src/clone.c \
+	src/commit.c \
+	src/commit_list.c \
+	src/config.c \
+	src/config_cache.c \
+	src/config_file.c \
+	src/crlf.c \
+	src/curl_stream.c \
+	src/date.c \
+	src/delta.c \
+	src/describe.c \
+	src/diff.c \
+	src/diff_driver.c \
+	src/diff_file.c \
+	src/diff_generate.c \
+	src/diff_parse.c \
+	src/diff_print.c \
+	src/diff_stats.c \
+	src/diff_tform.c \
+	src/diff_xdiff.c \
+	src/errors.c \
+	src/fetch.c \
+	src/fetchhead.c \
+	src/filebuf.c \
+	src/fileops.c \
+	src/filter.c \
+	src/fnmatch.c \
+	src/global.c \
+	src/graph.c \
+	src/hash.c \
+	src/hashsig.c \
+	src/ident.c \
+	src/ignore.c \
+	src/index.c \
+	src/indexer.c \
+	src/iterator.c \
+	src/merge.c \
+	src/merge_driver.c \
+	src/merge_file.c \
+	src/message.c \
+	src/mwindow.c \
+	src/netops.c \
+	src/notes.c \
+	src/object_api.c \
+	src/object.c \
+	src/odb.c \
+	src/odb_loose.c \
+	src/odb_mempack.c \
+	src/odb_pack.c \
+	src/oidarray.c \
+	src/oid.c \
+	src/openssl_stream.c \
+	src/pack.c \
+	src/pack-objects.c \
+	src/patch.c \
+	src/patch_generate.c \
+	src/patch_parse.c \
+	src/path.c \
+	src/pathspec.c \
+	src/pool.c \
+	src/posix.c \
+	src/pqueue.c \
+	src/proxy.c \
+	src/push.c \
+	src/rebase.c \
+	src/refdb.c \
+	src/refdb_fs.c \
+	src/reflog.c \
+	src/refs.c \
+	src/refspec.c \
+	src/remote.c \
+	src/repository.c \
+	src/reset.c \
+	src/revert.c \
+	src/revparse.c \
+	src/revwalk.c \
+	src/settings.c \
+	src/sha1_lookup.c \
+	src/signature.c \
+	src/socket_stream.c \
+	src/sortedcache.c \
+	src/stash.c \
+	src/status.c \
+	src/stransport_stream.c \
+	src/strmap.c \
+	src/submodule.c \
+	src/sysdir.c \
+	src/tag.c \
+	src/thread-utils.c \
+	src/tls_stream.c \
+	src/trace.c \
+	src/transaction.c \
+	src/transport.c \
+	src/tree.c \
+	src/tree-cache.c \
+	src/tsort.c \
+	src/util.c \
+	src/varint.c \
+	src/vector.c \
+	src/zstream.c \
+	src/transports/auth.c \
+	src/transports/auth_negotiate.c \
+	src/transports/cred.c \
+	src/transports/cred_helpers.c \
+	src/transports/git.c \
+	src/transports/http.c \
+	src/transports/local.c \
+	src/transports/smart.c \
+	src/transports/smart_pkt.c \
+	src/transports/smart_protocol.c \
+	src/transports/ssh.c \
+	src/transports/winhttp.c \
+	src/unix/map.c \
+	src/unix/realpath.c \
+	src/xdiff/xdiffi.c \
+	src/xdiff/xemit.c \
+	src/xdiff/xhistogram.c \
+	src/xdiff/xmerge.c \
+	src/xdiff/xpatience.c \
+	src/xdiff/xprepare.c \
+	src/xdiff/xutils.c \
+	deps/http-parser/http_parser.c \
+
+#	src/win32/dir.c \
+	src/win32/error.c \
+	src/win32/findfile.c \
+	src/win32/map.c \
+	src/win32/path_w32.c \
+	src/win32/posix_w32.c \
+	src/win32/precompiled.c \
+	src/win32/thread.c \
+	src/win32/utf-conv.c \
+	src/win32/w32_buffer.c \
+	src/win32/w32_crtdbg_stacktrace.c \
+	src/win32/w32_stack.c \
+	src/win32/w32_util.c \
+	src/hash/hash_win32.c \
+
+# 	src/hash/hash_generic.c \
+
+
+# NOTE: to find this, run cmake in the ext/libgit2 directory, and then look at
+# CMakeFIles/git2.dir/flags.make to find the ones required.
+LIBGIT2_DEFINES:=-D_GNU_SOURCE -DGIT_ARCH_64 -DGIT_CURL -DGIT_OPENSSL -DGIT_SSH -DGIT_THREADS -DGIT_USE_NSEC -DGIT_USE_STAT_MTIM -DHAVE_FUTIMENS -DHAVE_QSORT_R -DOPENSSL_SHA1 -D_FILE_OFFSET_BITS=64 -Dgit2_EXPORTS
+
+$(eval $(call set_compile_option,$(LIBGIT2_SOURCE),-Imldb/ext/libgit2/include -Imldb/ext/libgit2/src -Imldb/ext/libgit2/deps/http-parser $(LIBGIT2_DEFINES)))
+
+$(eval $(call library,git2,$(LIBGIT2_SOURCE)))

--- a/mldb_base/docker_create_mldb_base.sh
+++ b/mldb_base/docker_create_mldb_base.sh
@@ -84,7 +84,6 @@ apt-get install -y \
     libcurl3 \
     libssh2-1 \
     libpython2.7 \
-    libgit2-0 \
     libicu52 \
     liblapack3 \
     libblas3 \

--- a/plugins/git.cc
+++ b/plugins/git.cc
@@ -20,96 +20,11 @@
 #include "mldb/http/http_exception.h"
 #include "mldb/utils/log.h"
 
-#include <git2.h>
-#include <git2/revwalk.h>
-#include <git2/commit.h>
-#include <git2/diff.h>
+#include "mldb/ext/libgit2/include/git2.h"
+#include "mldb/ext/libgit2/include/git2/revwalk.h"
+#include "mldb/ext/libgit2/include/git2/commit.h"
+#include "mldb/ext/libgit2/include/git2/diff.h"
 
-#define LIBGIT2_INT_VERSION (LIBGIT2_VER_MAJOR * 10000 \
-                             + LIBGIT2_VER_MINOR * 100 \
-                             + LIBGIT2_VER_REVISION)
-
-/* libgit2 renamed a bunch of functions and defines between 0.19 and 0.22
- * We do the mapping here so the code below works on both versions
- */
-#if LIBGIT2_INT_VERSION < 2200
-#define git_libgit2_init git_threads_init
-#define git_libgit2_shutdown git_threads_shutdown
-#define git_checkout_options git_checkout_opts
-#define git_diff git_diff_list
-#define GIT_CHECKOUT_OPTIONS_INIT GIT_CHECKOUT_OPTS_INIT
-#define GIT_EUNBORNBRANCH GIT_EORPHANEDHEAD
-
-struct git_diff_stats {
-    git_diff_stats()
-        : files_changed(0), insertions(0), deletions(0)
-    {
-    }
-
-    size_t files_changed;
-    size_t insertions;
-    size_t deletions;
-};
-
-void git_diff_stats_free(git_diff_stats * stats)
-{
-    delete stats;
-}
-
-int stats_each_file_cb(const git_diff_delta *delta,
-                       float progress,
-                       void *payload)
-{
-    git_diff_stats * stats = (git_diff_stats *)payload;
-    ++stats->files_changed;
-    return 0;
-}
-
-int stats_each_hunk_cb(const git_diff_delta *delta,
-                       const git_diff_range *hunk,
-                       const char *header,
-                       size_t header_len,
-                       void *payload)
-{
-    git_diff_stats * stats = (git_diff_stats *)payload;
-    stats->insertions += hunk->new_lines;
-    stats->deletions += hunk->old_lines;
-    return 0;
-}
-
-int git_diff_get_stats(git_diff_stats **out, git_diff *diff)
-{
-    *out = new git_diff_stats();
-
-    int error = git_diff_foreach(diff,
-                                 stats_each_file_cb,
-                                 stats_each_hunk_cb,
-                                 nullptr,
-                                 *out);
-
-    if (error < 0) {
-        delete *out;
-        *out = 0;
-    }
-
-    return error;
-}
-
-
-size_t git_diff_stats_insertions(const git_diff_stats *stats)
-{
-    return stats->insertions;
-}
-
-size_t git_diff_stats_deletions(const git_diff_stats *stats)
-{
-    return stats->deletions;
-}
-
-size_t git_diff_stats_files_changed(const git_diff_stats *stats)
-{
-    return stats->files_changed;
-}
 
 struct GitFileOperation {
     GitFileOperation()
@@ -174,9 +89,7 @@ int stats_by_file_each_file_cb(const git_diff_delta *delta,
 }
 
 int stats_by_file_each_hunk_cb(const git_diff_delta *delta,
-                               const git_diff_range *hunk,
-                               const char *header,
-                               size_t header_len,
+                               const git_diff_hunk * hunk,
                                void *payload)
 {
     GitFileStats & stats = *((GitFileStats *)payload);
@@ -195,8 +108,9 @@ GitFileStats git_diff_by_file(git_diff *diff)
 
     int error = git_diff_foreach(diff,
                                  stats_by_file_each_file_cb,
+                                 nullptr,  /* binary callback */
                                  stats_by_file_each_hunk_cb,
-                                 nullptr,
+                                 nullptr, /* line callback */
                                  &result);
 
     if (error < 0) {
@@ -206,10 +120,6 @@ GitFileStats git_diff_by_file(git_diff *diff)
 
     return result;
 }
-
-
-#endif
-
 
 using namespace std;
 
@@ -331,7 +241,7 @@ struct GitImporter: public Procedure {
         const git_signature *author    = git_commit_author(commit);
         //const git_oid *tree_id         = git_commit_tree_id(commit);
         git_diff *diff = nullptr;
-        Scope_Exit(git_diff_list_free(diff));
+        Scope_Exit(git_diff_free(diff));
 
         Utf8String message;
         if (!encoding || strcmp(encoding, "UTF-8") == 0) {

--- a/server/plugin_resource.cc
+++ b/server/plugin_resource.cc
@@ -8,26 +8,10 @@
 
 #include "mldb/server/plugin_resource.h"
 
-#include <git2.h>
-#include <git2/clone.h>
+#include "mldb/ext/libgit2/include/git2.h"
+#include "mldb/ext/libgit2/include/git2/clone.h"
 #include "mldb/types/structure_description.h"
 #include "mldb/vfs/filter_streams.h"
-
-#define LIBGIT2_INT_VERSION (LIBGIT2_VER_MAJOR * 10000 \
-                             + LIBGIT2_VER_MINOR * 100 \
-                             + LIBGIT2_VER_REVISION)
-
-/* libgit2 renamed a bunch of functions and defines between 0.19 and 0.22
- * We do the mapping here so the code below works on both versions
- */
-#if LIBGIT2_INT_VERSION < 2200
-#define git_libgit2_init git_threads_init
-#define git_libgit2_shutdown git_threads_shutdown
-#define git_checkout_options git_checkout_opts
-#define GIT_CHECKOUT_OPTIONS_INIT GIT_CHECKOUT_OPTS_INIT
-#define GIT_EUNBORNBRANCH GIT_EORPHANEDHEAD
-#endif
-
 
 using namespace std;
 
@@ -256,7 +240,7 @@ LoadedPluginResource(ScriptLanguage lang, ScriptType type,
         git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
         git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
 
-        checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE_CREATE;
+        checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
         //   checkout_opts.progress_cb = checkout_progress;
         clone_opts.checkout_opts = checkout_opts;
         //   clone_opts.remote_callbacks.transfer_progress = &fetch_progress;


### PR DESCRIPTION
Adds submodule, build Makefile, and cleans up all of the version dependent code.

This means that mldb_runner's core can now be deployed on several more versions of Debian, as the libgit2 API is not frozen.

It also fixes an occasional segfault in the test cases caused by a bug in the 14.10 system version of libgit2.
