### PR TITLE
MLDB-2193 import text optimizations

### DIFF
--- a/plugins/importtext_procedure.cc
+++ b/plugins/importtext_procedure.cc
@@ -216,7 +216,8 @@ struct SqlCsvScope: public SqlExpressionMldbScope {
                      const VariableFilter & filter) -> const ExpressionValue &
                 {
                     auto & row = scope.as<RowScope>();
-                    return storage = ExpressionValue(row.row[index], row.ts);
+                    return storage = ExpressionValue(row.row[index],
+                                                     row.ts);
                 },
                 std::make_shared<AtomValueInfo>()};
     }
@@ -968,6 +969,10 @@ struct ImportTextProcedureWorkInstance
         // call the SQL parser
         bool isWhereTrue = config.where->isConstantTrue();
 
+        // Do we have a "NAMED lineNumber()"?  In that case, we can short
+        // circuit the evaluation of that expression.
+        bool isNamedLineNumber = config.named->surface == "lineNumber()";
+
         std::atomic<uint64_t> numSkipped(0);
         std::atomic<uint64_t> totalLinesProcessed(0);
 
@@ -1119,10 +1124,16 @@ struct ImportTextProcedureWorkInstance
                                          0 /* todo: chunk ofs */);
 
             ExpressionValue nameStorage;
-            RowPath rowName(namedBound(row, nameStorage, GET_ALL)
-                                .toUtf8String());
-            row.rowName = &rowName;
+            RowPath rowName;
 
+            if (isNamedLineNumber) {
+                rowName = Path(actualLineNum);
+            }
+            else {
+                rowName = namedBound(row, nameStorage, GET_ALL).coerceToPath();
+            }
+            row.rowName = &rowName;
+            
             // If it doesn't match the where, don't add it
             if (!isWhereTrue) {
                 ExpressionValue storage;

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -3316,15 +3316,42 @@ void
 ExpressionValue::
 mergeToRowDestructive(StructValue & row)
 {
-    row.reserve(row.size() + rowLength());
+    // This is optimized here because the SelectExpression uses it whenever
+    // merging
+    switch (type_) {
+    case Type::STRUCTURED:
+        if (structured_.unique()) {
+            // We have the only reference in the shared pointer, AND we have
+            // a non-const version of that expression.  This means that it
+            // should be thread-safe to break constness and steal the result,
+            // as otherwise we would have two references from different threads
+            // with at least one non-const, which breaks thread safety.
+            auto & nonConst = const_cast<Structured &>(*structured_);
+            if (row.empty())
+                row.swap(nonConst);
+            else {
+                row.reserve(row.size() + nonConst.size());
+                row.insert(row.end(),
+                           std::make_move_iterator(nonConst.begin()),
+                           std::make_move_iterator(nonConst.end()));
+            }
+            return;
+        }
+        break;
+    default:
+        break;
+    };
 
+    // Default implementation
+    row.reserve(row.size() + rowLength());
+    
     auto onSubexpr = [&] (PathElement & columnName,
                           ExpressionValue & val)
         {
             row.emplace_back(std::move(columnName), std::move(val));
             return true;
         };
-
+    
     forEachColumnDestructiveT(onSubexpr);
 }
 


### PR DESCRIPTION
Several micro-optimizations that between them allow for roughly doubling the speed of the import.text procedure.

Test coverage on these is pretty extensive on existing tests.
