### PR TITLE
Lower curl connect(2) timeout from 300s to 20s

### DIFF
--- a/http/http_rest_proxy.cc
+++ b/http/http_rest_proxy.cc
@@ -336,7 +336,9 @@ perform(const std::string & verb,
         if (timeout != -1)
             myRequest.add_option(CURLOPT_TIMEOUT, timeout);
         else myRequest.add_option(CURLOPT_TIMEOUT, 0L);
+
         myRequest.add_option(CURLOPT_NOSIGNAL, 1L);
+        myRequest.add_option(CURLOPT_CONNECTTIMEOUT, 20L);
 
         if (abortOnSlowConnection) {
             // abortOnSlowConnection SPECIFICATION *** /


### PR DESCRIPTION
This allows for ~3 SYN retransmits on a default linux config.

The idea is to avoid being stuck in connect(2) for too long while still
having a chance of success when going through flaky networks.

The timeout value is not configurable, but I think it is a "saner default" than 5 minutes.
(and you should probably fix your network if you need a higher value).

For the record, nginx's proxy_pass module uses a 60s connect timeout.