### PR TITLE
Test security: don't allow tests to listen outside of localhost

### DIFF
--- a/server/mldb_runner.cc
+++ b/server/mldb_runner.cc
@@ -87,7 +87,7 @@ int main(int argc, char ** argv)
     int numThreads(16);
     // Defaults for operational characteristics
     string httpListenPort = "11700-18000";
-    string httpListenHost = "0.0.0.0";
+    string httpListenHost = "127.0.0.1";
     string runScript;
     bool dontExitAfterScript = false;
 

--- a/testing/mldb_mnist_test.cc
+++ b/testing/mldb_mnist_test.cc
@@ -33,7 +33,7 @@ int main(int argc, char ** argv)
 
     server.init();
 
-    string httpBoundAddress = server.bindTcp(PortRange(17000,18000), "0.0.0.0");
+    string httpBoundAddress = server.bindTcp(PortRange(17000,18000), "127.0.0.1");
     
     cerr << "http listening on " << httpBoundAddress << endl;
 

--- a/testing/mldb_reddit_test.cc
+++ b/testing/mldb_reddit_test.cc
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE( test_two_members )
     
     server.init();
 
-    string httpBoundAddress = server.bindTcp(PortRange(17000,18000), "0.0.0.0");
+    string httpBoundAddress = server.bindTcp(PortRange(17000,18000), "127.0.0.1");
     
     cerr << "http listening on " << httpBoundAddress << endl;
 


### PR DESCRIPTION
We disable all tests from listening on the internet when starting the mldb_runner processes.