### PR TITLE
Fixed offset error on last line of chunk (MLDB-2167)

### DIFF
--- a/plugins/for_each_line.cc
+++ b/plugins/for_each_line.cc
@@ -395,9 +395,7 @@ void forEachLineBlock(std::istream & stream,
                         std::string lastLine;
                         getline(stream, lastLine);
                 
-                        size_t cnt = stream.gcount();
-
-                        if (cnt != 0) {
+                        if (!lastLine.empty()) {
                             // Check for overflow on the buffer size
                             if (offset + lastLine.size() + 1 > BLOCK_SIZE + EXTRA_SIZE) {
                                 // reallocate and copy
@@ -414,7 +412,7 @@ void forEachLineBlock(std::istream & stream,
                     
                             lineOffsets.emplace_back(offset + lastLine.length());
                             ++doneLines;
-                            offset += cnt;
+                            offset += lastLine.size() + 1;
                         }                
                     }
 


### PR DESCRIPTION
Fixed error using gcount() after readline(), leading to thinking that the chunk is bigger than it is and junk characters in between chunks.