### PR TITLE
Fixed slow make due to re-hashing over and over

### DIFF
--- a/jml-build/functions.mk
+++ b/jml-build/functions.mk
@@ -50,14 +50,22 @@ NOTHING :=
 SPACE := $(NOTHING) $(NOTHING)
 TAB := $(NOTHING)	$(NOTHING)
 DOLLAR := $$
+LPARAN:=(
+RPARAN:=)
+SEMICOLON:=;
+QUOTE:="
+#"  
+# (previous line is for emacs)
+
+
 
 hash_command2 = $(wordlist 1,1,$(shell echo $(strip $(1)) | md5sum))
 
 hash_command1 = $(eval HASH:=$(call hash_command2,$(1)))$(shell echo $(1)_hash:=$(HASH) >> .make_hash_cache)$(eval $(1)_hash:=$(HASH))
 
-command_key = $(subst =,_,$(subst $(SPACE),_,$(subst $(DOLLAR),_,$(subst \,,$(strip $(1))))))
+command_key = $(subst $(RPARAN),_,$(subst $(LPARAN),_,$(subst $(SEMICOLON),_,$(subst $(QUOTE),_,$(subst =,_,$(subst $(SPACE),_,$(subst $(DOLLAR),_,$(subst \,,$(strip $(1))))))))))
 
-hash_command = $(eval KEY=$(call command_key,$(1)))$(if $($(KEY)_hash),,$(call hash_command1,$(KEY)))$(if $($(KEY)_hash),,$(error hash_command1 didnt set variable $(KEY)_hash))$($(KEY)_hash)
+hash_command = $(eval KEY=$(call command_key,$(1)))$(if $($(KEY)_hash),,$(warning hash cache miss on $(KEY))$(call hash_command1,$(KEY)))$(if $($(KEY)_hash),,$(error hash_command1 didnt set variable $(KEY)_hash))$($(KEY)_hash)
 
 endif
 


### PR DESCRIPTION
Any command line with a semicolon, quote, or parentheses couldn't be saved and hence was re-hashed over and over leading to slow make build times.  This replaces them with underscores and allows this to work, halving the build latency.