### PR TITLE
[MLDB-2131] added a macro to document all TF operations wrapped in MLDB

### DIFF
--- a/tensorflow/doc/Tensorflow.md
+++ b/tensorflow/doc/Tensorflow.md
@@ -8,6 +8,4 @@ Most tensorflow functions are available in MLDB queries and expressions with a
 of the same dimensions and closest matching type, and vice versa. In case of inconsistent 
 type in a MLDB embedding, it will be converted to a 64-bit floating point tensor.
 
-![](%%tfOperation EncodePng)
-![](%%tfOperation MatrixInverse)
-
+![](%%tfOperations)


### PR DESCRIPTION
Added a new macro so that we can automatically generate the documentation of all the tensorflow operations that are wrapped in MLDB.