### PR TITLE
MLDB-2194 double timestamp column format

### DIFF
--- a/base/less.h
+++ b/base/less.h
@@ -1,18 +1,16 @@
-// This file is part of MLDB. Copyright 2015 mldb.ai inc. All rights reserved.
-
 /* less.h                                                          -*- C++ -*-
    Jeremy Barnes, 5 March 2009
    Copyright (c) 2009 Jeremy Barnes.  All rights reserved.
+   This file is part of MLDB. Copyright 2015 mldb.ai inc. All rights reserved.
 
    Functions to implement an operator <.
 */
 
-#ifndef __utils__less_h__
-#define __utils__less_h__
+#pragma once
 
 #include <algorithm>
 
-namespace ML {
+namespace MLDB {
 
 template<typename T1>
 bool less_all(const T1 & x1, const T1 & y1)
@@ -105,8 +103,5 @@ typename Compare::result_type compare_sorted( T & x, T & y, Compare comp) {
     return comp(x,y);
 }
 
-} // namespace ML
-
-#endif /* __utils__less_h__ */
-
+} // namespace MLDB
 

--- a/ml/jml/split.h
+++ b/ml/jml/split.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "split_fwd.h"
-#include "mldb/jml/utils/less.h"
+#include "mldb/base/less.h"
 #include "feature.h"
 #include "mldb/jml/db/persistent_fwd.h"
 #include <cmath>

--- a/ml/separation_stats.h
+++ b/ml/separation_stats.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "mldb/jml/utils/less.h"
+#include "mldb/base/less.h"
 #include "mldb/jml/math/xdiv.h"
 #include "mldb/jml/utils/rng.h"
 #include "mldb/ext/jsoncpp/json.h"
@@ -217,7 +217,7 @@ struct ScoredStats {
 
         bool operator < (const ScoredEntry & other) const
         {
-            return ML::less_all(-score, -other.score, label, other.label);
+            return MLDB::less_all(-score, -other.score, label, other.label);
         }
     };
 

--- a/plugins/behavior/behavior_types.h
+++ b/plugins/behavior/behavior_types.h
@@ -10,7 +10,7 @@
 #include "mldb/types/date.h"
 #include "mldb/arch/exception.h"
 #include "mldb/utils/compact_vector.h"
-#include "mldb/jml/utils/less.h"
+#include "mldb/base/less.h"
 #include "mldb/jml/utils/lightweight_hash.h"
 #include "mldb/ext/jsoncpp/json.h"
 
