### PR TITLE
Fix failed test causing junit script to hang

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ build:
     - ./sccache --show-stats
     - declare -x LANG=en_US.utf8 LC_ALL=en_US.utf8 USER=root
     - mkdir tmp
-    - (make -j8 -k test || make -j8 -k test) | python3 jml-build/to_junit.py > junit.xml
+    - (make -j8 -k test || (echo "TEST SUITE RESTART" && make -j8 -k test)) | python3 jml-build/to_junit.py > junit.xml
   artifacts:
     when: always
     paths:


### PR DESCRIPTION
When a test failed, we sometimes crashed the junit script, leading to a hang.  This fixes the hang and ensures that the test suite will eventually finish, turning a timeout on test failure into an explicit test failure.