### PR TITLE
switch quay.io organization to mldb

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -173,11 +173,11 @@ docker exec -t -i CONTAINER_ID|CONTAINER_NAME /bin/bash
 
 The `mldb` docker is built on top of a few base images:
 
-  - `quay.io/datacratic/mldb_base:14.04`
-  - `quay.io/datacratic/baseimage:0.9.17`
+  - `quay.io/mldb/mldb_base:14.04`
+  - `quay.io/mldb/baseimage:0.9.17`
 
 Some warnings:
-* you will not be able to push to quay.io/datacratic unless you are a Datacratic employee
+* you will not be able to push to quay.io/mldb unless you are a MLDB.ai employee
 * if you need to rebuild a layer, you must rebuild all layers which depend on it. (all the ones above it)
 * the build is done from the top level of the mldb repo
 * The build process will build whatever is in the current workspace.
@@ -186,7 +186,7 @@ Some warnings:
 * **Note that there is no versioning of the resulting images at the moment**
 
 
-### `quay.io/datacratic/mldb_base`
+### `quay.io/mldb/mldb_base`
 
 This layer is built on top of `baseimage`, it contains all the required system packages and python modules to run the `mldb` layer.
 A change to any of these would require a rebuild of this image:
@@ -200,14 +200,14 @@ A change to any of these would require a rebuild of this image:
 To rebuild this layer, run:
 
 ```
-make mldb_base IMG_NAME=quay.io/datacratic/mldb_base:YOUR_NEW_TAG
+make mldb_base IMG_NAME=quay.io/mldb/mldb_base:YOUR_NEW_TAG
 
-make docker_mldb DOCKER_BASE_IMAGE=quay.io/datacratic/mldb_base:YOUR_NEW_TAG
+make docker_mldb DOCKER_BASE_IMAGE=quay.io/mldb/mldb_base:YOUR_NEW_TAG
 # When convinced things are ok:
-docker tag quay.io/datacratic/mldb_base:YOUR_NEW_TAG quay.io/datacratic/mldb_base:vYYYY.MM.DD.0
-docker tag quay.io/datacratic/mldb_base:YOUR_NEW_TAG quay.io/datacratic/mldb_base:14.04
-docker push quay.io/datacratic/mldb_base:vYYYY.MM.DD.0
-docker push quay.io/datacratic/mldb_base:14.04
+docker tag quay.io/mldb/mldb_base:YOUR_NEW_TAG quay.io/mldb/mldb_base:vYYYY.MM.DD.0
+docker tag quay.io/mldb/mldb_base:YOUR_NEW_TAG quay.io/mldb/mldb_base:14.04
+docker push quay.io/mldb/mldb_base:vYYYY.MM.DD.0
+docker push quay.io/mldb/mldb_base:14.04
 ```
 
 The script used to build this layer is `mldb_base/docker_create_mldb_base.sh`
@@ -217,12 +217,12 @@ Some switches are available if you need to do a custom build of that layer for s
 ```
 docker_create_mldb_base.sh [-b base_image] [-i image_name] [-w pip_wheelhouse_url]
 
-    -b base_image               Base image to use (quay.io/datacratic/baseimage:0.9.17)
-    -i image_name               Name of the resulting image (quay.io/datacratic/mldb_base:14.04)
+    -b base_image               Base image to use (quay.io/mldb/baseimage:0.9.17)
+    -i image_name               Name of the resulting image (quay.io/mldb/mldb_base:14.04)
     -w pip_wheelhouse_url       URL to use a a pip wheelhouse
 ```
 
-### `quay.io/datacratic/baseimage:0.9.17`
+### `quay.io/mldb/baseimage:0.9.17`
 
 This image is a fork of `phusion/baseimage:0.9.17` rebuilt to have the latest packages updates.
 This image contains the base ubuntu packages and a custom init system.
@@ -237,8 +237,8 @@ To do so, run the following commands from the top of the mldb repo:
 ```
 docker pull ubuntu:14.04
 make baseimage
-docker tag quay.io/datacratic/baseimage:0.9.17 quay.io/datacratic/baseimage:latest
-docker push quay.io/datacratic/baseimage:latest
+docker tag quay.io/mldb/baseimage:0.9.17 quay.io/mldb/baseimage:latest
+docker push quay.io/mldb/baseimage:latest
 ```
 
 ## S3 Credentials