@@ -33,7 +33,7 @@ struct SubjectBehavior {
 
     bool operator < (const SubjectBehavior & other) const
     {
-        return ML::less_all(timestamp, other.timestamp,
+        return MLDB::less_all(timestamp, other.timestamp,
                             behavior, other.behavior,
                             count, other.count);
     }

--- a/plugins/behavior/id.cc
+++ b/plugins/behavior/id.cc
@@ -12,7 +12,7 @@
 #include "mldb/arch/format.h"
 #include "mldb/arch/exception.h"
 #include "mldb/base/exc_assert.h"
-#include "mldb/jml/utils/less.h"
+#include "mldb/base/less.h"
 #include "mldb/types/value_description.h"
 #include "mldb/ext/jsoncpp/value.h"
 #include "mldb/ext/cityhash/src/city.h" // Google city hash function
@@ -714,7 +714,7 @@ complexLess(const Id & other) const
         return std::lexicographical_compare(data1, data1 + len1, data2, data2 + len2);
     }
     else if (type == COMPOUND2) {
-        return ML::less_all(compoundId1(), other.compoundId1(),
+        return MLDB::less_all(compoundId1(), other.compoundId1(),
                             compoundId2(), other.compoundId2());
     }
     else throw MLDB::Exception("unknown Id type");

--- a/plugins/behavior/mutable_behavior_domain.cc
+++ b/plugins/behavior/mutable_behavior_domain.cc
@@ -1974,7 +1974,7 @@ sortUnlocked(bool immutable, const MutableBehaviorDomain *owner)
 
         bool operator < (const Entry & other) const
         {
-            return ML::less_all(timestamp, other.timestamp,
+            return MLDB::less_all(timestamp, other.timestamp,
                                 behavior, other.behavior,
                                 count, other.count);
         }

--- a/plugins/behavior_dataset.cc
+++ b/plugins/behavior_dataset.cc
@@ -11,7 +11,7 @@
 #include "mldb/plugins/behavior/behavior_utils.h"
 
 #include "mldb/arch/timers.h"
-#include "mldb/jml/utils/less.h"
+#include "mldb/base/less.h"
 #include "mldb/base/parallel.h"
 #include "mldb/vfs/filter_streams.h"
 #include "mldb/jml/utils/hex_dump.h"
@@ -83,7 +83,7 @@ struct BehaviorValueInfo {
 
     bool operator < (const BehaviorValueInfo & other) const
     {
-        return ML::less_all(rowCount, other.rowCount,
+        return MLDB::less_all(rowCount, other.rowCount,
                             itl, other.itl);
     }
 };

--- a/plugins/binary_behavior_dataset.cc
+++ b/plugins/binary_behavior_dataset.cc
@@ -10,7 +10,7 @@
 #include "behavior_dataset.h"  // for behManager
 
 #include "mldb/arch/timers.h"
-#include "mldb/jml/utils/less.h"
+#include "mldb/base/less.h"
 #include "mldb/base/parallel.h"
 #include "mldb/vfs/filter_streams.h"
 #include "mldb/jml/utils/hex_dump.h"

--- a/plugins/column_types.cc
+++ b/plugins/column_types.cc
@@ -46,6 +46,8 @@ ColumnTypesDescription()
              "Number of string values in the column");
     addField("numBlobs", &ColumnTypes::numBlobs,
              "Number of blob values in the column");
+    addField("numTimestamps", &ColumnTypes::numTimestamps,
+             "Number of timestamp values in the column");
     addField("numOther", &ColumnTypes::numOther,
              "Number of other typed values in the column");
 }
@@ -57,13 +59,6 @@ ColumnTypesDescription()
 
 ColumnTypes::   
 ColumnTypes()
-    : numNulls(0), numZeros(0), numIntegers(0),
-      minNegativeInteger(std::numeric_limits<int64_t>::max()),
-      maxNegativeInteger(0),
-      minPositiveInteger(std::numeric_limits<uint64_t>::max()),
-      maxPositiveInteger(0),
-      numReals(0), numStrings(0), numBlobs(0),
-      numOther(0)
 {
 }
 
@@ -98,6 +93,8 @@ update(const CellValue & val)
         numStrings += 1;  break;
     case CellValue::BLOB:
         numBlobs += 1;  break;
+    case CellValue::TIMESTAMP:
+        numTimestamps += 1;  break;
     default:
         numOther += 1;  break;
     }
@@ -116,6 +113,7 @@ update(const ColumnTypes & other)
     numReals = numReals + other.numReals;
     numStrings = numStrings + other.numStrings;
     numBlobs = numBlobs + other.numBlobs;
+    numTimestamps = numTimestamps + other.numTimestamps;
     numOther = numOther + other.numOther;
 }
 
