### PR TITLE
[MLDB-2123] Updated svdlibc to 1.4 by backporting changes

### DIFF
--- a/ext/svdlibc/doc/svdlibc/index.html
+++ b/ext/svdlibc/doc/svdlibc/index.html
@@ -5,18 +5,20 @@
 
 <center>
 <h1>SVDLIBC</h1>
-<h3>Doug Rohde's SVD C Library</h3>
-<h3>version 1.34</h3>
+<h3>A C Library for Computing Singular Value Decompositions</h3>
+<h3>version 1.4</h3>
 </center>
 <hr>
 
-SVDLIBC is a C library based on the <a
+SVDLIBC is a C library written by Doug Rohde.  It was based on the <a
 href="http://www.netlib.org/svdpack/">SVDPACKC</a> library, which was written
 by Michael Berry, Theresa Do, Gavin O'Brien, Vijay Krishna and Sowmini
-Varadhan.  SVDLIBC offers a cleaned-up version of the code with a sane library
+Varadhan at the University of Tennessee.  <b>SVDLIBC is made available <a href="license.html">under a BSD License.</a></b>
+
+<p>SVDLIBC offers a cleaned-up version of the code with a new library
 interface and a front-end executable that performs matrix file type
 conversions, along with computing singular value decompositions.  Currently
-the only SVDPACKC algorithm implemented is
+the only SVDPACKC algorithm implemented in SVDLIBC is
 <b>las2</b>, because it seems to be consistently the fastest.  This algorithm
 has the drawback that the low order singular values may be relatively
 imprecise, but that is not a problem for most users who only want the
@@ -188,6 +190,13 @@ SVDPACKC.</a>
 <h3>Version Notes</h3>
 
 <table>
+<tr><td valign=top><b>1.4</b>
+<td><ul>
+<li> Added BSD License
+<li> Incorporated bug fixes by piskvorky, <a href="https://github.com/lucasmaystre/svdlibc/commit/9d0f04b32f6e4c806f2b51127e846bdee8d24f42">reported here</a>.
+<li> Fixed some gcc compiler warnings.
+</ul>
+
 <tr><td valign=top><b>1.34</b>
 <td><ul>
 <li> Worked around a gcc optimizer bug that was reordering statements in the

--- a/ext/svdlibc/doc/svdlibc/license.html
+++ b/ext/svdlibc/doc/svdlibc/license.html
@@ -1,0 +1,36 @@
+<html>
+<title>SVDLIBC License</title>
+<body>
+<i>The following BSD License applies to all SVDLIBC source code and documentation:</i><p>
+
+Copyright &copy; 2002, University of Tennessee Research Foundation.
+<br>All rights reserved.
+<p>
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+<p>
+<ul>
+<li> Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+<li> Neither the name of the University of Tennessee nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+</ul>
+<p>
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+</html></body>

--- a/ext/svdlibc/svdlib.cc
+++ b/ext/svdlibc/svdlib.cc
@@ -1,3 +1,34 @@
+/*
+Copyright © 2002, University of Tennessee Research Foundation.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the University of Tennessee nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "svdlib.h"
@@ -10,7 +41,7 @@
 
 using namespace std;
 
-const char *SVDVersion = "1.34";
+const char *SVDVersion = "1.4";
 long SVDVerbosity = 1;
 long SVDCount[SVD_COUNTERS];
 

--- a/ext/svdlibc/svdlib.h
+++ b/ext/svdlibc/svdlib.h
@@ -1,5 +1,36 @@
 /* -*- C++ -*- */
 
+/*
+Copyright © 2002, University of Tennessee Research Foundation.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the University of Tennessee nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
 #ifndef SVDLIB_H
 #define SVDLIB_H
 

--- a/ext/svdlibc/svdutil.cc
+++ b/ext/svdlibc/svdutil.cc
@@ -1,3 +1,34 @@
+/*
+Copyright © 2002, University of Tennessee Research Foundation.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the University of Tennessee nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/ext/svdlibc/svdutil.h
+++ b/ext/svdlibc/svdutil.h
@@ -1,5 +1,36 @@
 /* -*- C++ -*- */
 
+/*
+Copyright © 2002, University of Tennessee Research Foundation.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the University of Tennessee nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
 #ifndef SVDUTIL_H
 #define SVDUTIL_H
 


### PR DESCRIPTION
We had a modified version of 1.34. I backported remote changes from version 1.4 into our copy.

This shows the remote changes cleanly: https://github.com/lucasmaystre/svdlibc/commit/0abfaf8da00ed14f2e275bb4435ca0844f89f936