--- a/Building.md
+++ b/Building.md
@@ -177,7 +177,7 @@ The `mldb` docker is built on top of a few base images:
   - `quay.io/mldb/baseimage:0.9.17`
 
 Some warnings:
-* you will not be able to push to quay.io/mldb unless you are a MLDB.ai employee
+* you will not be able to push to quay.io/mldb unless you are a mldb.ai employee
 * if you need to rebuild a layer, you must rebuild all layers which depend on it. (all the ones above it)
 * the build is done from the top level of the mldb repo
 * The build process will build whatever is in the current workspace.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCUMENTATION_ENABLED:=1
 TCMALLOC_ENABLED?=1
 
 DOCKER_REGISTRY:=quay.io/
-DOCKER_USER:=datacratic/
+DOCKER_USER:=mldb/
 
 # Shim for the 14.04 migration
 DIST_CODENAME:=$(shell lsb_release -sc)

--- a/container_files/nvidia/Dockerfile
+++ b/container_files/nvidia/Dockerfile
@@ -2,7 +2,7 @@
 # See README.md for notes on building this image
 #
 
-FROM quay.io/datacratic/mldb_base:14.04
+FROM quay.io/mldb/mldb_base:14.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 ADD files/cuda-repo-ubuntu1404-8-0-local_8.0.44-1_amd64.deb \

--- a/container_files/nvidia/README.md
+++ b/container_files/nvidia/README.md
@@ -18,9 +18,9 @@ Requirements
 
 ### mldb_base
 
-This baseimage should is built on top of `quay.io/datacratic/mldb_base`.
+This baseimage should is built on top of `quay.io/mldb/mldb_base`.
 
-Make sure it exists before trying to build. (`docker pull quay.io/datacratic/mldb_base:14.04`)
+Make sure it exists before trying to build. (`docker pull quay.io/mldb/mldb_base:14.04`)
 
 ### NVIDIA packages
 
@@ -40,17 +40,17 @@ Put these 3 files in the `container_files/nvidia/files` directory.
 Run `docker build` from the `container_files/nvidia` directory as follows,  changing `TAG` for something useful:
 
 ```
-docker build -t quay.io/datacratic/mldb_base_nvidia:TAG -f ./Dockerfile  .
+docker build -t quay.io/mldb/mldb_base_nvidia:TAG -f ./Dockerfile  .
 
 # To reduce the image size we can squash (flatten, merge) the docker image
-virtualenv/bin/docker-squash -t quay.io/datacratic/mldb_base_nvidia:TAG.squashed quay.io/datacratic/mldb_base_nvidia:TAG
+virtualenv/bin/docker-squash -t quay.io/mldb/mldb_base_nvidia:TAG.squashed quay.io/mldb/mldb_base_nvidia:TAG
 ```
 
 
 ### Building MLDB docker based on this image
 
 ```
-nice make -j $(nproc) docker_mldb WITH_CUDA=1 DOCKER_POST_INSTALL_ARGS=-s DOCKER_BASE_IMAGE=quay.io/datacratic/mldb_base_nvidia:TAG.squashed
+nice make -j $(nproc) docker_mldb WITH_CUDA=1 DOCKER_POST_INSTALL_ARGS=-s DOCKER_BASE_IMAGE=quay.io/mldb/mldb_base_nvidia:TAG.squashed
 ```
 
 Running MLDB with GPUs
@@ -66,7 +66,7 @@ docker run [... usual arguments ...] \
     --device=/dev/nvidia0:/dev/nvidia0 \
     --device=/dev/nvidiactl:/dev/nvidiactl \
     --device=/dev/nvidia-uvm:/dev/nvidia-uvm \
