### PR TITLE
MLDB-2192 value info embedding scalar

### DIFF
--- a/sql/builtin_functions.cc
+++ b/sql/builtin_functions.cc
@@ -535,7 +535,7 @@ struct RegisterBuiltinBinaryScalar {
     {
         auto resultInfo
             = std::make_shared<EmbeddingValueInfo>
-            (args[0].info->getEmbeddingShape(),
+            (args[1].info->getEmbeddingShape(),
              info->getEmbeddingType());
         return wrap(functionName, fn, std::move(resultInfo),
                     applyScalarEmbedding);
@@ -550,8 +550,9 @@ struct RegisterBuiltinBinaryScalar {
     {
         auto resultInfo
             = std::make_shared<EmbeddingValueInfo>
-            (args[1].info->getEmbeddingShape(),
+            (args[0].info->getEmbeddingShape(),
              info->getEmbeddingType());
+
         return wrap(functionName, fn, std::move(resultInfo),
                     applyEmbeddingScalar);
     }

--- a/testing/MLDB-1317-tensor-datatype.js
+++ b/testing/MLDB-1317-tensor-datatype.js
@@ -30,6 +30,56 @@ var expected = [
 
 assertEqual(resp, expected);
 
+var resp = mldb.query("select static_expression_info([ [ 10, 20 ], [ 30, 40 ] ]) as *");
+
+var expected = [
+    {"columns":[["expr","[ [ 10, 20 ], [ 30, 40 ] ]","-Inf"],
+                ["info.isConstant",1,"-Inf"],
+                ["info.kind","embedding","-Inf"],
+                ["info.shape.0",2,"-Inf"],
+                ["info.shape.1",2,"-Inf"],
+                ["info.type","INT64","-Inf"]],
+     "rowName":"result"}];
+
+assertEqual(resp, expected);
+
+var resp = mldb.query("select static_expression_info(normalize([ [ 10, 20 ], [ 30, 40 ] ], 1) ) as *");
+
+var expected = [
+    {"columns":[["expr","normalize([ [ 10, 20 ], [ 30, 40 ] ], 1)","-Inf"],
+                ["info.isConstant",1,"-Inf"],
+                ["info.kind","embedding","-Inf"],
+                ["info.shape.0",2,"-Inf"],
+                ["info.shape.1",2,"-Inf"],
+                ["info.type","FLOAT32","-Inf"]],
+     "rowName":"result"}];
+
+assertEqual(resp, expected);
+
+var resp = mldb.query("select normalize([ [ 10, 20 ], [ 30, 40 ] ], 1) as *");
+
+var expected = [
+    {"columns":[["0.0",0.1,"-Inf"],
+                ["0.1",0.2,"-Inf"],
+                ["1.0",0.3,"-Inf"],
+                ["1.1",0.4,"-Inf"]],
+     "rowName":"result"}];
+
+assertEqual(resp, expected);
+
+var resp = mldb.query("select static_expression_info(quantize(normalize([ [ 10, 20 ], [ 30, 40 ] ], 1), 0.1 )) as *");
+
+var expected = [
+    {"columns":[["expr","quantize(normalize([ [ 10, 20 ], [ 30, 40 ] ], 1), 0.1 )","-Inf"],
+                ["info.isConstant",0,"-Inf"],
+                ["info.kind","embedding","-Inf"],
+                ["info.shape.0",2,"-Inf"],
+                ["info.shape.1",2,"-Inf"],
+                ["info.type","FLOAT64","-Inf"]],
+     "rowName":"result"}];
+
+assertEqual(resp, expected);
+
 var resp = mldb.query("select quantize(normalize([ [ 10, 20 ], [ 30, 40 ] ], 1), 0.1) as *");
 
 mldb.log(resp);


### PR DESCRIPTION
Fixes incorrect return shape inference for binary operations between an embedding and a scalar.  Includes a test case.

The test failure is spurious.
