### PR TITLE
Vendored cryptopp (OSX)

### DIFF
--- a/base/base.mk
+++ b/base/base.mk
@@ -18,7 +18,8 @@ $(eval $(call library,base,$(LIBBASE_SOURCES),$(LIBBASE_LINK)))
 # gcc 4.7
 $(eval $(call set_compile_option,hash.cc,-fpermissive))
 
-$(eval $(call library,hash,hash.cc,cryptopp))
+$(eval $(call set_compile_option,hash.cc,-I $(CRYPTOPP_INCLUDE_DIR)))
+$(eval $(call library,hash,hash.cc,arch cryptopp))
 
 $(eval $(call include_sub_make,base_testing,testing))
 

--- a/base/hash.cc
+++ b/base/hash.cc
@@ -23,7 +23,7 @@ using namespace std;
 
 namespace MLDB {
 
-using byte = ::byte;
+using byte = CryptoPP::byte;
 
 std::string base64Encode(const std::string & str)
 {

--- a/ext/crypto++
+++ b/ext/crypto++
@@ -1,0 +1,1 @@
+cryptopp

--- a/ext/cryptopp.mk
+++ b/ext/cryptopp.mk
@@ -1,0 +1,26 @@
+CRYPTOPP_SOURCE := cryptlib.cpp cpu.cpp integer.cpp $(filter-out cryptlib.cpp cpu.cpp integer.cpp pch.cpp simple.cpp adhoc.cpp test.cpp bench1.cpp bench2.cpp bench3.cpp datatest.cpp dlltest.cpp fipsalgt.cpp validat0.cpp validat1.cpp validat2.cpp validat3.cpp validat4.cpp validat5.cpp validat6.cpp validat7.cpp validat8.cpp validat9.cpp validat10.cpp regtest1.cpp regtest2.cpp regtest3.cpp regtest4.cpp,$(notdir $(sort $(wildcard $(CWD)/*.cpp))))
+
+$(eval $(call set_compile_option,aria_simd.cpp,-msse3))
+$(eval $(call set_compile_option,blake2b_simd.cpp,-msse4.1))
+$(eval $(call set_compile_option,blake2s_simd.cpp,-msse4.1))
+$(eval $(call set_compile_option,chacha_avx.cpp,-mavx2))
+$(eval $(call set_compile_option,chacha_simd.cpp,-msse2))
+$(eval $(call set_compile_option,cham_simd.cpp,-msse3))
+$(eval $(call set_compile_option,crc_simd.cpp,-msse4.2))
+$(eval $(call set_compile_option,donna_sse.cpp,-msse2))
+$(eval $(call set_compile_option,gcm_simd.cpp,-msse3 -mpclmul))
+$(eval $(call set_compile_option,gf2n_simd.cpp,-mpclmul))
+$(eval $(call set_compile_option,keccak_simd.cpp,-msse3))
+$(eval $(call set_compile_option,lea_simd.cpp,-msse3))
+$(eval $(call set_compile_option,rijndael_simd.cpp,-msse4.1 -maes))
+$(eval $(call set_compile_option,sha_simd.cpp,-msse4.2 -msha))
+$(eval $(call set_compile_option,shacal2_simd.cpp,-msse4.2 -msha))
+$(eval $(call set_compile_option,simon128_simd.cpp,-msse3))
+$(eval $(call set_compile_option,sm4_simd.cpp,-msse3 -maes))
+$(eval $(call set_compile_option,speck128_simd.cpp,-msse3))
+$(eval $(call set_compile_option,sse_simd.cpp,-msse3))
+
+
+
+$(eval $(call library,cryptopp,$(CRYPTOPP_SOURCE)))
+CRYPTOPP_INCLUDE_DIR:=mldb/ext

--- a/ext/ext.mk
+++ b/ext/ext.mk
@@ -23,5 +23,6 @@ EASYEXIF_CC_FILES:= easyexif/exif.cpp
 $(eval $(call set_compile_option,$(EASYEXIF_CC_FILES),$(EASYEXIF_WARNING_OPTIONS)))
 $(eval $(call library,easyexif,$(EASYEXIF_CC_FILES)))
 $(eval $(call include_sub_make,libgit2,libgit2,../libgit2.mk))
+$(eval $(call include_sub_make,cryptopp,cryptopp,../cryptopp.mk))
 $(eval $(call include_sub_make,libarchive,libarchive,../libarchive.mk))
 

--- a/vfs_handlers/aws/aws.cc
+++ b/vfs_handlers/aws/aws.cc
@@ -30,6 +30,7 @@ using std::map;
 using std::cout;
 using std::cerr;
 using std::endl;
+using CryptoPP::byte;
 
 namespace MLDB {
 

--- a/vfs_handlers/aws/aws.mk
+++ b/vfs_handlers/aws/aws.mk
@@ -7,7 +7,7 @@ LIBAWS_SOURCES := \
 	aws.cc \
 	sqs.cc \
 
-LIBAWS_LINK := credentials hash crypto++ tinyxml2 http rest
+LIBAWS_LINK := credentials hash cryptopp tinyxml2 http rest
 
 $(eval $(call library,aws,$(LIBAWS_SOURCES),$(LIBAWS_LINK)))
 
@@ -15,7 +15,7 @@ $(eval $(call library,aws_vfs_handlers,s3_handlers.cc,aws vfs tinyxml2 http))
 
 
 # gcc 4.7
-$(eval $(call set_compile_option,aws.cc,-fpermissive))
+$(eval $(call set_compile_option,aws.cc,-fpermissive -I $(CRYPTOPP_INCLUDE_DIR)))
 
 $(eval $(call program,s3tee,aws_vfs_handlers boost_program_options utils))
 $(eval $(call program,s3cp,aws_vfs_handlers boost_program_options utils))


### PR DESCRIPTION
Not all platforms that MLDB runs on have an accessible way to install a secure version of cryptopp, so instead we vendor it in.