-    quay.io/datacratic/mldb:YOUR_MLDB_TAG
+    quay.io/mldb/mldb:YOUR_MLDB_TAG
 ```
 
 *Multiple GPUs can be mounted into the container by passing multiple `--dev /dev/nvidiaN:/dev/nvidiaN` flags.*

--- a/container_files/public_html/doc/builtin/BatchMode.md
+++ b/container_files/public_html/doc/builtin/BatchMode.md
@@ -7,7 +7,7 @@ docker run \
   --rm=true \
   -v </absolute/path/to/mldb_data>:/mldb_data \
   -e MLDB_IDS="`id`" \
-  quay.io/datacratic/mldb:latest /opt/bin/mldb_runner \
+  quay.io/mldb/mldb:latest /opt/bin/mldb_runner \
   --plugin-directory /opt/mldb/plugins \
   --run-script /mldb_data/<script>
 ```
@@ -25,7 +25,7 @@ docker run \
   -v </absolute/path/to/mldb_data>:/mldb_data \
   -e MLDB_IDS="`id`" \
   -p 127.0.0.1:<mldbport>:80 \
-  quay.io/datacratic/mldb:latest /opt/bin/mldb_runner \
+  quay.io/mldb/mldb:latest /opt/bin/mldb_runner \
   --http-listen-port 80 \
   --plugin-directory /opt/mldb/plugins \
   --dont-exit-after-script yes \

--- a/container_files/public_html/doc/builtin/Running.md
+++ b/container_files/public_html/doc/builtin/Running.md
@@ -109,7 +109,7 @@ docker run --rm=true \
 -v </absolute/path/to/mldb_data>:/mldb_data \
 -e MLDB_IDS="`id`" \
 -p 127.0.0.1:<mldbport>:80 \
-quay.io/datacratic/mldb:latest
+quay.io/mldb/mldb:latest
 ```
 
 Once the container is booted, the path `/mldb_data` inside the container is mapped to `</absolute/path/to/mldb_data>` on the host machine, so MLDB will be able to access files at `</absolute/path/to/mldb_data>/file.ext` via the URL `file:///mldb_data/file.ext`. Read more about URLs [here](Url.md).
@@ -151,7 +151,7 @@ done manually.
 
 When you launch MLDB with the commands above, your container will be called `mldb`, and will keep running even if you close the terminal you used to launch it. To stop MLDB, use `docker kill mldb`, and to restart it you re-run the command you used to launch the container.
 
-To upgrade MLDB to the latest version hosted, just stop your container, run `docker pull quay.io/datacratic/mldb:latest` and restart your container.
+To upgrade MLDB to the latest version hosted, just stop your container, run `docker pull quay.io/mldb/mldb:latest` and restart your container.
 
 ### Batch mode
 

--- a/makefile-main-plugin.mk
+++ b/makefile-main-plugin.mk
@@ -9,7 +9,7 @@ DOCUMENTATION_ENABLED:=1
 TCMALLOC_ENABLED?=1
 
 DOCKER_REGISTRY:=quay.io/
-DOCKER_USER:=datacratic/
+DOCKER_USER:=mldb/
 
 # Shim for the 14.04 migration
 DIST_CODENAME:=$(shell lsb_release -sc)

--- a/mldb_base/docker_create_mldb_base.sh
+++ b/mldb_base/docker_create_mldb_base.sh
@@ -6,8 +6,8 @@ set -x
 progname=$(basename $0)
 
 CIDFILE=$(mktemp -u -t $progname.cid.XXXXXX)  # Race me!
-BASE_IMG="quay.io/datacratic/baseimage:0.9.17"
-IMG_NAME=${IMG_NAME:="quay.io/datacratic/mldb_base:14.04"}
+BASE_IMG="quay.io/mldb/baseimage:0.9.17"
+IMG_NAME=${IMG_NAME:="quay.io/mldb/mldb_base:14.04"}
 
 BUILD_DOCKER_DIR="/mnt/build"
 

--- a/release.mk
+++ b/release.mk
@@ -39,14 +39,14 @@ ifdef VERSION_NAME
 endif
 
 docker_mldb: \
