### PR TITLE
Python interpreter finalization fixes

### DIFF
--- a/python_constraints.txt
+++ b/python_constraints.txt
@@ -40,6 +40,7 @@ backcall==0.2.0
 bleach==3.3.0
 blinker==1.4
 bokeh==2.3.3
+bottle==0.12.19
 brewer2mpl==1.4.1
 Brlapi==0.7.0
 certifi==2019.11.28


### PR DESCRIPTION
Fixes issues with the (very complex) GIL / PyEndInterpreter / PyThreadState_Swap dance that needs to be done to properly end a python interpreter.  Under Python 3.9 some of the deprecated functions that were used segfault.