### PR TITLE
size_t <-> uint64_t confusion

### DIFF
--- a/builtin/filtered_dataset.cc
+++ b/builtin/filtered_dataset.cc
@@ -131,7 +131,7 @@ struct FilteredDataset::Itl
         return matrixView->getRowHashes(start, limit);
     }
 
-    virtual size_t getRowCount() const
+    virtual uint64_t getRowCount() const
     {
         return matrixView->getRowCount();
     }

--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -873,7 +873,7 @@ struct JoinedDataset::Itl
         return result;
     }
 
-    virtual size_t getRowCount() const
+    virtual uint64_t getRowCount() const
     {
         return rowIndex.size();
     }

--- a/builtin/merged_dataset.cc
+++ b/builtin/merged_dataset.cc
@@ -594,7 +594,7 @@ struct MergedDataset::Itl
         return result;
     }
 
-    virtual size_t getRowCount() const
+    virtual uint64_t getRowCount() const
     {
         return rowIndex.size();
     }

--- a/builtin/sampled_dataset.cc
+++ b/builtin/sampled_dataset.cc
@@ -231,7 +231,7 @@ struct SampledDataset::Itl
         return matrix->getRowColumnCount(row);
     }
 
-    virtual size_t getRowCount() const
+    virtual uint64_t getRowCount() const
     {
         return sampledRows.size();
     }

--- a/builtin/sub_dataset.cc
+++ b/builtin/sub_dataset.cc
@@ -530,7 +530,7 @@ struct SubDataset::Itl
         return result;
     }
 
-    virtual size_t getRowCount() const
+    virtual uint64_t getRowCount() const
     {
         return mainChunk.subOutput.size();
     }

--- a/builtin/transposed_dataset.cc
+++ b/builtin/transposed_dataset.cc
@@ -298,7 +298,7 @@ struct TransposedDataset::Itl
         return result;
     }
 
-    virtual size_t getRowCount() const
+    virtual uint64_t getRowCount() const
     {
         return dataset->getFlattenedColumnCount();
     }

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -80,7 +80,7 @@ struct MatrixView {
     virtual std::vector<RowHash>
     getRowHashes(ssize_t start = 0, ssize_t limit = -1) const = 0;
 
-    virtual size_t getRowCount() const = 0;
+    virtual uint64_t getRowCount() const = 0;
 
     /// Can be implemented by getRowPathName() then knownRow().  Deprecated.
     //virtual bool knownRowHash(const RowHash & row) const = 0;

--- a/engine/dataset_utils.cc
+++ b/engine/dataset_utils.cc
@@ -68,7 +68,7 @@ getRowHashes(ssize_t start, ssize_t limit) const
     return std::vector<RowHash>(it, end);
 }
 
-size_t
+uint64_t
 MergedMatrixView::
 getRowCount() const
 {

--- a/engine/dataset_utils.h
+++ b/engine/dataset_utils.h
@@ -54,7 +54,7 @@ struct MergedMatrixView : public MatrixView
     std::vector<RowHash>
     getRowHashes(ssize_t start = 0, ssize_t limit = -1) const;
 
-    size_t getRowCount() const;
+    uint64_t getRowCount() const;
     bool knownRow(const RowPath & row) const;
     MatrixNamedRow getRow(const RowPath & row) const;
 

--- a/plugins/behavior/behavior_dataset.cc
+++ b/plugins/behavior/behavior_dataset.cc
@@ -662,7 +662,7 @@ struct BehaviorMatrixView: public MatrixView {
         return applyOffsetLimit(offset, limit, result);
     }
 
-    virtual size_t getRowCount() const
+    virtual uint64_t getRowCount() const
     {
         return behs->subjectCount();
     }

--- a/plugins/behavior/behavior_domain.cc
+++ b/plugins/behavior/behavior_domain.cc
@@ -824,7 +824,7 @@ serialize(DB::Store_Writer & store, ssize_t maxSubjectBehaviors)
                     numWithMultipleBehaviors += 1;
 
                 // Atomically set the maximum number of behaviors
-                size_t knownMaxBehaviors = maxNumBehaviors;
+                uint64_t knownMaxBehaviors = maxNumBehaviors;
                 while (knownMaxBehaviors < behCounts.size()) {
                     if (maxNumBehaviors.compare_exchange_weak(knownMaxBehaviors, behCounts.size()))
                         break;

--- a/plugins/behavior/binary_behavior_dataset.cc
+++ b/plugins/behavior/binary_behavior_dataset.cc
@@ -278,7 +278,7 @@ struct BinaryBehaviorDataset::Itl: public ColumnIndex, public MatrixView {
         return doGetColumnPath(BH(column.hash()));
     }
 
-    virtual size_t getRowCount() const
+    virtual uint64_t getRowCount() const
     {
         return behs->subjectCount();
     }

--- a/plugins/embedding/embedding.cc
+++ b/plugins/embedding/embedding.cc
@@ -473,7 +473,7 @@ struct EmbeddingDataset::Itl
         return applyOffsetLimit(offset, limit, result);
     }
 
-    virtual size_t getRowCount() const override
+    virtual uint64_t getRowCount() const override
     {
         auto repr = committed();
         if (!repr->initialized())

--- a/plugins/mongodb/mongo_dataset.cc
+++ b/plugins/mongodb/mongo_dataset.cc
@@ -42,7 +42,7 @@ struct MongoMatrixView : MatrixView {
         return vector<RowHash>{};
     }
 
-    size_t getRowCount() const override
+    uint64_t getRowCount() const override
     {
         return -1;
     }

--- a/plugins/sparse/sparse_matrix_dataset.cc
+++ b/plugins/sparse/sparse_matrix_dataset.cc
@@ -952,7 +952,7 @@ struct SparseMatrixDataset::Itl
         return MR_NO;
     }
 
-    virtual size_t getRowCount() const override
+    virtual uint64_t getRowCount() const override
     {
         auto trans = getReadTransaction();
         return trans->matrix->rowCount();

--- a/plugins/sqlite/sqlite_dataset.cc
+++ b/plugins/sqlite/sqlite_dataset.cc
@@ -508,7 +508,7 @@ struct SqliteSparseDataset::Itl
         return runQuery<ColumnPath>(query);
     }
 
-    virtual size_t getRowCount() const
+    virtual uint64_t getRowCount() const
     {
         return runScalarQuery<size_t>("SELECT count(DISTINCT rowName) FROM rows");
     }

--- a/plugins/tabular/tabular_dataset.cc
+++ b/plugins/tabular/tabular_dataset.cc
@@ -906,7 +906,7 @@ struct TabularDataset::TabularDataStore
             return stats;
         }
 