-	DOCKER_BASE_IMAGE=quay.io/datacratic/mldb_base:14.04
+	DOCKER_BASE_IMAGE=quay.io/mldb/mldb_base:14.04
 	DOCKER_POST_INSTALL_SCRIPT=mldb/container_files/docker_post_install.sh $(DOCKER_POST_INSTALL_ARGS)
 
 mldb_base:
-	./mldb/mldb_base/docker_create_mldb_base.sh -w https://wheelhouse.datacratic.com/public/ubuntu/trusty/x86_64 $(IMG_NAME)
+	./mldb/mldb_base/docker_create_mldb_base.sh -w https://wheelhouse.mldb.ai/public/ubuntu/trusty/x86_64 $(IMG_NAME)
 .PHONY: mldb_base
 
 baseimage:
-	(cd mldb/baseimage-docker && make build NAME=quay.io/datacratic/baseimage)
+	(cd mldb/baseimage-docker && make build NAME=quay.io/mldb/baseimage)
 
 endif

--- a/sdk/sdk.mk
+++ b/sdk/sdk.mk
@@ -29,7 +29,7 @@ docker_mldb_sdk: docker_mldb
 
 
 docker_mldb_sdk: \
-	DOCKER_BASE_IMAGE=quay.io/datacratic/mldb:$(WHOAMI)-$(CURRENT_BRANCH) \
+	DOCKER_BASE_IMAGE=quay.io/mldb/mldb:$(WHOAMI)-$(CURRENT_BRANCH) \
 	DOCKER_POST_INSTALL_SCRIPT=sdk/install_sdk.sh \
 	DOCKER_COMMIT_ARGS=-run='{"Cmd": [ "/sbin/my_init" ], "PortSpecs": ["80"], "Volumes": { "$(MLDB_DATA_DIR)": {} } }'
 

--- a/testing/MLDB-756-docker-plugin.js
+++ b/testing/MLDB-756-docker-plugin.js
@@ -24,7 +24,7 @@ var pluginConfig = {
             params: {
                 copy: [
                     {
-                        archive: 'docker://quay.io/datacratic/mldb_sample_plugin:latest',
+                        archive: 'docker://quay.io/mldb/mldb_sample_plugin:latest',
                         match: '.*',
                         dest: '/\0'
                     }
@@ -48,7 +48,7 @@ var pluginConfig = {
         startup: {
             type: 'experimental.docker',
             params: {
-                repo: 'quay.io/datacratic/mldb_sample_plugin:latest',
+                repo: 'quay.io/mldb/mldb_sample_plugin:latest',
                 sharedLibrary: 'build/plugin.so'
             }
         }


### PR DESCRIPTION
There are a few `quay.io/datacratic/*` left, but I'm unsure of their use:

```
docker_create_dependencies.sh:docker run -i -cidfile tmp/docker_dependencies.cid -v ~/local:/tmp/local -v `pwd`:/tmp/build quay.io/datacratic/platform-deps sh -c 'cat > /tmp/command-to-run && chmod +x /tmp/command-to-run && exec /tmp/command-to-run' <<EOF
docker_create_dependencies.sh:docker commit $CID quay.io/datacratic/dependencies
docker_create_platform_deps.sh:docker run -i -cidfile platform-deps.cid -v ~/local:/tmp/local -v `pwd`:/tmp/build quay.io/datacratic/ubuntu-base sh -c 'cat > /tmp/command-to-run && chmod +x /tmp/command-to-run && exec /tmp/command-to-run' <<EOF
docker_create_platform_deps.sh:docker commit $CID quay.io/datacratic/platform-deps
sdk/Dockerfile:FROM quay.io/datacratic/mldb_autobuild:MLDB-756-plugin-sdk
testing/MLDB-905-docker-archive.js:var dir2 = mldb.ls("docker://quay.io/datacratic/datacratic-ubuntu:jeremy-test");
testing/MLDB-905-docker-archive.js:assertEqual(dir2.objects["docker://quay.io/datacratic/datacratic-ubuntu:jeremy-test/etc/timezone"].exists, true);
```

 - docker_create_dependencies.sh is unused, should we just kill it?
 - docker_create_platform_deps.sh is also dead code, nuke it?
 - testing/MLDB-905-docker-archive.js is a manual test, does it still work?