### PR TITLE
connection->sendResponse() --> connection->sendJsonResponse() and UTF-8

### DIFF
--- a/builtin/js/js_plugin.cc
+++ b/builtin/js/js_plugin.cc
@@ -316,13 +316,13 @@ setRequestHandler(const v8::FunctionCallbackInfo<v8::Value> & args)
                         LOG(itl->loader) << jsonEncode(exc) << endl;
                     }
 
-                    connection.sendResponse(400, jsonEncode(exc));
+                    connection.sendJsonResponse(400, jsonEncode(exc));
                     return RestRequestRouter::MR_YES;
                 }
 
                 Json::Value jsonResult = JS::fromJS(result.ToLocalChecked());
 
-                connection.sendResponse(200, jsonResult);
+                connection.sendJsonResponse(200, jsonResult);
 
                 return RestRequestRouter::MR_YES;
             };
@@ -583,7 +583,7 @@ handleTypeRoute(RestDirectory * engine,
                 }
             }
             else {
-                conn.sendResponse(200, symbolData);
+                conn.sendJsonResponse(200, symbolData);
                 return RestRequestRouter::MR_YES;
             }
         }

--- a/builtin/js/mldb_js.cc
+++ b/builtin/js/mldb_js.cc
@@ -741,7 +741,7 @@ struct MldbJS::Methods {
         if (!connection->response().empty()) {
             JS::set(isolate, result, "response", JS::toJS(connection->response()));
             if (connection->contentType() == "application/json") {
-                JS::set(isolate, result, "json", JS::toJS(Json::parse(connection->response())));
+		JS::set(isolate, result, "json", JS::toJS(Json::parse(connection->response().rawString())));
             }
         }
 

--- a/builtin/python/python_plugin.cc
+++ b/builtin/python/python_plugin.cc
@@ -287,8 +287,8 @@ handleRequest(RestConnection & connection,
              locals);
         
         if (last_output.exception) {
-            connection.sendResponse(last_output.getReturnCode(),
-                                    jsonEncode(last_output));
+            connection.sendJsonResponse(last_output.getReturnCode(),
+                                        jsonEncode(last_output));
         }
         else {
             last_output.result = std::move(pyRestRequest->returnValue);
@@ -301,8 +301,8 @@ handleRequest(RestConnection & connection,
             
             last_output.setReturnCode(pyRestRequest->returnCode);
 
-            connection.sendResponse(last_output.getReturnCode(),
-                                    jsonEncode(last_output.result));
+            connection.sendJsonResponse(last_output.getReturnCode(),
+                                        jsonEncode(last_output.result));
         }
         
         return MR_YES;
@@ -375,8 +375,8 @@ handleTypeRoute(RestDirectory * engine,
         }
         std::stable_sort(output.logs.begin(), output.logs.end());
         
-        conn.sendResponse(output.getReturnCode(),
-                          jsonEncode(output));
+        conn.sendJsonResponse(output.getReturnCode(),
+                              jsonEncode(output));
         
         interpreter.destroy();
         

--- a/builtin/script_function.cc
+++ b/builtin/script_function.cc
@@ -101,10 +101,10 @@ apply(const FunctionApplier & applier,
     // TODO. better exception message
     if(connection->responseCode() != 200) {
         throw AnnotatedException(400, "responseCode != 200 for function",
-                                 Json::parse(connection->response()));
+                                 Json::parse(connection->response().rawString()));
     }
 
-    Json::Value result = Json::parse(connection->response())["result"];
+    Json::Value result = Json::parse(connection->response().rawString())["result"];
     
     vector<tuple<PathElement, ExpressionValue>> vals;
     if(!result.isArray()) {

--- a/builtin/script_procedure.cc
+++ b/builtin/script_procedure.cc
@@ -118,7 +118,7 @@ run(const ProcedureRunConfig & run,
             details["exception"] = jsonEncode(parsed.exception);
     }
 
-    Json::Value result = Json::parse(connection->response());
+    Json::Value result = Json::parse(connection->response().rawString());
 
     return RunOutput(result["result"], details);
 }

--- a/core/dataset.cc
+++ b/core/dataset.cc
@@ -2248,7 +2248,7 @@ handleRequest(RestConnection & connection,
         + "' does not respond to custom route '" + context.remaining + "'";
     error["details"]["verb"] = request.verb;
     error["details"]["resource"] = request.resource;
-    connection.sendErrorResponse(400, error);
+    connection.sendJsonErrorResponse(400, error);
     return RestRequestRouter::MR_ERROR;
 }
 

--- a/core/function.cc
+++ b/core/function.cc
@@ -185,7 +185,7 @@ handleRequest(RestConnection & connection,
         + "' does not respond to custom route '" + context.remaining + "'";
     error["details"]["verb"] = request.verb;
     error["details"]["resource"] = request.resource;
-    connection.sendErrorResponse(400, error);
+    connection.sendJsonErrorResponse(400, error);
     return RestRequestRouter::MR_ERROR;
 }
 

--- a/core/plugin.cc
+++ b/core/plugin.cc
@@ -73,7 +73,7 @@ handleRequest(RestConnection & connection,
         + "' does not respond to custom route '" + context.remaining + "'";
     error["details"]["verb"] = request.verb;
     error["details"]["resource"] = request.resource;
-    connection.sendErrorResponse(400, error);
+    connection.sendJsonErrorResponse(400, error);
     return RestRequestRouter::MR_ERROR;
 }
 

--- a/core/sensor.cc
+++ b/core/sensor.cc
@@ -76,7 +76,7 @@ handleRequest(RestConnection & connection,
         + "' does not respond to custom route '" + context.remaining + "'";
     error["details"]["verb"] = request.verb;
     error["details"]["resource"] = request.resource;
-    connection.sendErrorResponse(400, error);
+    connection.sendJsonErrorResponse(400, error);
     return MR_ERROR;
 }
 

--- a/engine/dataset_collection.cc
+++ b/engine/dataset_collection.cc
@@ -67,7 +67,7 @@ void runHttpQuery(std::function<std::vector<MatrixNamedRow> ()> runQuery,
     }
 
     if (format == "full" || format == "") {
-        connection.sendResponse(200, jsonEncodeStr(sparseOutput),
+        connection.sendResponse(200, jsonEncodeUtf8(sparseOutput),
                                 "application/json");
     }
     else if (format == "sparse") {
@@ -93,7 +93,7 @@ void runHttpQuery(std::function<std::vector<MatrixNamedRow> ()> runQuery,
             output.emplace_back(std::move(rowOut));
         }
 
-        connection.sendResponse(200, jsonEncodeStr(output),
+        connection.sendResponse(200, jsonEncodeUtf8(output),
                                 "application/json");
     }
     else if (format == "soa") {
@@ -117,7 +117,8 @@ void runHttpQuery(std::function<std::vector<MatrixNamedRow> ()> runQuery,
                 vals[i] = val;
             }
         }
-        connection.sendResponse(200, jsonEncodeStr(output),
+
+        connection.sendResponse(200, jsonEncodeUtf8(output),
                                 "application/json");
     }
     else if (format == "aos") {
@@ -140,7 +141,7 @@ void runHttpQuery(std::function<std::vector<MatrixNamedRow> ()> runQuery,
 
             output.emplace_back(std::move(row));
         }
-        connection.sendResponse(200, jsonEncodeStr(output),
+        connection.sendResponse(200, jsonEncodeUtf8(output),
                                 "application/json");
     }
     else if (format == "table") {
@@ -231,39 +232,39 @@ void runHttpQuery(std::function<std::vector<MatrixNamedRow> ()> runQuery,
             output.push_back(rowOut);
         }
 
-        connection.sendResponse(200, jsonEncodeStr(output),
+        connection.sendResponse(200, jsonEncodeUtf8(output),
                                 "application/json");
     }
     else if (format == "atom") {
         if (sparseOutput.size() > 1) {
-            connection.sendErrorResponse(400, "Query with atom format returning multiple rows. Consider using limit.");
+            connection.sendJsonErrorResponse(400, "Query with atom format returning multiple rows. Consider using limit.");
             return;
         }
 
         if (sparseOutput.size() == 0) {
-            connection.sendErrorResponse(400, "Query with atom format returned no rows.");
+            connection.sendJsonErrorResponse(400, "Query with atom format returned no rows.");
             return;
         }
 
         const auto& columns = sparseOutput[0].columns;
 
         if (columns.size() == 0) {
-            connection.sendErrorResponse(400, "Query with atom format returned no columns.");
+            connection.sendJsonErrorResponse(400, "Query with atom format returned no columns.");
             return;
         }
 
         if (columns.size() > 1) {
-            connection.sendErrorResponse(400, "Query with atom format returned multiple columns.");
+            connection.sendJsonErrorResponse(400, "Query with atom format returned multiple columns.");
             return;
         }
 
         const auto& val = std::get<1>(columns[0]);
 
-        connection.sendResponse(200, jsonEncodeStr(val),
+        connection.sendResponse(200, jsonEncodeUtf8(val),
                                 "application/json"); 
     }
     else {
-        connection.sendErrorResponse(400, "Unknown output format '" + format + "'");
+        connection.sendJsonErrorResponse(400, "Unknown output format '" + format + "'");
     }
 }
 
@@ -506,7 +507,7 @@ initRoutes(RouteManager & manager)
             } catch (const std::exception & exc) {
                 return sendExceptionResponse(connection, exc);
             } MLDB_CATCH_ALL {
-                connection.sendErrorResponse(400, "Unknown exception was thrown");
+                connection.sendJsonErrorResponse(400, "Unknown exception was thrown");
                 return RestRequestRouter::MR_ERROR;
             }
         };

--- a/engine/function_collection.cc
+++ b/engine/function_collection.cc
@@ -235,7 +235,7 @@ applyBatch(const Function * function,
         };
 
     if (inputs.isNull()) {
-        connection.sendResponse(200, inputs, "application/json");
+        connection.sendJsonResponse(200, inputs, "application/json");
         return;
     }
     else if (inputs.isArray()) {
@@ -361,7 +361,7 @@ initRoutes(RouteManager & manager)
             } catch (const std::exception & exc) {
                 return sendExceptionResponse(connection, exc);
             } MLDB_CATCH_ALL {
-                connection.sendErrorResponse(400, "Unknown exception was thrown");
+                connection.sendJsonErrorResponse(400, "Unknown exception was thrown");
                 return RestRequestRouter::MR_ERROR;
             }
         };

--- a/engine/plugin_collection.cc
+++ b/engine/plugin_collection.cc
@@ -110,7 +110,7 @@ initRoutes(RouteManager & manager)
             auto key = manager.getKey(cxt);
 
             try {
-                connection.sendResponse(200, jsonEncode(plugin->getVersion()));
+                connection.sendJsonResponse(200, jsonEncode(plugin->getVersion()));
                 return RestRequestRouter::MR_YES;
             }
             catch (const AnnotatedException & exc) {

--- a/engine/procedure_collection.cc
+++ b/engine/procedure_collection.cc
@@ -179,7 +179,7 @@ handlePutWithFirstRun(Utf8String key, PolyConfig config, bool mustBeNew, bool as
         
         Json::Value runResponse;
         Json::Reader reader;
-        if (!reader.parse(connection->response(), runResponse, false)) {
+        if (!reader.parse(connection->response().rawString(), runResponse, false)) {
             throw AnnotatedException
                 (500, "failed to create the initial run",
                  "entry", key,

--- a/engine/sensor_collection.cc
+++ b/engine/sensor_collection.cc
@@ -108,7 +108,7 @@ initRoutes(RouteManager & manager)
             auto key = manager.getKey(cxt);
 
             try {
-                connection.sendResponse(200, jsonEncode(sensor->getVersion()));
+                connection.sendJsonResponse(200, jsonEncode(sensor->getVersion()));
                 return RestRequestRouter::MR_YES;
             }
             catch (const AnnotatedException & exc) {

--- a/engine/static_content_macro.cc
+++ b/engine/static_content_macro.cc
@@ -443,7 +443,7 @@ void configMacro(MacroContext & context,
         context.writeText("mldb.put(\"/v1/" + kind + "s/\"+<id>, {\n"+
                               "    \"type\": \"" + type + "\"");
         
-        Json::Value params = Json::parse(connection->response());
+        Json::Value params = Json::parse(connection->response().rawString());
         string typeName;
         bool withParams = false;
         if (!params.isNull()) {
@@ -522,7 +522,7 @@ void availabletypesMacro(MacroContext & context,
         };
 
         Json::Value params
-            = internalEntitiesFilter(Json::parse(connection->response()));
+            = internalEntitiesFilter(Json::parse(connection->response().rawString()));
 
         if(format == "list") {
             context.writeHtml("<ul>\n");

--- a/plugins/feature_gen/dist_table_procedure.cc
+++ b/plugins/feature_gen/dist_table_procedure.cc
@@ -654,7 +654,7 @@ handleRequest(RestConnection & connection,
 
         increment(result.keys, result.outcomes);
 
-        connection.sendResponse(200, Json::Value("OK"), "application/json");
+        connection.sendJsonResponse(200, Json::Value("OK"), "application/json");
         return RestRequestRouter::MR_YES;
     }
     else if (context.remaining == "/persist") {
@@ -668,7 +668,7 @@ handleRequest(RestConnection & connection,
 
         persist(result.modelFileUrl);
 
-        connection.sendResponse(200, Json::Value("OK"), "application/json");
+        connection.sendJsonResponse(200, Json::Value("OK"), "application/json");
         return RestRequestRouter::MR_YES;
 
     }

--- a/rest/http_rest_endpoint.cc
+++ b/rest/http_rest_endpoint.cc
@@ -184,31 +184,31 @@ void
 HttpRestEndpoint::RestConnectionHandler::
 sendErrorResponse(int code, const Json::Value & error)
 {
-    std::string encodedError = error.toString();
+    Utf8String encodedError = error.toStringUtf8();
     
     logRequest(code);
     putResponseOnWire(HttpResponse(code, "application/json",
-                                   std::move(encodedError),
+                                   encodedError.stealRawString(),
                                    endpoint->extraHeaders),
                       nullptr, NEXT_CLOSE);
 }
 
 void
 HttpRestEndpoint::RestConnectionHandler::
-sendResponse(int code,
-             const Json::Value & response,
-             std::string contentType,
-             RestParams headers)
+sendJsonResponse(int code,
+                 const Json::Value & response,
+                 std::string contentType,
+                 RestParams headers)
 {
     return sendResponse(code,
-                        response.toString(), std::move(contentType),
+                        response.toStringUtf8(), std::move(contentType),
                         std::move(headers));
 }
 
 void
 HttpRestEndpoint::RestConnectionHandler::
 sendResponse(int code,
-             std::string body, std::string contentType,
+             Utf8String body, std::string contentType,
              RestParams headers)
 {
     for (auto & h: endpoint->extraHeaders)
@@ -216,7 +216,7 @@ sendResponse(int code,
 
     logRequest(code);
     putResponseOnWire(HttpResponse(code,
-                                   std::move(contentType), std::move(body),
+                                   std::move(contentType), body.stealRawString(),
                                    std::move(headers)));
 }
 
@@ -242,11 +242,11 @@ sendResponseHeader(int code, std::string contentType, RestParams headers)
 
 void
 HttpRestEndpoint::RestConnectionHandler::
-sendHttpChunk(std::string chunk,
+sendHttpChunk(Utf8String chunk,
               NextAction next,
               OnWriteFinished onWriteFinished)
 {
-    HttpLegacySocketHandler::send(std::move(chunk), next, onWriteFinished);
+    HttpLegacySocketHandler::send(chunk.rawString(), next, onWriteFinished);
 }
 
 inline void

--- a/rest/http_rest_endpoint.h
+++ b/rest/http_rest_endpoint.h
@@ -82,13 +82,13 @@ struct HttpRestEndpoint {
 
         void sendErrorResponse(int code, const Json::Value & error);
 
-        void sendResponse(int code,
-                          const Json::Value & response,
-                          std::string contentType = "application/json",
-                          RestParams headers = RestParams());
+        void sendJsonResponse(int code,
+                              const Json::Value & response,
+                              std::string contentType = "application/json",
+                              RestParams headers = RestParams());
 
         void sendResponse(int code,
-                          std::string body, std::string contentType,
+                          Utf8String, std::string contentType,
                           RestParams headers = RestParams());
 
         void sendResponseHeader(int code,
@@ -97,7 +97,7 @@ struct HttpRestEndpoint {
 
         /** Send an HTTP chunk with the appropriate headers back down the
             wire. */
-        void sendHttpChunk(std::string chunk,
+        void sendHttpChunk(Utf8String chunk,
                            NextAction next = NEXT_CONTINUE,
                            OnWriteFinished onWriteFinished = OnWriteFinished());
 
@@ -110,7 +110,7 @@ struct HttpRestEndpoint {
 
     typedef std::function<void (std::shared_ptr<RestConnectionHandler> connection,
                                 const HttpHeader & header,
-                                const std::string & payload)> OnRequest;
+                                const Utf8String & payload)> OnRequest;
 
     OnRequest onRequest;
 

--- a/rest/http_rest_service.h
+++ b/rest/http_rest_service.h
@@ -72,22 +72,22 @@ struct HttpRestConnection: public RestConnection {
 
     /** Send the given response back on the connection. */
     virtual void sendResponse(int responseCode,
-                              std::string response,
-                              std::string contentType);
+                              Utf8String response,
+                              std::string contentType) override;
     
     /** Send the given response back on the connection. */
-    virtual void sendResponse(int responseCode,
-                              const Json::Value & response,
-                              std::string contentType = "application/json");
+    virtual void sendJsonResponse(int responseCode,
+                                  const Json::Value & response,
+                                  std::string contentType = "application/json") override;
     
-    virtual void sendRedirect(int responseCode, std::string location);
+    virtual void sendRedirect(int responseCode, std::string location) override;
 
     /** Send an HTTP-only response with the given headers.  If it's not
         an HTTP connection, this will fail.
     */
     virtual void sendHttpResponse(int responseCode,
-                                  std::string response, std::string contentType,
-                                  RestParams headers);
+                                  Utf8String response, std::string contentType,
+                                  RestParams headers) override;
 
     /** Send an HTTP-only response header.  This will not close the connection.  A
         contentLength of -1 means don't send it (for when the content length is
@@ -97,35 +97,35 @@ struct HttpRestConnection: public RestConnection {
     virtual void sendHttpResponseHeader(int responseCode,
                                         std::string contentType,
                                         ssize_t contentLength,
-                                        RestParams headers = RestParams());
+                                        RestParams headers = RestParams()) override;
     
     /** Send a payload (or a chunk of a payload) for an HTTP connection. */
-    virtual void sendPayload(std::string payload);
+    virtual void sendPayload(Utf8String payload) override;
 
     /** Finish the response, recycling or closing the connection. */
-    virtual void finishResponse();
+    virtual void finishResponse() override;
 
     /** Send the given error string back on the connection. */
     virtual void sendErrorResponse(int responseCode,
-                                   std::string error,
-                                   std::string contentType);
+                                   Utf8String error,
+                                   std::string contentType) override;
     
-    virtual void sendErrorResponse(int responseCode, const Json::Value & error);
+    virtual void sendJsonErrorResponse(int responseCode, const Json::Value & error) override;
 
     using RestConnection::sendErrorResponse;
 
-    virtual bool responseSent() const
+    virtual bool responseSent() const override
     {
         return responseSent_;
     }
 
-    virtual bool isConnected() const;
+    virtual bool isConnected() const override;
 
     virtual std::shared_ptr<RestConnection>
-    capture(std::function<void ()> onDisconnect);
+    capture(std::function<void ()> onDisconnect) override;
 
     virtual std::shared_ptr<RestConnection>
-    captureInConnection(std::shared_ptr<void> piggyBack);
+    captureInConnection(std::shared_ptr<void> piggyBack) override;
 };
 
 

--- a/rest/in_process_rest_connection.cc
+++ b/rest/in_process_rest_connection.cc
@@ -28,7 +28,7 @@ struct InProcessRestConnection::Itl {
     int responseCode = -1;
     std::string contentType;
     RestParams headers;
-    std::string response;
+    Utf8String response;
 
     enum State {
         NOTHING_SENT,
@@ -98,7 +98,7 @@ InProcessRestConnection::
 
 void
 InProcessRestConnection::
-sendResponse(int responseCode, std::string response, std::string contentType)
+sendResponse(int responseCode, Utf8String response, std::string contentType)
 {
     std::unique_lock<std::mutex> guard(itl->responseMutex);
     itl->startResponse();
@@ -111,7 +111,7 @@ sendResponse(int responseCode, std::string response, std::string contentType)
 
 void
 InProcessRestConnection::
-sendResponse(int responseCode,
+sendJsonResponse(int responseCode,
              const Json::Value & response,
              std::string contentType)
 {
@@ -139,7 +139,7 @@ sendRedirect(int responseCode, std::string location)
 void
 InProcessRestConnection::
 sendHttpResponse(int responseCode,
-                 std::string response, std::string contentType,
+                 Utf8String response, std::string contentType,
                  RestParams headers)
 {
     std::unique_lock<std::mutex> guard(itl->responseMutex);
@@ -169,7 +169,7 @@ sendHttpResponseHeader(int responseCode,
 
 void
 InProcessRestConnection::
-sendPayload(std::string payload)
+sendPayload(Utf8String payload)
 {
     std::unique_lock<std::mutex> guard(itl->responseMutex);
     itl->continueResponse();
@@ -186,7 +186,7 @@ finishResponse()
 
 void InProcessRestConnection::
 sendErrorResponse(int responseCode,
-                  std::string error, std::string contentType)
+                  Utf8String error, std::string contentType)
 {
     std::unique_lock<std::mutex> guard(itl->responseMutex);
     itl->startResponse();
@@ -198,7 +198,7 @@ sendErrorResponse(int responseCode,
 }
 
 void InProcessRestConnection::
-sendErrorResponse(int responseCode, const Json::Value & error)
+sendJsonErrorResponse(int responseCode, const Json::Value & error)
 {
     std::unique_lock<std::mutex> guard(itl->responseMutex);
     itl->startResponse();
@@ -262,7 +262,7 @@ headers() const
     return itl->headers;
 }
 
-const std::string &
+const Utf8String &
 InProcessRestConnection::
 response() const
 {
@@ -271,7 +271,7 @@ response() const
     return itl->response;
 }
 
-std::string
+Utf8String
 InProcessRestConnection::
 stealResponse()
 {

--- a/rest/in_process_rest_connection.h
+++ b/rest/in_process_rest_connection.h
@@ -29,61 +29,61 @@ public:
     // pointer.
     static std::shared_ptr<InProcessRestConnection> create();
 
-    virtual ~InProcessRestConnection();
+    virtual ~InProcessRestConnection() override;
 
     using RestConnection::sendResponse;
 
     /** Send the given response back on the connection. */
     virtual void sendResponse(int responseCode,
-                              std::string response,
-                              std::string contentType);
+                              Utf8String response,
+                              std::string contentType) override;
 
     /** Send the given response back on the connection. */
     virtual void
-    sendResponse(int responseCode,
-                 const Json::Value & response,
-                 std::string contentType = "application/json");
+    sendJsonResponse(int responseCode,
+                     const Json::Value & response,
+                     std::string contentType = "application/json") override;
 
-    virtual void sendRedirect(int responseCode, std::string location);
+    virtual void sendRedirect(int responseCode, std::string location) override;
 
     /** Send an HTTP-only response with the given headers.  If it's not
         an HTTP connection, this will fail.
     */
     virtual void sendHttpResponse(int responseCode,
-                                  std::string response, std::string contentType,
-                                  RestParams headers);
+                                  Utf8String response, std::string contentType,
+                                  RestParams headers) override;
 
     virtual void
     sendHttpResponseHeader(int responseCode,
                            std::string contentType, ssize_t contentLength,
-                           RestParams headers = RestParams());
+                           RestParams headers = RestParams()) override;
 
-    virtual void sendPayload(std::string payload);
+    virtual void sendPayload(Utf8String payload) override;
 
-    virtual void finishResponse();
+    virtual void finishResponse() override;
 
     /** Send the given error string back on the connection. */
     virtual void sendErrorResponse(int responseCode,
-                                   std::string error,
-                                   std::string contentType);
+                                   Utf8String error,
+                                   std::string contentType) override;
 
     using RestConnection::sendErrorResponse;
 
-    virtual void sendErrorResponse(int responseCode, const Json::Value & error);
-    virtual bool responseSent() const;
-    virtual bool isConnected() const;
+    virtual void sendJsonErrorResponse(int responseCode, const Json::Value & error) override;
+    virtual bool responseSent() const override;
+    virtual bool isConnected() const override;
 
     int responseCode() const;
     const std::string & contentType() const;
     const RestParams & headers() const;
-    const std::string & response() const;
-    std::string stealResponse();
+    const Utf8String & response() const;
+    Utf8String stealResponse();
 
     virtual std::shared_ptr<RestConnection>
-    capture(std::function<void ()> onDisconnect = nullptr);
+    capture(std::function<void ()> onDisconnect = nullptr) override;
 
     virtual std::shared_ptr<RestConnection>
-    captureInConnection(std::shared_ptr<void> toCapture = nullptr);
+    captureInConnection(std::shared_ptr<void> toCapture = nullptr) override;
 
     // In the case of a captured connection, this will block until the full
     // response has been received.  This is used to deal with asynchronous

--- a/rest/poly_collection_impl.h
+++ b/rest/poly_collection_impl.h
@@ -230,7 +230,7 @@ struct PolyCollection<Entity>::Registry {
         guard.unlock();
 
         if (!it->second.docRoute) {
-            connection.sendErrorResponse(404, "type " + type + " has no documentation registered");
+            connection.sendJsonErrorResponse(404, "type " + type + " has no documentation registered");
             return MR_YES;
         }
         return it->second.docRoute(server, connection, req, const_cast<RestRequestParsingContext &>(cxt));
@@ -282,7 +282,7 @@ struct PolyCollection<Entity>::Registry {
                       const RestRequestParsingContext & cxt)
     {
         Json::Value result = getTypeInfo(nounPlural, type);
-        connection.sendResponse(200, result);
+        connection.sendJsonResponse(200, result);
         return MR_YES;
     }
 
@@ -305,7 +305,7 @@ struct PolyCollection<Entity>::Registry {
         guard.unlock();
 
         if (!it->second.customRoute) {
-            connection.sendErrorResponse(404, "type " + type + " has no custom route handler registered");
+            connection.sendJsonErrorResponse(404, "type " + type + " has no custom route handler registered");
             return MR_YES;
         }
         return it->second.customRoute(server, connection, req, const_cast<RestRequestParsingContext &>(cxt));

--- a/rest/rest_collection_impl.h
+++ b/rest/rest_collection_impl.h
@@ -304,7 +304,7 @@ initNodes(RouteManager & result)
                         = nounSingular + " entry '"
                         + resource + "' does not exist or has been deleted";
                 }
-                connection.sendResponse(404, error);
+                connection.sendJsonResponse(404, error);
             }
             else {
                 context.addSharedPtr(ptr);
@@ -348,8 +348,8 @@ initRoutes(RouteManager & result)
                 auto collection = result.getCollection(cxt);
 
                 MLDB_TRACE_EXCEPTIONS(false);
-                auto resultStr = jsonEncodeStr(collection->getKeys());
-                connection.sendHttpResponse(200, resultStr,
+                auto resultStr = jsonEncodeUtf8(collection->getKeys());
+                connection.sendHttpResponse(200, std::move(resultStr),
                                             "application/json", {});
                 return RestRequestRouter::MR_YES;
             } catch (const std::exception & exc) {
@@ -403,7 +403,7 @@ handleGetValue(Key key,
 
     if (found.second) {
         // under construction
-        connection.sendResponse(200, found.second->progress);
+        connection.sendJsonResponse(200, found.second->progress);
         return RestRequestRouter::MR_YES;
     }
     else {
@@ -956,7 +956,7 @@ handleGetExistingValue(Key key,
                        const RestRequest & request,
                        const RestRequestParsingContext & context) const
 {
-    connection.sendResponse(200, getExistingValue(key, value));
+    connection.sendJsonResponse(200, getExistingValue(key, value));
     return RestRequestRouter::MR_YES;
 }
 
@@ -1526,7 +1526,7 @@ addPutRoute()
                     { "EntityPath", jsonEncodeStr(path) }
                 };
 
-                connection.sendHttpResponse(202, jsonEncodeStr(status),
+                connection.sendHttpResponse(202, jsonEncodeUtf8(status),
                                             "application/json", headers);
 
                 return RestRequestRouter::MR_YES;
@@ -1566,7 +1566,7 @@ addPutRoute()
                     { "EntityPath", jsonEncodeStr(path) }
                 };
 
-                connection.sendHttpResponse(201, jsonEncodeStr(status),
+                connection.sendHttpResponse(201, jsonEncodeUtf8(status),
                                             "application/json", headers);
 
                 return RestRequestRouter::MR_YES;
@@ -1631,7 +1631,7 @@ addPostRoute()
                     { "EntityPath", jsonEncodeStr(path) }
                 };
 
-                connection.sendHttpResponse(201, jsonEncodeStr(status),
+                connection.sendHttpResponse(201, jsonEncodeUtf8(status),
                                             "application/json", headers);
 
                 return RestRequestRouter::MR_YES;
@@ -1667,7 +1667,7 @@ addPostRoute()
                     { "EntityPath", jsonEncodeStr(path) }
                 };
 
-                connection.sendHttpResponse(201, jsonEncodeStr(status),
+                connection.sendHttpResponse(201, jsonEncodeUtf8(status),
                                             "application/json", headers);
 
                 return RestRequestRouter::MR_YES;

--- a/rest/rest_connection.h
+++ b/rest/rest_connection.h
@@ -33,20 +33,20 @@ struct RestConnection {
                               const char * response,
                               std::string contentType)
     {
-        return sendResponse(responseCode, std::string(response),
+        return sendResponse(responseCode, Utf8String(response),
                             std::move(contentType));
     }
     
     /** Send the given response back on the connection. */
     virtual void sendResponse(int responseCode,
-                              std::string response,
+                              Utf8String response,
                               std::string contentType) = 0;
     
     /** Send the given response back on the connection. */
     virtual void
-    sendResponse(int responseCode,
-                 const Json::Value & response,
-                 std::string contentType = "application/json") = 0;
+    sendJsonResponse(int responseCode,
+                     const Json::Value & response,
+                     std::string contentType = "application/json") = 0;
     
     virtual void sendResponse(int responseCode)
     {
@@ -59,7 +59,7 @@ struct RestConnection {
         an HTTP connection, this will fail.
     */
     virtual void sendHttpResponse(int responseCode,
-                                  std::string response,
+                                  Utf8String response,
                                   std::string contentType,
                                   RestParams headers) = 0;
     
@@ -79,23 +79,23 @@ struct RestConnection {
                            RestParams headers = RestParams()) = 0;
     
     /** Send a payload (or a chunk of a payload) for an HTTP connection. */
-    virtual void sendPayload(std::string payload) = 0;
+    virtual void sendPayload(Utf8String payload) = 0;
 
     /** Finish the response, recycling or closing the connection. */
     virtual void finishResponse() = 0;
 
     /** Send the given error string back on the connection. */
     virtual void sendErrorResponse(int responseCode,
-                                   std::string error,
+                                   Utf8String error,
                                    std::string contentType) = 0;
     
     virtual void sendErrorResponse(int responseCode, const char * error,
                                    std::string contentType)
     {
-        sendErrorResponse(responseCode, std::string(error), "application/json");
+        sendErrorResponse(responseCode, Utf8String(error), contentType);
     }
 
-    virtual void sendErrorResponse(int responseCode, const Json::Value & error)
+    virtual void sendJsonErrorResponse(int responseCode, const Json::Value & error)
         = 0;
 
     virtual bool responseSent() const = 0;

--- a/rest/rest_request_binding.cc
+++ b/rest/rest_request_binding.cc
@@ -135,7 +135,7 @@ createRequestValidater(const Json::Value & argHelp,
                 details["unknownParameters"].append(std::move(detail));
             }
 
-            connection.sendErrorResponse(400, exc);
+            connection.sendJsonErrorResponse(400, exc);
             return false;
         };
 

--- a/rest/rest_request_binding.h
+++ b/rest/rest_request_binding.h
@@ -723,7 +723,7 @@ struct RestRequestBinder {
     catch (const std::exception & exc) { \
         return sendExceptionResponse(connection, exc); \
     } catch (...) { \
-        connection.sendErrorResponse(400, "unknown exception"); \
+        connection.sendJsonErrorResponse(400, "unknown exception"); \
         return RestRequestRouter::MR_ERROR; \
     }
 
@@ -1154,7 +1154,7 @@ struct RestRequestBinder<TypeList<PositionedDualTypes...> > {
                     if (excFn)
                         return excFn("unknown exception", std::current_exception(),
                                      connection, request, context);
-                    connection.sendErrorResponse(400, "unknown exception");
+                    connection.sendJsonErrorResponse(400, "unknown exception");
                     return RestRequestRouter::MR_ERROR;
                 }
             };
@@ -1211,7 +1211,7 @@ struct RestRequestBinder<TypeList<PositionedDualTypes...> > {
                     if (excFn)
                         return excFn("unknown exception", std::current_exception(),
                                      connection, request, context);
-                    connection.sendErrorResponse(400, "unknown exception");
+                    connection.sendJsonErrorResponse(400, "unknown exception");
                     return RestRequestRouter::MR_ERROR;
                 }
             };

--- a/rest/rest_request_router.cc
+++ b/rest/rest_request_router.cc
@@ -402,7 +402,7 @@ processRequest(RestConnection & connection,
         } catch (const std::exception & exc) {
             return sendExceptionResponse(connection, exc);
         } catch (...) {
-            connection.sendErrorResponse(500, "unknown exception");
+            connection.sendJsonErrorResponse(500, "unknown exception");
             return MR_YES;
         }
     }
@@ -655,7 +655,7 @@ addHelpRoute(PathSpec path, RequestFilter filter)
             } else {
                 getHelp(help, "", set<string>());
             }
-            connection.sendResponse(200, help);
+            connection.sendJsonResponse(200, help);
             return MR_YES;
         };
 
@@ -985,7 +985,7 @@ void
 RestRequestRouter::
 defaultNotFoundHandler(RestConnection & connection,
                        const RestRequest & request) {
-    connection.sendErrorResponse(404, "unknown resource " + request.verb + " " +  request.resource);
+    connection.sendJsonErrorResponse(404, "unknown resource " + request.verb + " " +  request.resource);
 };
 
 RestRequestMatchResult
@@ -1000,7 +1000,7 @@ sendExceptionResponse(RestConnection & connection,
         code = val["httpCode"].asInt();
     }
 
-    connection.sendResponse(code, val);
+    connection.sendJsonResponse(code, val);
     return RestRequestRouter::MR_ERROR;
 }
 

--- a/rest/rest_service_endpoint.h
+++ b/rest/rest_service_endpoint.h
@@ -92,36 +92,36 @@ struct RestServiceEndpoint {
 
         void sendResponse(int responseCode,
                           const char * response,
-                          std::string contentType)
+                          std::string contentType) override
         {
-            return sendResponse(responseCode, std::string(response),
+            return sendResponse(responseCode, Utf8String(response),
                                 std::move(contentType));
         }
 
         /** Send the given response back on the connection. */
         void sendResponse(int responseCode,
-                          std::string response,
-                          std::string contentType);
+                          Utf8String response,
+                          std::string contentType) override;
 
         /** Send the given response back on the connection. */
-        void sendResponse(int responseCode,
-                          const Json::Value & response,
-                          std::string contentType = "application/json");
+        void sendJsonResponse(int responseCode,
+                              const Json::Value & response,
+                              std::string contentType = "application/json") override;
 
         void sendResponse(int responseCode)
         {
             return sendResponse(responseCode, "", "");
         }
 
-        void sendRedirect(int responseCode, std::string location);
+        void sendRedirect(int responseCode, std::string location) override;
 
         /** Send an HTTP-only response with the given headers.  If it's not
             an HTTP connection, this will fail.
         */
         void sendHttpResponse(int responseCode,
-                              std::string response,
+                              Utf8String response,
                               std::string contentType,
-                              RestParams headers);
+                              RestParams headers) override;
 
         enum {
             UNKNOWN_CONTENT_LENGTH = -1,
@@ -136,42 +136,42 @@ struct RestServiceEndpoint {
         void sendHttpResponseHeader(int responseCode,
                                     std::string contentType,
                                     ssize_t contentLength,
-                                    RestParams headers = RestParams());
+                                    RestParams headers = RestParams()) override;
 
         /** Send a payload (or a chunk of a payload) for an HTTP connection. */
-        void sendPayload(std::string payload);
+        void sendPayload(Utf8String payload) override;
 
         /** Finish the response, recycling or closing the connection. */
-        void finishResponse();
+        void finishResponse() override;
 
         /** Send the given error string back on the connection. */
         void sendErrorResponse(int responseCode,
-                               std::string error,
-                               std::string contentType);
+                               Utf8String error,
+                               std::string contentType) override;
 
         void sendErrorResponse(int responseCode, const char * error,
-                               std::string contentType)
+                               std::string contentType) override
         {
-            sendErrorResponse(responseCode, std::string(error), "application/json");
+            sendErrorResponse(responseCode, Utf8String(error), "application/json");
         }
 
-        void sendErrorResponse(int responseCode, const Json::Value & error);
+        void sendJsonErrorResponse(int responseCode, const Json::Value & error) override;
 
-        bool responseSent() const
+        bool responseSent() const override
         {
             return itl->responseSent;
         }
 
-        bool isConnected() const
+        bool isConnected() const override
         {
             return itl->http->isConnected();
         }
 
         virtual std::shared_ptr<RestConnection>
-        capture(std::function<void ()> onDisconnect);
+        capture(std::function<void ()> onDisconnect) override;
 
         virtual std::shared_ptr<RestConnection>
-        captureInConnection(std::shared_ptr<void> piggyBack);
+        captureInConnection(std::shared_ptr<void> piggyBack) override;
     };
 
     void init();

--- a/rest/service_peer.cc
+++ b/rest/service_peer.cc
@@ -64,7 +64,7 @@ addRoutes()
         = [] (RestConnection & connection,
               const RestRequest & request,
               const RestRequestParsingContext & context) {
-        connection.sendResponse(200, "1");
+        connection.sendJsonResponse(200, "1");
         return RestRequestRouter::MR_YES;
     };
     

--- a/server/mldb_server.cc
+++ b/server/mldb_server.cc
@@ -151,7 +151,7 @@ initRoutes()
                const RestRequestParsingContext & context) {
         Json::Value result;
         result["apiVersions"]["v1"] = "1.0.0";
-        connection.sendResponse(200, result);
+        connection.sendJsonResponse(200, result);
         return RestRequestRouter::MR_YES;
     };
 
@@ -182,7 +182,7 @@ initRoutes()
 
         Json::Value result;
         result["shutdown"] = true;
-        connection.sendResponse(200, result);
+        connection.sendJsonResponse(200, result);
         return RestRequestRouter::MR_YES;
     };
 
@@ -246,7 +246,7 @@ initRoutes()
 
         versionNode.notFoundHandler = [&] (RestConnection & connection,
                                            const RestRequest & request) {
-            connection.sendErrorResponse(500, errorMessage);
+            connection.sendJsonErrorResponse(500, errorMessage);
         };
 
         router.notFoundHandler = versionNode.notFoundHandler;
@@ -298,7 +298,7 @@ handleRedirectToGet(RestConnection & connection,
     
     Json::Value redirectResponse;
     Json::Reader reader;
-    if (!reader.parse(redirectConnection->response(), redirectResponse, false))
+    if (!reader.parse(redirectConnection->response().rawString(), redirectResponse, false))
         throw AnnotatedException(500, "failed to parse the redirect call");
   
     if (200 > redirectConnection->responseCode()


### PR DESCRIPTION
This improves the API, by ensuring that JSON vs non-JSON responses have a
different method name and thus that the semantics don't depend upon the
implicit conversions to JSON::Value (or not).  That confusion was leading
to several places where the content-type was wrong, and worse, when an API
was improved to use a UTF8String instead of an ASCII string, it would
suddenly send it as a JSON object instead of the string itself.

This is a pure internal API change, with the users of the API updated for
the new semantics.