@@ -123,7 +121,7 @@ std::shared_ptr<ExpressionValueInfo>
 ColumnTypes::   
 getExpressionValueInfo() const
 {
-    if (!numNulls && !numReals && !numStrings && !numBlobs && !numOther) {
+    if (!numNulls && !numReals && !numStrings && !numBlobs && !numTimestamps && !numOther) {
         // Integers only
         if (minNegativeInteger == 0) {
             // All positive
@@ -139,7 +137,7 @@ getExpressionValueInfo() const
             return std::make_shared<AtomValueInfo>();
         }
     }
-    else if (!numNulls && !numStrings && !numBlobs && !numOther) {
+    else if (!numNulls && !numStrings && !numBlobs && !numTimestamps && !numOther) {
         // Reals and integers.  If all integers are representable as
         // doubles, in other words a maximum of 53 bits, then we're all
         // doubles.
@@ -150,7 +148,7 @@ getExpressionValueInfo() const
         // Doubles would lose precision.  It's an atom.
         return std::make_shared<AtomValueInfo>();
     }
-    else if (!numNulls && !numIntegers && !numReals && !numBlobs && !numOther) {
+    else if (!numNulls && !numIntegers && !numReals && !numBlobs && !numTimestamps && !numOther) {
         return std::make_shared<Utf8StringValueInfo>();
     }
     else {

--- a/plugins/frozen_column.cc
+++ b/plugins/frozen_column.cc
@@ -736,7 +736,9 @@ struct IntegerFrozenColumnFormat: public FrozenColumnFormat {
                             const ColumnFreezeParameters & params,
                             std::shared_ptr<void> & cachedInfo) const override
     {
-        return true;
+        return column.columnTypes.onlyIntegersAndNulls()
+            && column.columnTypes.maxPositiveInteger
+            <= (uint64_t)std::numeric_limits<int64_t>::max();
     }
 
     virtual ssize_t columnSize(const TabularDatasetColumn & column,

--- a/plugins/frozen_column.h
+++ b/plugins/frozen_column.h
@@ -107,6 +107,11 @@ struct FrozenColumnFormat {
                                ssize_t previousBest,
                                std::shared_ptr<void> & cachedInfo) const = 0;
     
+    static std::pair<ssize_t,
+              std::function<std::shared_ptr<FrozenColumn> (TabularDatasetColumn & column)> >
+    preFreeze(const TabularDatasetColumn & column,
+              const ColumnFreezeParameters & params);
+
     /** Freeze the given column as this particular column format.  It has access
         to the cachedInfo that isFeasible and columnSize have provided.  This
         method should not fail unless there is an error in the underlying

--- a/plugins/matrix.cc
+++ b/plugins/matrix.cc
@@ -14,7 +14,7 @@
 #include "mldb/sql/sql_expression.h"
 #include "mldb/server/dataset_context.h"
 #include "mldb/http/http_exception.h"
-#include "mldb/jml/utils/less.h"
+#include "mldb/base/less.h"
 #include "mldb/utils/log.h"
 #include "mldb/rest/cancellation_exception.h"
 #include <mutex>
@@ -292,7 +292,7 @@ extractFeaturesFromRows(const SelectExpression & select,
                       [] (const ExtractedRow & r1,
                           const ExtractedRow & r2) -> bool
                           {
-                              return ML::less_all(r1.rowHash, r2.rowHash,
+                              return MLDB::less_all(r1.rowHash, r2.rowHash,
                                                   ((const std::vector<float> &)r1.continuous),
                                                   ((const std::vector<float> &)r2.continuous),
                                                   r1.sparse, r2.sparse);

--- a/plugins/tabular_dataset_column.cc
+++ b/plugins/tabular_dataset_column.cc
@@ -105,9 +105,11 @@ TabularDatasetColumn::
 freeze(const ColumnFreezeParameters & params)
 {
     ExcAssert(!isFrozen);
+
+    auto result = FrozenColumn::freeze(*this, params);
     isFrozen = true;
 
-    return FrozenColumn::freeze(*this, params);
+    return result;
 }
 
 #if 0

--- a/rest/rest_request_router.cc
+++ b/rest/rest_request_router.cc
@@ -14,7 +14,7 @@
 #include "mldb/jml/utils/environment.h"
 #include "mldb/jml/utils/file_functions.h"
 #include "mldb/jml/utils/string_functions.h"
-#include "mldb/jml/utils/less.h"
+#include "mldb/base/less.h"
 #include "mldb/types/value_description.h"
 
 
@@ -146,7 +146,7 @@ bool
 RequestParamFilter::
 operator < (const RequestParamFilter & other) const
 {
-    return  ML::less_all(location, other.location,
+    return  MLDB::less_all(location, other.location,
                  param, other.param,
                  value, other.value);
 }

--- a/sql/cell_value.cc
+++ b/sql/cell_value.cc
@@ -21,6 +21,7 @@
 #include "path.h"
 #include "mldb/ext/s2/s2.h"
 #include "mldb/utils/possibly_dynamic_buffer.h"
+#include "mldb/base/less.h"
 
 using namespace std;
 

--- a/sql/cell_value.h
+++ b/sql/cell_value.h
@@ -310,29 +310,19 @@ struct CellValue {
     bool isNaN() const
     {
         CellType t = cellType();
-        if (t == INTEGER) {
-            return std::isnan(toInt());
-        }
-        else if (t == FLOAT) {
+        if (t == FLOAT) {
             return std::isnan(toDouble());
         }
-        else {
-            return false;
-        }
+        return false;
     }
 
     bool isInf() const
     {
         CellType t = cellType();
-        if (t == INTEGER) {
-            return std::isinf(toInt());
-        }
-        else if (t == FLOAT) {
+        if (t == FLOAT) {
             return std::isinf(toDouble());
         }
-        else {
-            return false;
-        }
+        return false;
     }
 
     CellValue coerceToInteger() const;
@@ -444,6 +434,10 @@ private:
 
     Utf8String trimmedExceptionString() const;
 
+    /// All of the different types of storage format for the
+    /// CellValue class.  Note that every time something is
+    /// added to this list, examples should be added to the
+    /// test_sorting_absolute_order test in cell_value_test.
     enum StorageType {
         ST_EMPTY,
         ST_INTEGER,

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -21,7 +21,7 @@
 #include "mldb/jml/stats/distribution.h"
 #include "mldb/utils/json_utils.h"
 #include "mldb/types/hash_wrapper_description.h"
-#include "mldb/jml/utils/less.h"
+#include "mldb/base/less.h"
 #include "mldb/jml/utils/lightweight_hash.h"
 #include "mldb/utils/compact_vector.h"
 #include "mldb/base/optimized_path.h"

--- a/sql/expression_value.cc
+++ b/sql/expression_value.cc
@@ -4264,14 +4264,10 @@ ExpressionValue::
 initStructured(std::shared_ptr<const Structured> value) noexcept
 {
     assertType(Type::NONE);
-    ts_ = Date();
-    if (value->size() == 0) {
-        ts_ = Date::notADate();
-    }
-    else {
-        for (auto& r : *value) {
-            ts_ = std::max(std::get<1>(r).getEffectiveTimestamp(), ts_);
-        }
+
+    ts_ = Date::notADate();
+    for (auto& r : *value) {
+        ts_ = std::max(std::get<1>(r).getEffectiveTimestamp(), ts_);
     }
 
     // In the case of a superposition, this isn't true

--- a/testing/MLDB-1192-js-procedure-function.js
+++ b/testing/MLDB-1192-js-procedure-function.js
@@ -29,7 +29,7 @@ var res = fn.call({ x: 10 });
 
 mldb.log(res);
 
-assertEqual(res[0][0], [ "y", [ 100, 'NaD' ]]);
+assertEqual(res[0][0], [ "y", [ 100, '-Inf' ]]);
 
 var procConfig = {
     type: "null",

--- a/testing/MLDB-1636-row-column-path.js
+++ b/testing/MLDB-1636-row-column-path.js
@@ -70,7 +70,7 @@ var expected = [
             {
                "path" : [ "[result]-[0]" ]
             },
-            "-Inf"
+            "NaD"
          ],
          [ "x.1", 1, "-Inf" ],
          [ "y.column", { path: ["x"] }, "-Inf" ],

--- a/testing/MLDB-1710-left-right-rowname.py
+++ b/testing/MLDB-1710-left-right-rowname.py
@@ -78,7 +78,7 @@ class LikeTest(MldbUnitTest):
         res1 = mldb.query("select rightRowName() from ds1 left join ds2 on ds1.a = ds2.a + 1")
         mldb.log(res1)
 
-        expected = [["_rowName", "rightRowName()"], ["[x]-[]", '""']]
+        expected = [["_rowName", "rightRowName()"], ["[x]-[]", '']]
 
         self.assertEqual(res1, expected);
 

--- a/testing/MLDB-1742-tabular-dataset-integer-columns.cc
+++ b/testing/MLDB-1742-tabular-dataset-integer-columns.cc
@@ -1,4 +1,4 @@
-/* MLDB-1360-sparse-mutable-multithreaded-insert.cc
+/* MLDB-1742-tabular-dataset-integer-columns.cc
    Jeremy Barnes, 20 March 2015
    Copyright (c) 2015 mldb.ai inc.  All rights reserved.
 
@@ -32,12 +32,92 @@ freezeAndTest(const std::vector<CellValue> & cells)
     ColumnFreezeParameters params;
     std::shared_ptr<FrozenColumn> frozen = col.freeze(params);
 
+    cerr << "testing " << MLDB::type_name(*frozen) << endl;
+
     ExcAssertEqual(frozen->size(), cells.size());
 
     for (size_t i = 0;  i < cells.size();  ++i) {
         BOOST_REQUIRE_EQUAL(frozen->get(i), cells[i]);
     }
+
+    {
+        std::vector<CellValue> outVals(cells.size());
+        std::vector<int8_t> done(cells.size());
+        size_t numDone = 0;
+
+        auto onEntry = [&] (int64_t rowNum, CellValue val)
+            {
+                BOOST_CHECK_GE(rowNum, 0);
+                BOOST_CHECK_LT(rowNum, cells.size());
+                BOOST_CHECK_EQUAL(done[rowNum], false);
+                done[rowNum] = true;
+                outVals[rowNum] = std::move(val);
+                ++numDone;
+                return true;
+            };
+        
+        frozen->forEachDense(onEntry);
+
+        BOOST_CHECK_EQUAL(numDone, cells.size());
+
+        for (size_t i = 0;  i < outVals.size();  ++i) {
+            BOOST_CHECK_EQUAL(cells[i], outVals[i]);
+        }
+    }
+
+    {
+        std::vector<CellValue> outVals(cells.size());
+        std::vector<int8_t> done(cells.size());
+        
+        auto onEntry = [&] (int64_t rowNum, CellValue val)
+            {
+                if (val.empty()) {
+                    cerr << "rowNum " <<rowNum << " has null" << endl;
+                }
+                BOOST_CHECK_GE(rowNum, 0);
+                BOOST_CHECK_LT(rowNum, cells.size());
+                BOOST_CHECK_EQUAL(done[rowNum], false);
+                BOOST_CHECK(!val.empty());
+                done[rowNum] = true;
+                outVals[rowNum] = std::move(val);
+                return true;
+            };
+        
+        frozen->forEach(onEntry);
+
+        for (size_t i = 0;  i < outVals.size();  ++i) {
+            BOOST_CHECK_EQUAL(cells[i], outVals[i]);
+        }
+    }
+
+    {
+        std::set<CellValue> vals, cellVals;
+
+        auto onDistinct = [&] (CellValue val)
+            {
+                bool inserted = vals.insert(val).second;
+                if (!inserted) {
+                    cerr << "error on " << jsonEncodeStr(val) << endl;
+                }
+                BOOST_CHECK(inserted);
+                return true;
+            };
+
+        frozen->forEachDistinctValue(onDistinct);
+
+        for (auto & c: cells) {
+            if (!vals.count(c)) {
+                cerr << "error on " << jsonEncodeStr(c) << endl;
+            }
+            BOOST_CHECK_EQUAL(vals.count(c), 1);
+            cellVals.insert(c);
+        }
+
+        BOOST_CHECK(vals == cellVals);
+    }
     
+    BOOST_REQUIRE_EQUAL(frozen->size(), cells.size());
+
     return frozen;
 }
 
@@ -187,4 +267,103 @@ BOOST_AUTO_TEST_CASE( test_big_pos_neg_range_and_nulls )
     vals.emplace_back();
 
     freezeAndTest(vals);
+}
+
+BOOST_AUTO_TEST_CASE( test_double_basics )
+{
+    std::vector<CellValue> vals;
+
+    for (int64_t i = 0;  i < 1000;  ++i) {
+        vals.push_back(i * 0.5);
+    }
+        
+    auto frozen = freezeAndTest(vals);
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
+                      "MLDB::DoubleFrozenColumn");
+    
+}
+
+BOOST_AUTO_TEST_CASE( test_double_special_values )
+{
+    std::vector<CellValue> vals;
+    vals.emplace_back();
+    vals.emplace_back(INFINITY);
+    vals.emplace_back(-INFINITY);
+    vals.emplace_back(std::numeric_limits<double>::quiet_NaN());
+    vals.emplace_back(0.0);
+    vals.emplace_back(-0.0);
+    vals.emplace_back(1);
+    vals.emplace_back(std::numeric_limits<double>::max());
+    vals.emplace_back(std::numeric_limits<double>::min());
+    vals.emplace_back(std::numeric_limits<double>::lowest());
+    
+    auto frozen = freezeAndTest(vals);
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
+                      "MLDB::DoubleFrozenColumn");
+}
+
+BOOST_AUTO_TEST_CASE( test_double_basics_null )
+{
+    std::vector<CellValue> vals;
+    vals.emplace_back();
+
+    for (int64_t i = 0;  i < 1000;  ++i) {
+        vals.push_back(i * 0.5);
+        vals.emplace_back();
+        vals.push_back(-(i * 0.5));
+    }
+    vals.emplace_back();
+
+    auto frozen = freezeAndTest(vals);
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
+                      "MLDB::DoubleFrozenColumn");
+}
+
+BOOST_AUTO_TEST_CASE( test_timestamp_basics )
+{
+    std::vector<CellValue> vals;
+
+    for (int64_t i = 0;  i < 10;  ++i) {
+        vals.push_back(Date::now().plusSeconds(i * 0.5));
+    }
+        
+    auto frozen = freezeAndTest(vals);
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
+                      "MLDB::TimestampFrozenColumn");
+    
+}
+
+BOOST_AUTO_TEST_CASE( test_timestamp_special_values )
+{
+    std::vector<CellValue> vals;
+    vals.emplace_back();
+    vals.emplace_back(Date::positiveInfinity());
+    vals.emplace_back(Date::negativeInfinity());
+    vals.emplace_back(Date::notADate());
+    vals.emplace_back(Date::fromSecondsSinceEpoch(0.0));
+    vals.emplace_back(Date::fromSecondsSinceEpoch(1));
+    vals.emplace_back(Date::fromSecondsSinceEpoch(std::numeric_limits<double>::max()));
+    vals.emplace_back(Date::fromSecondsSinceEpoch(std::numeric_limits<double>::min()));
+    vals.emplace_back(Date::fromSecondsSinceEpoch(std::numeric_limits<double>::lowest()));
+    
+    auto frozen = freezeAndTest(vals);
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
+                      "MLDB::TimestampFrozenColumn");
+}
+
+BOOST_AUTO_TEST_CASE( test_timestamp_basics_null )
+{
+    std::vector<CellValue> vals;
+    vals.emplace_back();
+
+    for (int64_t i = 0;  i < 10;  ++i) {
+        vals.push_back(Date::now().plusSeconds(i * 0.5));
+        vals.emplace_back();
+        vals.push_back(Date::now().plusSeconds(-i * 0.5));
+    }
+    vals.emplace_back();
+
+    auto frozen = freezeAndTest(vals);
+    BOOST_CHECK_EQUAL(MLDB::type_name(*frozen),
+                      "MLDB::TimestampFrozenColumn");
 }

--- a/testing/builtin_hash_fct_test.py
+++ b/testing/builtin_hash_fct_test.py
@@ -19,7 +19,7 @@ class BuiltinHashFctTest(MldbUnitTest):  # noqa
         self.assertEqual(res[1][1], 9281407066453831864)
 
         res = mldb.query("SELECT hash({a: 12, b: 'coco'})")
-        self.assertEqual(res[1][1], 12351211796938911870)
+        self.assertEqual(res[1][1], 17779398697240081926)
 
         res = mldb.query("SELECT hash(NULL)")
         self.assertEqual(res[1][1], None)

--- a/types/date.h
+++ b/types/date.h
@@ -126,7 +126,15 @@ struct Date {
 
     bool operator == (const Date & other) const
     {
-        return secondsSinceEpoch_ == other.secondsSinceEpoch_;
+        bool nad1 = std::isnan(secondsSinceEpoch_);
+        bool nad2 = std::isnan(other.secondsSinceEpoch_);
+
+        switch (nad1 + 2 * nad2) {
+        case 3: return true;
+        case 2: return false;
+        case 1: return false;
+        default: return secondsSinceEpoch_ == other.secondsSinceEpoch_;
+        }
     }
 
     bool operator != (const Date & other) const
@@ -136,22 +144,38 @@ struct Date {
 
     bool operator <  (const Date & other) const
     {
-        return secondsSinceEpoch_ < other.secondsSinceEpoch_;
+        bool nad1 = std::isnan(secondsSinceEpoch_);
+        bool nad2 = std::isnan(other.secondsSinceEpoch_);
+        
+        switch (nad1 + 2 * nad2) {
+        case 3: return false;
+        case 2: return false;
+        case 1: return true;
+        default: return secondsSinceEpoch_ < other.secondsSinceEpoch_;
+        }
     }
 
     bool operator <= (const Date & other) const
     {
-        return secondsSinceEpoch_ <= other.secondsSinceEpoch_;
+        bool nad1 = std::isnan(secondsSinceEpoch_);
+        bool nad2 = std::isnan(other.secondsSinceEpoch_);
+        
+        switch (nad1 + 2 * nad2) {
+        case 3: return true;
+        case 2: return false;
+        case 1: return true;
+        default: return secondsSinceEpoch_ <= other.secondsSinceEpoch_;
+        }
     }
 
     bool operator >  (const Date & other) const
     {
-        return secondsSinceEpoch_ > other.secondsSinceEpoch_;
+        return ! operator <= (other);
     }
 
     bool operator >= (const Date & other) const
     {
-        return secondsSinceEpoch_ >= other.secondsSinceEpoch_;
+        return ! operator < (other);
     }
 
     double operator + (const Date & other) const

--- a/types/testing/date_test.cc
+++ b/types/testing/date_test.cc
@@ -629,3 +629,17 @@ BOOST_AUTO_TEST_CASE( test_cast_to_int_same_as_quantize_to_second )
 
     }
 }
+
+BOOST_AUTO_TEST_CASE( test_NaD_sorting )
+{
+    Date d1 = Date::notADate();
+    Date d2;
+
+    BOOST_CHECK_EQUAL(d1, d1);
+    BOOST_CHECK_EQUAL(d2, d2);
+    BOOST_CHECK_NE(d1, d2);
+    BOOST_CHECK(!(d1 < d1));
+    BOOST_CHECK_LE(d1, d1);
+    BOOST_CHECK_LT(d1, d2);
+    BOOST_CHECK_GE(d2, d1);
+}


### PR DESCRIPTION
Reduces memory usage for doubles from 12 to 8 bytes/entry, and from timestamps from 12 to 8 or much less if they are integers.

It also puts in place a mechanism that frozen columns can use other frozen columns as part of their implementation.