-        virtual size_t getRowCount() const override
+        virtual uint64_t getRowCount() const override
         {
             return rowCount;
         }
@@ -1326,7 +1326,7 @@ struct TabularDataset::TabularDataStore
         return currentState.load()->getColumnStats(column, stats);
     }
 
-    virtual size_t getRowCount() const override
+    virtual uint64_t getRowCount() const override
     {
         return currentState.load()->getRowCount();
     }

--- a/sql/expression_value.h
+++ b/sql/expression_value.h
@@ -1451,9 +1451,19 @@ struct ScalarExpressionValueInfoT: public ExpressionValueInfoT<Storage> {
         return value.isAtom() || value.empty();
     }
 
-    virtual std::string getScalarDescription() const
+    static std::string getScalarDescription_switch(std::true_type)
+    {
+        return (std::is_signed_v<Storage> ? "i" : "u") + std::to_string(sizeof(Storage) * 8);
+    }
+
+    static std::string getScalarDescription_switch(std::false_type)
     {
         return MLDB::type_name<Storage>();
+    }
+
+    virtual std::string getScalarDescription() const
+    {
+        return getScalarDescription_switch(std::is_integral<Storage>());
     }
 
     virtual std::vector<ssize_t> getEmbeddingShape() const

--- a/testing/MLDB-1486-embedding-types.js
+++ b/testing/MLDB-1486-embedding-types.js
@@ -21,7 +21,7 @@ var expected = [
       "result",
       1,
       "scalar",
-      "long",
+      "i64",
       "MLDB::IntegerValueInfo"
    ]
 ];

--- a/testing/MLDB-1891-case-in-import.py
+++ b/testing/MLDB-1891-case-in-import.py
@@ -150,7 +150,7 @@ class MLDB1891CaseInImport(MldbUnitTest):  # noqa
         res = mldb.query("select static_type(CASE x WHEN 'patate' THEN 0 WHEN 'banane' THEN 1 END) as * FROM test");
         
         expected = [["_rowName", "isConstant", "kind", "scalar", "type"],
-                    ["row", 0, "scalar", "long", "MLDB::IntegerValueInfo"]]
+                    ["row", 0, "scalar", "i64", "MLDB::IntegerValueInfo"]]
 
         self.assertTableResultEquals(res, expected)
 
@@ -173,7 +173,7 @@ class MLDB1891CaseInImport(MldbUnitTest):  # noqa
                 "dense",
                 0,
                 "scalar",
-                "long",
+                "i64",
                 "MLDB::VariantExpressionValueInfo"
             ]
         ]
@@ -199,7 +199,7 @@ class MLDB1891CaseInImport(MldbUnitTest):  # noqa
                 "sparse",
                 1,
                 "scalar",
-                "long",
+                "i64",
                 "MLDB::IntegerValueInfo"
             ]
         ]
@@ -230,12 +230,12 @@ class MLDB1891CaseInImport(MldbUnitTest):  # noqa
                 "dense",
                 0,
                 "scalar",
-                "long",
+                "i64",
                 "MLDB::VariantExpressionValueInfo",
                 "b",
                 "sparse",
                 "scalar",
-                "long",
+                "i64",
                 "MLDB::IntegerValueInfo"
             ]
         ]


### PR DESCRIPTION
MLDB has been developed on platforms where `size_t`, `uint64_t` and `unsigned long long` are the same thing.  This is not the case on OSX.  This patch series fixes the confusion, and modifies the internal MLDB type system to call integral types "i64" and "u64" instead of the C++ names like "long long" which can vary between platforms.

One more step along the way to OSX support.