### PR TITLE
Fix wrong implementation of rowLength for embeddings

### DIFF
--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -2527,7 +2527,7 @@ BoundFunction flatten(const std::vector<BoundSqlExpression> & args)
                     // If this is an embedding (but couldn't be proved statically),
                     // then do it the simple and efficient way
                     if (args[0].isEmbedding()) {
-                        size_t len = args[0].rowLength();
+                        size_t len = args[0].getAtomCount();
                         return args[0].reshape({len});
                     }
 
@@ -2769,7 +2769,7 @@ BoundFunction concat(const std::vector<BoundSqlExpression> & args)
             // Go argument by argument, copying elements in
             char * data = (char *)outBuffer.get();
             for (auto & a: args) {
-                size_t n = a.rowLength();
+                size_t n = a.getAtomCount();
                 a.convertEmbedding(data, n, st);
                 size_t bytes = storageBufferBytes(n, st);
                 data += bytes;

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -1199,7 +1199,7 @@ struct ExpressionValue::Embedding {
     /* Non-Flattened length */
     size_t rowLength() const
     {
-        if (dims_.empty())
+        if (!dims_.empty())
             return dims_[0];
         else 
             return 0;

--- a/sql/sql_expression_operations.cc
+++ b/sql/sql_expression_operations.cc
@@ -1827,9 +1827,9 @@ bind(SqlBindingScope & scope) const
                     ts.setMin(v.getEffectiveTimestamp());
 
                     std::vector<CellValue> valueCells
-                        = v.getEmbeddingCell(v.rowLength());
+                        = v.getEmbeddingCell(v.getAtomCount());
 
-                    if (valueCells.size() != v.rowLength())
+                    if (valueCells.size() != v.getAtomCount())
                         throw HttpReturnException(400, "Embeddings don't contain the same number of elements");
 
                     cells.insert(cells.end(),

--- a/testing/expression_value_test.cc
+++ b/testing/expression_value_test.cc
@@ -535,3 +535,18 @@ BOOST_AUTO_TEST_CASE( test_superposition_with_search_row )
     BOOST_CHECK_EQUAL(jsonEncode(found), Json::parse(expected));
 }
 
+BOOST_AUTO_TEST_CASE( test_embedding_length )
+{
+    std::vector<float> values = {1,2,3,4};
+    Date ts;
+    DimsVector shape = {2,2};
+
+    ExpressionValue myValue(values,
+                            ts,
+                            shape);
+
+    cerr << jsonEncode(myValue) << endl;
+
+    BOOST_CHECK_EQUAL(myValue.rowLength(), 2);
+    BOOST_CHECK_EQUAL(myValue.getAtomCount(), 4);
+}

--- a/testing/expression_value_test.cc
+++ b/testing/expression_value_test.cc
@@ -545,8 +545,6 @@ BOOST_AUTO_TEST_CASE( test_embedding_length )
                             ts,
                             shape);
 
-    cerr << jsonEncode(myValue) << endl;
-
     BOOST_CHECK_EQUAL(myValue.rowLength(), 2);
     BOOST_CHECK_EQUAL(myValue.getAtomCount(), 4);
 }


### PR DESCRIPTION
Fix wrong implementation of rowLength for embeddings and implement getAtomCount.

rowLength is meant to return the number of columns in the first structured level, and that worked for row representations. However for embeddings representations is was returning the number of atoms. 

If you need the total number of atoms, the proper method is getAtomCount.