### PR TITLE
ID transducer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ container_files/nvidia/files/*.deb
 *.bak
 file::test*
 *.DS_Store
+airlines
+airlines.*

--- a/block/memory_region.cc
+++ b/block/memory_region.cc
@@ -336,7 +336,7 @@ newObject(const PathElement & name,
         desc.printJson(val, context);
     }
     //cerr << "doing metadata " << printed << endl;
-    auto entry = newEntry("md");
+    auto entry = newEntry(name);
     auto serializeTo = entry->allocateWritable(printed.rawLength(),
                                                1 /* alignment */);
     

--- a/plugins/tabular/frozen_column.cc
+++ b/plugins/tabular/frozen_column.cc
@@ -31,6 +31,53 @@ namespace MLDB {
 
 
 /*****************************************************************************/
+/* FROZEN COLUMN                                                             */
+/*****************************************************************************/
+
+void
+FrozenColumn::
+reconstituteMetadataHelper(StructuredReconstituter & reconstituter,
+                           void * md,
+                           const std::type_info & mdType)
+{
+    FrozenMemoryRegion mdRegion = reconstituter.getRegion("md");
+
+    Utf8StringJsonParsingContext context
+        (mdRegion.data(), mdRegion.length(),
+         (reconstituter.getContext() + "/md").rawString());
+        
+    std::shared_ptr<const ValueDescription> desc
+        = ValueDescription::get(mdType);
+    ExcAssert(desc);
+
+    int version = 0;
+    std::shared_ptr<void> mdObject;
+    
+    auto onMember = [&] ()
+        {
+            if (std::strcmp(context.fieldNamePtr(), "fmt") == 0) {
+                context.skip();
+            }
+            else if (std::strcmp(context.fieldNamePtr(), "type") == 0) {
+                context.skip();
+                //std::string structType = context.expectStringAscii();
+                // TODO: make sure it matches
+                //desc = ValueDescription::getType(structType);
+                // TODO: get the correct version too...
+            }
+            else if (std::strcmp(context.fieldNamePtr(), "ver") == 0) {
+                version = context.expectInt();
+            }
+            else if (std::strcmp(context.fieldNamePtr(), "data") == 0) {
+                desc->parseJson(md, context);
+            }
+        };
+        
+    context.forEachMember(onMember);
+}
+
+
+/*****************************************************************************/
 /* DIRECT FROZEN COLUMN                                                      */
 /*****************************************************************************/
 
@@ -130,10 +177,10 @@ struct DirectFrozenColumn
 
         result += values.memusage();
 
-        cerr << "Direct memusage is " << result << " for " 
-             << numEntries << " entries at "
-             << 1.0 * values.memusage() / numEntries << " per entry"
-             << endl;
+        //cerr << "Direct memusage is " << result << " for " 
+        //     << numEntries << " entries at "
+        //     << 1.0 * values.memusage() / numEntries << " per entry"
+        //     << endl;
         
         return result;
     }
@@ -175,6 +222,12 @@ struct DirectFrozenColumn
     {
         serializeMetadataT<DirectFrozenColumnMetadata>(serializer, *this);
         values.serialize(*serializer.newStructure("values"));
+    }
+
+    DirectFrozenColumn(StructuredReconstituter & reconstituter)
+    {
+        reconstituteMetadataT<DirectFrozenColumnMetadata>(reconstituter, *this);
+        values.reconstitute(*reconstituter.getStructure("values"));
     }
 };
 
@@ -222,7 +275,7 @@ struct DirectFrozenColumnFormat: public FrozenColumnFormat {
         return result;
     }
     
-    virtual FrozenColumn *
+    virtual DirectFrozenColumn *
     freeze(TabularDatasetColumn & column,
            MappedSerializer & serializer,
            const ColumnFreezeParameters & params,
@@ -231,10 +284,10 @@ struct DirectFrozenColumnFormat: public FrozenColumnFormat {
         return new DirectFrozenColumn(column, serializer);
     }
 
-    virtual FrozenColumn *
+    virtual DirectFrozenColumn *
     reconstitute(StructuredReconstituter & reconstituter) const override
     {
-        throw AnnotatedException(600, "Tabular reconstitution not finished");
+        return new DirectFrozenColumn(reconstituter); 
     }
 };
 
@@ -419,8 +472,16 @@ struct TableFrozenColumn
     virtual void serialize(StructuredSerializer & serializer) const
     {
         serializeMetadataT<TableFrozenColumnMetadata>(serializer, *this);
-        indexes.serialize(*serializer.newStructure("index"));
-        table.serialize(*serializer.newStructure("table"));
+        indexes.serialize(*serializer.newStructure("ix"));
+        table.serialize(*serializer.newStructure("t"));
+    }
+
+    /// Reconstitute constructor
+    TableFrozenColumn(StructuredReconstituter & reconstituter)
+    {
+        reconstituteMetadataT<TableFrozenColumnMetadata>(reconstituter, *this);
+        indexes.reconstitute(*reconstituter.getStructure("ix"));
+        table.reconstitute(*reconstituter.getStructure("t"));
     }
 };
 
@@ -460,7 +521,7 @@ struct TableFrozenColumnFormat: public FrozenColumnFormat {
         return result;
     }
     
-    virtual FrozenColumn *
+    virtual TableFrozenColumn *
     freeze(TabularDatasetColumn & column,
            MappedSerializer & serializer,
            const ColumnFreezeParameters & params,
@@ -469,10 +530,10 @@ struct TableFrozenColumnFormat: public FrozenColumnFormat {
         return new TableFrozenColumn(column, serializer);
     }
 
-    virtual FrozenColumn *
+    virtual TableFrozenColumn *
     reconstitute(StructuredReconstituter & reconstituter) const override
     {
-        throw AnnotatedException(600, "Tabular reconstitution not finished");
+        return new TableFrozenColumn(reconstituter);
     }
 };
 
@@ -688,11 +749,21 @@ struct SparseTableFrozenColumn
     virtual void serialize(StructuredSerializer & serializer) const
     {
         serializeMetadataT<SparseTableFrozenColumnMetadata>(serializer, *this);
-        table.serialize(*serializer.newStructure("table"));
+        table.serialize(*serializer.newStructure("t"));
         rowNum.serialize(*serializer.newStructure("rn"));
-        index.serialize(*serializer.newStructure("idx"));
+        index.serialize(*serializer.newStructure("ix"));
     }
 
+    /// Reconstitute constructor
+    SparseTableFrozenColumn(StructuredReconstituter & reconstituter)
+    {
+        reconstituteMetadataT<SparseTableFrozenColumnMetadata>
+            (reconstituter, *this);
+        table.reconstitute(*reconstituter.getStructure("t"));
+        rowNum.reconstitute(*reconstituter.getStructure("rn"));
+        index.reconstitute(*reconstituter.getStructure("ix"));
+    }
+    
     /// Set of distinct values in the column chunk
     FrozenCellValueSet table;
 
@@ -743,7 +814,7 @@ struct SparseTableFrozenColumnFormat: public FrozenColumnFormat {
         return result;
     }
     
-    virtual FrozenColumn *
+    virtual SparseTableFrozenColumn *
     freeze(TabularDatasetColumn & column,
            MappedSerializer & serializer,
            const ColumnFreezeParameters & params,
@@ -752,10 +823,10 @@ struct SparseTableFrozenColumnFormat: public FrozenColumnFormat {
         return new SparseTableFrozenColumn(column, serializer);
     }
 
-    virtual FrozenColumn *
+    virtual SparseTableFrozenColumn *
     reconstitute(StructuredReconstituter & reconstituter) const override
     {
-        throw AnnotatedException(600, "Tabular reconstitution not finished");
+        return new SparseTableFrozenColumn(reconstituter);
     }
 };
 
@@ -1041,7 +1112,15 @@ struct IntegerFrozenColumn
     virtual void serialize(StructuredSerializer & serializer) const
     {
         serializeMetadataT<IntegerFrozenColumnMetadata>(serializer, *this);
-        table.serialize(*serializer.newStructure("table"));
+        table.serialize(*serializer.newStructure("t"));
+    }
+
+    /// Reconstitute constructor
+    IntegerFrozenColumn(StructuredReconstituter & reconstituter)
+    {
+        reconstituteMetadataT<IntegerFrozenColumnMetadata>
+            (reconstituter, *this);
+        table.reconstitute(*reconstituter.getStructure("t"));
     }
 };
 
@@ -1076,7 +1155,7 @@ struct IntegerFrozenColumnFormat: public FrozenColumnFormat {
         return result;
     }
     
-    virtual FrozenColumn *
+    virtual IntegerFrozenColumn *
     freeze(TabularDatasetColumn & column,
            MappedSerializer & serializer,
            const ColumnFreezeParameters & params,
@@ -1088,10 +1167,10 @@ struct IntegerFrozenColumnFormat: public FrozenColumnFormat {
         return new IntegerFrozenColumn(column, *infoCast, serializer);
     }
 
-    virtual FrozenColumn *
+    virtual IntegerFrozenColumn *
     reconstitute(StructuredReconstituter & reconstituter) const override
     {
-        throw AnnotatedException(600, "Tabular reconstitution not finished");
+        return new IntegerFrozenColumn(reconstituter);
     }
 };
 
@@ -1296,7 +1375,14 @@ struct DoubleFrozenColumn
     virtual void serialize(StructuredSerializer & serializer) const
     {
         serializeMetadataT<DoubleFrozenColumnMetadata>(serializer, *this);
-        serializer.addRegion(storage, "doubles");
+        serializer.addRegion(storage, "d");
+    }
+
+    /// Reconstitute constructor
+    DoubleFrozenColumn(StructuredReconstituter & reconstituter)
+    {
+        reconstituteMetadataT<DoubleFrozenColumnMetadata>(reconstituter, *this);
+        storage = reconstituter.getRegion("d");
     }
 };
 
@@ -1326,7 +1412,7 @@ struct DoubleFrozenColumnFormat: public FrozenColumnFormat {
         return DoubleFrozenColumn::bytesRequired(column);
     }
     
-    virtual FrozenColumn *
+    virtual DoubleFrozenColumn *
     freeze(TabularDatasetColumn & column,
            MappedSerializer & serializer,
            const ColumnFreezeParameters & params,
@@ -1335,10 +1421,10 @@ struct DoubleFrozenColumnFormat: public FrozenColumnFormat {
         return new DoubleFrozenColumn(column, serializer);
     }
 
-    virtual FrozenColumn *
+    virtual DoubleFrozenColumn *
     reconstitute(StructuredReconstituter & reconstituter) const override
     {
-        throw AnnotatedException(600, "Tabular reconstitution not finished");
+        return new DoubleFrozenColumn(reconstituter);
     }
 };
 
@@ -1461,6 +1547,15 @@ struct TimestampFrozenColumn
         serializeMetadataT<TimestampFrozenColumnMetadata>(serializer, *this);
         unwrapped->serialize(*serializer.newStructure("ul"));
     }
+
+    /// Reconstitute constructor
+    TimestampFrozenColumn(StructuredReconstituter & reconstituter)
+    {
+        reconstituteMetadataT<TimestampFrozenColumnMetadata>
+            (reconstituter, *this);
+        unwrapped.reset(FrozenColumnFormat::thaw
+                        (*reconstituter.getStructure("ul")));
+    }
 };
 
 struct TimestampFrozenColumnFormat: public FrozenColumnFormat {
@@ -1491,7 +1586,7 @@ struct TimestampFrozenColumnFormat: public FrozenColumnFormat {
         return sizeof(TimestampFrozenColumn) + 8 * (column.maxRowNumber - column.minRowNumber);
     }
     
-    virtual FrozenColumn *
+    virtual TimestampFrozenColumn *
     freeze(TabularDatasetColumn & column,
            MappedSerializer & serializer,
            const ColumnFreezeParameters & params,
@@ -1500,10 +1595,10 @@ struct TimestampFrozenColumnFormat: public FrozenColumnFormat {
         return new TimestampFrozenColumn(column, serializer, params);
     }
 
-    virtual FrozenColumn *
+    virtual TimestampFrozenColumn *
     reconstitute(StructuredReconstituter & reconstituter) const override
     {
-        throw AnnotatedException(600, "Tabular reconstitution not finished");
+        return new TimestampFrozenColumn(reconstituter);
     }
 };
 
@@ -1569,6 +1664,21 @@ registerFormat(std::shared_ptr<FrozenColumnFormat> format)
             return std::shared_ptr<void>(format.get(), deregister);
         }
     }
+}
+
+std::shared_ptr<const FrozenColumnFormat>
+FrozenColumnFormat::
+getFormat(const std::string & formatName)
+{
+    auto formats = getFormats().load();
+
+    auto it = formats->find(formatName);
+    if (it == formats->end()) {
+        throw AnnotatedException
+            (400, "Frozen column format " + formatName + " not found");
+    }
+
+    return it->second;
 }
 
 
@@ -1688,12 +1798,80 @@ serializeMetadata(StructuredSerializer & serializer,
 
     //cerr << "got metadata " << printed << endl;
 
-    auto entry = serializer.newEntry("md.json");
+    auto entry = serializer.newEntry("md");
     auto serializeTo = entry->allocateWritable(printed.rawLength(),
                                                1 /* alignment */);
     
     std::memcpy(serializeTo.data(), printed.rawData(), printed.rawLength());
     serializeTo.freeze();
+}
+
+FrozenColumn *
+FrozenColumnFormat::
+thaw(StructuredReconstituter & reconstituter)
+{
+    // TODO: this is user generated data; we can't trust it.  We need to
+    // ensure that things align properly between the types
+
+    // 1.  Get the metadata
+    FrozenMemoryRegion md = reconstituter.getRegion("md");
+
+    //cerr << "md = " << std::string(md.data(), md.data() + md.length())
+    //     << endl;
+    
+    Utf8StringJsonParsingContext context
+        (md.data(), md.length(),
+         (reconstituter.getContext() + "/md").rawString());
+
+    std::string fmt;
+
+    auto onMember = [&] ()
+        {
+            if (std::strcmp(context.fieldNamePtr(), "fmt") == 0) {
+                fmt = context.expectStringAscii();
+            }
+            else {
+                context.skip();
+            }
+        };
+
+    context.forEachMember(onMember);
+
+    std::shared_ptr<const FrozenColumnFormat> format
+        = FrozenColumnFormat::getFormat(fmt);
+
+    return format->reconstitute(reconstituter);
+
+#if 0
+    std::shared_ptr<const ValueDescription> desc;
+    int version = 0;
+    std::shared_ptr<void> mdObject;
+    
+    auto onMember = [&] ()
+        {
+            if (std::strcmp(context.fieldNamePtr(), "fmt") == 0) {
+                fmt = context.expectStringAscii();
+            }
+            else if (std::strcmp(context.fieldNamePtr(), "type") == 0) {
+                std::string structType = context.expectStringAscii();
+                desc = ValueDescription::getType(structType);
+                // TODO: get the correct version too...
+            }
+            else if (std::strcmp(context.fieldNamePtr(), "ver") == 0) {
+                version = context.expectInt();
+            }
+            else if (std::strcmp(context.fieldNamePtr(), "data") == 0) {
+                ExcAssert(desc);
+                mdObject.reset(desc->constructDefault(),
+                               [=] (void * obj) { desc->destroy(obj); });
+                desc->parseJson(mdObject.get(), context);
+            }
+        };
+    
+    context.forEachMember(onMember);
+#endif
+    
+    
 }
 
 

--- a/plugins/tabular/frozen_column.h
+++ b/plugins/tabular/frozen_column.h
@@ -82,6 +82,20 @@ struct FrozenColumn {
     }
 
     virtual void serialize(StructuredSerializer & serializer) const = 0;
+
+protected:
+    // Helper to grab the metadata from the given structure
+    template<typename Metadata>
+    static void reconstituteMetadataT(StructuredReconstituter & reconstituter,
+                                      Metadata & md)
+    {
+        reconstituteMetadataHelper(reconstituter, &md, typeid(Metadata));
+    }
+
+    static void
+    reconstituteMetadataHelper(StructuredReconstituter & reconstituter,
+                               void * md,
+                               const std::type_info & mdType);
 };
 
 
@@ -142,6 +156,10 @@ struct FrozenColumnFormat {
            MappedSerializer & serializer,
            const ColumnFreezeParameters & params,
            std::shared_ptr<void> cachedInfo) const = 0;
+
+
+    static FrozenColumn *
+    thaw(StructuredReconstituter & reconstituter);
     
     /** Reconstitute a mapped version of the given frozen column. */
     virtual FrozenColumn *
@@ -152,6 +170,10 @@ struct FrozenColumnFormat {
     */
     static std::shared_ptr<void>
     registerFormat(std::shared_ptr<FrozenColumnFormat> format);
+
+    /** Return the format handler for the given format. */
+    static std::shared_ptr<const FrozenColumnFormat>
+    getFormat(const std::string & formatName);
 };
 
 

--- a/plugins/tabular/frozen_tables.cc
+++ b/plugins/tabular/frozen_tables.cc
@@ -11,8 +11,14 @@
 
 #include "mldb/ext/zstd/lib/zdict.h"
 #include "mldb/ext/zstd/lib/zstd.h"
+
+#include "transducer.h"
+#include "mldb/utils/possibly_dynamic_buffer.h"
+#include "mldb/types/basic_value_descriptions.h"
+
 #include "mldb/base/scope.h"
 #include <mutex>
+#include <bitset>
 
 
 using namespace std;
@@ -66,8 +72,16 @@ void
 FrozenIntegerTable::
 serialize(StructuredSerializer & serializer) const
 {
-    serializer.newObject("md.json", md);
-    serializer.addRegion(storage, "ints");
+    serializer.newObject("md", md);
+    serializer.addRegion(storage, "i");
+}
+
+void
+FrozenIntegerTable::
+reconstitute(StructuredReconstituter & reconstituter)
+{
+    reconstituter.getObject("md", md);
+    storage = reconstituter.getRegion("i");
 }
 
 
@@ -219,30 +233,121 @@ freeze(MappedSerializer & serializer)
 /* FROZEN BLOB TABLE                                                         */
 /*****************************************************************************/
 
+struct FrozenBlobTableMetadata {
+};
+
 IMPLEMENT_STRUCTURE_DESCRIPTION(FrozenBlobTableMetadata)
 {
     setVersion(1);
-    addAuto("format", &FrozenBlobTableMetadata::format, "");
 }
 
 struct FrozenBlobTable::Itl {
     Itl()
-        : dict(nullptr)
     {
     }
 
     ~Itl()
     {
-        ZSTD_DDict * prev = dict.exchange(nullptr);
-        if (prev) {
-            ZSTD_freeDDict(prev);
-        }
     }
 
-    std::atomic<ZSTD_DDict *> dict;
+    FrozenBlobTableMetadata md;
+    FrozenMemoryRegion blobData;
+    FrozenIntegerTable offset;
+    FrozenIntegerTable length;  // How much longer is uncompressed than cmprsd
+    std::shared_ptr<StringTransducer> transducer;
 
-    std::mutex contextPoolLock;
-    std::vector<std::shared_ptr<ZSTD_DCtx> > contextPool;
+    // We have six interfaces that we need to handle in a device independent
+    // manner:
+    // - getSize(index, offset)
+    // - getContents(index)
+    // - getBufferSize(index), which is trivial
+    // - needsBuffer(index), which is trivial
+    // - size, which is trivial
+
+    size_t
+    getSize(uint32_t index) const
+    {
+        size_t offset0 = (index == 0) ? 0 : offset.get(index - 1);
+        size_t offset1 = offset.get(index);
+        size_t compressedLength = offset1 - offset0;
+        const char * data = blobData.data() + offset0;
+        if (transducer->canGetOutputLength()) {
+            return transducer
+                ->getOutputLength(string_view(data, compressedLength));
+        }
+        else {
+            size_t decompressedLength = compressedLength + length.get(index);
+            return decompressedLength;
+        }
+    }
+    
+    size_t
+    getBufferSize(uint32_t index) const
+    {
+        size_t offset0 = (index == 0) ? 0 : offset.get(index - 1);
+        size_t offset1 = offset.get(index);
+        size_t compressedLength = offset1 - offset0;
+        const char * data = blobData.data() + offset0;
+        size_t decompressedLength = compressedLength + length.get(index);
+        return transducer
+            ->getTemporaryBufferSize(string_view(data, compressedLength),
+                                     decompressedLength);
+    }
+
+    bool
+    needsBuffer(uint32_t index) const
+    {
+        return transducer->needsTemporaryBuffer();
+    }
+
+    string_view
+    getContents(uint32_t index,
+                char * tempBuffer,
+                size_t tempBufferSize) const
+    {
+        size_t offset0 = (index == 0) ? 0 : offset.get(index - 1);
+        size_t offset1 = offset.get(index);
+        size_t compressedLength = offset1 - offset0;
+        std::string_view input(blobData.data() + offset0, compressedLength);
+        return transducer->generateAll(input, tempBuffer, tempBufferSize);
+    }
+
+    size_t
+    memusage() const
+    {
+        size_t result
+            = blobData.memusage()
+            + offset.memusage()
+            + length.memusage()
+            + transducer->memusage();
+        return result;
+    }
+
+    size_t
+    size() const
+    {
+        return offset.size();
+    }
+
+    void
+    serialize(StructuredSerializer & serializer) const
+    {
+        serializer.newObject("md", md);
+        serializer.addRegion(blobData, "bl");
+        offset.serialize(*serializer.newStructure("of"));
+        length.serialize(*serializer.newStructure("l"));
+        transducer->serialize(*serializer.newStructure("tr"));
+    }
+
+    void
+    reconstitute(StructuredReconstituter & reconstituter)
+    {
+        reconstituter.getObject("md", md);
+        blobData = reconstituter.getRegion("bl");
+        offset.reconstitute(*reconstituter.getStructure("of"));
+        length.reconstitute(*reconstituter.getStructure("l"));
+        transducer = StringTransducer::thaw(*reconstituter.getStructure("tr"));
+    }
 };
 
 FrozenBlobTable::
@@ -251,153 +356,84 @@ FrozenBlobTable()
 {
 }
 
+FrozenBlobTable::
+~FrozenBlobTable()
+{
+}
+
 size_t
 FrozenBlobTable::
 getSize(uint32_t index) const
 {
-    size_t offset0 = (index == 0) ? 0 : offset.get(index - 1);
-    size_t offset1 = offset.get(index);
-    size_t storageSize = offset1 - offset0;
- 
-    switch (md.format) {
-    case UNCOMPRESSED:
-        return storageSize;
-    case ZSTD: {
-        const char * data = blobData.data() + offset0;
-        auto res = ZSTD_getDecompressedSize(data, storageSize);
-        if (ZSTD_isError(res)) {
-            throw AnnotatedException(500, "Error with decompressing: "
-                                      + string(ZSTD_getErrorName(res)));
-        }
-        return res;
-    }
-    }
-
-    throw AnnotatedException(600, "Invalid format for frozen blob table");
+    return itl->getSize(index);
 }
     
 size_t
 FrozenBlobTable::
 getBufferSize(uint32_t index) const
 {
-    switch (md.format) {
-    case UNCOMPRESSED:
-        return 0;
-    case ZSTD: {
-        size_t offset0 = (index == 0) ? 0 : offset.get(index - 1);
-        size_t offset1 = offset.get(index);
-        size_t storageSize = offset1 - offset0;
-        const char * data = blobData.data() + offset0;
-        auto res = ZSTD_getDecompressedSize(data, storageSize);
-        if (ZSTD_isError(res)) {
-            throw AnnotatedException(500, "Error with decompressing: "
-                                      + string(ZSTD_getErrorName(res)));
-        }
-        return res;
-    }
-    }
-
-    throw AnnotatedException(600, "Invalid format for frozen blob table");
+    return itl->getBufferSize(index);
 }
 
 bool
 FrozenBlobTable::
 needsBuffer(uint32_t index) const
 {
-    return md.format == ZSTD;
+    return itl->needsBuffer(index);
 }
 
-const char *
+string_view
 FrozenBlobTable::
 getContents(uint32_t index,
             char * tempBuffer,
             size_t tempBufferSize) const
 {
-    size_t offset0 = (index == 0) ? 0 : offset.get(index - 1);
-
-    switch (md.format) {
-    case UNCOMPRESSED:
-        return blobData.data() + offset0;
-    case ZSTD: {
-        size_t offset1 = offset.get(index);
-        size_t storageSize = offset1 - offset0;
-        const char * data = blobData.data() + offset0;
-
-        std::shared_ptr<ZSTD_DCtx> context;
-
-        {
-            std::unique_lock<std::mutex> guard(itl->contextPoolLock);
-            if (!itl->contextPool.empty()) {
-                context = itl->contextPool.back();
-                itl->contextPool.pop_back();
-            }
-        }
-
-        auto freeContext = [&] ()
-            {
-                if (!context)
-                    return;
-                std::unique_lock<std::mutex> guard(itl->contextPoolLock);
-                itl->contextPool.emplace_back(std::move(context));
-            };
-
-        Scope_Exit(freeContext());
-                    
-        if (!context) {
-            context.reset(ZSTD_createDCtx(),
-                          [] (ZSTD_DCtx * context) { ZSTD_freeDCtx(context); });
-        }
-
-        if (!itl->dict.load()) {
-            ZSTD_DDict * dict = ZSTD_createDDict(formatData.data(),
-                                                 formatData.length());
-            ZSTD_DDict * previous = nullptr;
-            if (!itl->dict.compare_exchange_strong(previous, dict)) {
-                ZSTD_freeDDict(dict);
-            }
-        }
-
-        auto res = ZSTD_decompress_usingDDict(context.get(),
-                                              tempBuffer,
-                                              tempBufferSize,
-                                              data, storageSize,
-                                              itl->dict.load());
-        
-        if (ZSTD_isError(res)) {
-            throw AnnotatedException(500, "Error with decompressing: "
-                                      + string(ZSTD_getErrorName(res)));
-        }
-        return tempBuffer;
-    }
-    }
-
-    throw AnnotatedException(600, "Invalid format for frozen blob table");
+    return itl->getContents(index, tempBuffer, tempBufferSize);
 }
 
 size_t
 FrozenBlobTable::
 memusage() const
 {
-    return formatData.memusage()
-        + blobData.memusage()
-        + offset.memusage();
+    return itl->memusage();
 }
 
 size_t
 FrozenBlobTable::
 size() const
 {
-    return offset.size();
+    return itl->size();
 }
 
 void
 FrozenBlobTable::
 serialize(StructuredSerializer & serializer) const
 {
-    serializer.newObject("md.json", md);
-    serializer.addRegion(formatData, "fmt");
-    serializer.addRegion(blobData, "blob");
-    offset.serialize(*serializer.newStructure("offsets"));
+    itl->serialize(serializer);
+}
+
+void
+FrozenBlobTable::
+reconstitute(StructuredReconstituter & reconstituter)
+{
+    itl->reconstitute(reconstituter);
+}
+
+void
+StringStats::
+add(std::string_view blob)
+{
+    totalBytes += blob.size();
+    if (blob.size() <= 255) {
+        uniqueShortLengths += (shortLengthDistribution[blob.size()]++ == 0);
+    }
+    else {
+        uniqueLongLengths += (longLengthDistribution[blob.size()]++ == 0);
+    }
+
+    for (unsigned char c: blob) {
+        uniqueBytes += (byteDistribution[c - 0U]++ == 0);
+    }
 }
 
 
@@ -405,110 +441,137 @@ serialize(StructuredSerializer & serializer) const
 /* MUTABLE BLOB TABLE                                                        */
 /*****************************************************************************/
 
+MutableBlobTable::
+MutableBlobTable()
+{
+}
+
 size_t
 MutableBlobTable::
-add(std::string blob)
+add(std::string && blob)
 {
     size_t result = blobs.size();
-    totalBytes += blob.size();
-    offsets.add(totalBytes);
+    stats.add(blob);
     blobs.emplace_back(std::move(blob));
+    offsets.add(stats.totalBytes);
     return result;
+}
+
+size_t
+MutableBlobTable::
+add(std::string_view blob)
+{
+    return add(std::string(blob.cbegin(), blob.cend()));
 }
 
 FrozenBlobTable
 MutableBlobTable::
-freezeCompressed(MappedSerializer & serializer)
+freeze(MappedSerializer & serializer)
 {
-    // Let the dictionary size be 5% of the total
-    size_t dictionarySize = 131072;//32768; //info->totalBytes / 20;
+    //cerr << "freezing with " << uniqueShortLengths << " short lengths"
+    //     << " and " << uniqueBytes << " unique bytes" << endl;
 
-    std::string dictionary(dictionarySize, '\0');
+    double bytesPerEntry = 1.0 * stats.totalBytes / blobs.size();
 
-    static constexpr size_t TOTAL_SAMPLE_SIZE = 1024 * 1024;
+    std::shared_ptr<StringTransducer> forward, reverse;
+    
+    if (stats.totalBytes > 10000000 // 10MB
+        && bytesPerEntry > 64) {
+        std::tie(forward, reverse)
+            = ZstdStringTransducer::train(blobs, serializer);
+    }
+    if (!forward
+        && stats.uniqueLongLengths == 0
+        && stats.uniqueShortLengths == 1) {
 
-    // Give it the first 1MB to train on
-    std::string sampleBuffer;
-    sampleBuffer.reserve(2 * TOTAL_SAMPLE_SIZE);
-
-    std::vector<size_t> sampleSizes;
-    size_t currentOffset = 0;
-    size_t valNumber = 0;
-
-    // Accumulate the first 1MB of strings in a contiguous buffer
-
-    for (auto & v: blobs) {
-        if (currentOffset > TOTAL_SAMPLE_SIZE)
-            break;
-        size_t sampleSize = v.length();
-        sampleBuffer.append(v);
-        sampleSizes.push_back(sampleSize);
-        currentOffset += sampleSize;
-        valNumber += 1;
+        //std::tie(forward, reverse)
+        //    = trainIdTransducer(blobs, stats, serializer);
+    }
+    if (!forward) {
+        return freezeUncompressed(serializer);
     }
 
-    Date before = Date::now();
+    MutableBlobTable compressedBlobs;
 
-    // Perform the dictionary training
-    size_t res = ZDICT_trainFromBuffer(&dictionary[0],
-                                       dictionary.size(),
-                                       sampleBuffer.data(),
-                                       sampleSizes.data(),
-                                       sampleSizes.size());
-    if (ZDICT_isError(res)) {
-        throw AnnotatedException(500, "Error with dictionary: "
-                                  + string(ZDICT_getErrorName(res)));
-    }
-        
-    Date after = Date::now();
-    double elapsed = after.secondsSince(before);
-    before = after;
+#if 0    
+    std::function<void ()> compress = compressor.getHost("generateAll");
+    std::function<void ()> length = compressor.getHost("length");
 
-    dictionary.resize(res);
+    // The pipeline we create for this operation is as follows:
+    // in order map over i = 0..blobs.size()
+    //    extract offset[i] as end
+    //    extract offset[i - 1] as start
+    //    length = end - start
+    //    add length to lengths
+    //    data = compress from (offset[i] to offset[i - 1])
+    //    add data to blobs
+    //
+    // (parallel map [i 0 blobs.size()]
+    //  (let [end offset(i)
+    //        start offset(- i 1)
+    //        len (- end start)
+    //        bl blob(data start end)
+    //        data compress(bl)]
+    //   (insert lengths i length)
+    //   (insert blobs i blob)))
+    //
+    // FOREACH
 
-    cerr << "created dictionary of " << res << " bytes from "
-         << currentOffset << " bytes of samples in "
-         << elapsed << " seconds" << endl;
+    Parameter<uint32_t> i("i");
+    Constant<uint32_t> one(1);
+    Function<uint64_t (uint64_t)> getOffset = offsets.getFunction("get");
+    Plus<uint64_t> iPlusOne(i, one);
+    
+    
+    Function<void (size_t)> mapper("mapper", blob);
 
-    // Now compress another 1MB to see what the ratio is...
-    std::shared_ptr<ZSTD_CDict> dict
-        (ZSTD_createCDict(dictionary.data(), res, 1 /* compression level */),
-         ZSTD_freeCDict);
-        
-    std::shared_ptr<ZSTD_CCtx> context
-        (ZSTD_createCCtx(), ZSTD_freeCCtx);
+    Parameter<size_t> i("i");
+    Function mapper("mapper", i);
+    Variable start = mapper.local<uint64_t>("start");
+    Variable end = mapper.local<uint64_t>("end");
+    Variable length = mapper.local<uint64_t>("length");
+    Assign a1(start, Call(getOffset, i - 1));
+    Assign a2(end, Call(getOffset, i));
+    Assign a3(length, end - start);
+    
+    Operation operation
+        = parallelMapInOrderReduce(Range(0, i), mapper, reducer);
+
+#endif
 
     size_t compressedBytes = 0;
     size_t numSamples = 0;
     size_t uncompressedBytes = 0;
 
-    MutableBlobTable compressedBlobs;
+    Date before = Date::now();
 
+    // How much longer the uncompressed version is than the compressed
+    MutableIntegerTable lengths;
+    
     for (size_t i = 0 /*valNumber*/;  i < blobs.size();  ++i) {
         const std::string & v = blobs[i];
         size_t len = v.length();
-        PossiblyDynamicBuffer<char, 65536> buf(ZSTD_compressBound(len));
-
-        size_t res
-            = ZSTD_compress_usingCDict(context.get(),
-                                       buf.data(), buf.size(),
-                                       v.data(), len,
-                                       dict.get());
-
-        if (ZSTD_isError(res)) {
-            throw AnnotatedException(500, "Error with compressing: "
-                                      + string(ZSTD_getErrorName(res)));
-        }
-
-        compressedBlobs.add(std::string(buf.data(), res));
+        size_t bufferLen
+            = forward->getTemporaryBufferSize(string_view(v.data(), len),
+                                              len);
+        
+        PossiblyDynamicBuffer<char, 4096> buf(bufferLen);
+        
+        std::string_view res
+            = forward->generateAll(string_view(v.data(), len),
+                                   buf.data(), bufferLen);
 
         uncompressedBytes += len;
-        compressedBytes += res;
+        compressedBytes += res.size();
         numSamples += 1;
+
+        compressedBlobs.add(res);
+        lengths.add(len - res.size());
+        offsets.add(compressedBytes);
     }
 
-    after = Date::now();
-    elapsed = after.secondsSince(before);
+    Date after = Date::now();
+    double elapsed = after.secondsSince(before);
 
     cerr << "compressed " << numSamples << " samples with "
          << uncompressedBytes << " bytes to " << compressedBytes
@@ -518,54 +581,22 @@ freezeCompressed(MappedSerializer & serializer)
 
     FrozenBlobTable frozenCompressedBlobs
         = compressedBlobs.freezeUncompressed(serializer);
-
+    
     cerr << "frozenCompressedBlobs.memusage() = "
          << frozenCompressedBlobs.memusage() << endl;
 
     FrozenBlobTable result;
-    MutableMemoryRegion dictRegion
-        = serializer.allocateWritable(dictionary.length(), 1);
-    std::memcpy(dictRegion.data(), dictionary.data(), dictionary.length());
-    result.formatData = dictRegion.freeze();
-    result.md.format = ZSTD;
-    result.blobData = std::move(frozenCompressedBlobs.blobData);
-    result.offset = std::move(frozenCompressedBlobs.offset);
 
-    cerr << "result.memusage() = "
-         << result.memusage() << endl;
-
-    return result;
+    result.itl->blobData = std::move(frozenCompressedBlobs.itl->blobData);
+    result.itl->offset = std::move(frozenCompressedBlobs.itl->offset);
+    result.itl->length = lengths.freeze(serializer);
+    result.itl->transducer = std::move(reverse);
     
+
 #if 0
-    ssize_t totalBytesRequired = sizeof(CompressedStringFrozenColumn)
-        + dictionarySize
-        + compressedBytes
-        + 4 * column.indexedVals.size();
+    MutableBlobTable compressedBlobs;
 
-    cerr << "result is " << totalBytesRequired << endl;
-
-    return result;
-#endif
-}
-
-FrozenBlobTable
-MutableBlobTable::
-freeze(MappedSerializer & serializer)
-{
-    double bytesPerEntry = 1.0 * totalBytes / blobs.size();
     
-    if (totalBytes > 10000000 // 10MB
-        && bytesPerEntry > 64) {
-        return freezeCompressed(serializer);
-    }
-
-    return freezeUncompressed(serializer);
-}
-
-FrozenBlobTable
-MutableBlobTable::
-freezeUncompressed(MappedSerializer & serializer)
-{
     FrozenIntegerTable frozenOffsets
         = offsets.freeze(serializer);
     MutableMemoryRegion region
@@ -586,8 +617,32 @@ freezeUncompressed(MappedSerializer & serializer)
     ExcAssertEqual(currentOffset, totalBytes);
 
     FrozenBlobTable result;
-    result.blobData = region.freeze();
-    result.offset = std::move(frozenOffsets);
+    result.itl->blobData = region.freeze();
+    result.itl->offset = std::move(frozenOffsets);
+#endif
+
+    return result;
+}
+
+FrozenBlobTable
+MutableBlobTable::
+freezeUncompressed(MappedSerializer & serializer)
+{
+    auto buf = serializer.allocateWritable(stats.totalBytes, 1 /* alignment */);
+
+    char * data = buf.data();
+
+    for (size_t i = 0 /*valNumber*/;  i < blobs.size();  ++i) {
+        const std::string & v = blobs[i];
+        size_t len = v.length();
+        std::memcpy(data, v.data(), len);
+        data += len;
+    }
+
+    FrozenBlobTable result;
+    result.itl->blobData = buf.freeze();
+    result.itl->offset = offsets.freeze(serializer);
+    result.itl->transducer.reset(new IdentityStringTransducer());
     return result;
 }
 
@@ -613,14 +668,16 @@ operator [] (size_t index) const
 
         // Create a buffer for the blob, and reconstitute it
         PossiblyDynamicBuffer<char, 4096> buf(bytesRequired);
-        const char * contents = blobs.getContents(index, buf.data(), buf.size());
+        std::string_view contents
+            = blobs.getContents(index, buf.data(), buf.size());
         // Decode the output
-        return CellValue::reconstitute(contents, bytesRequired, format,
+        return CellValue::reconstitute(contents.data(), contents.length(),
+                                       format,
                                        true /* known length */).first;
     }
     else {
-        const char * contents = blobs.getContents(index, nullptr, 0);
-        size_t length = blobs.getSize(index);
+        std::string_view contents = blobs.getContents(index, nullptr, 0);
+        size_t length = contents.length();
 
         // Nulls are serialized as zero byte blobs; all others take at least
         // one byte so there is no ambiguity
@@ -628,7 +685,8 @@ operator [] (size_t index) const
             return CellValue();
 
         // Decode the output directly in place
-        return CellValue::reconstitute(contents, length, format,
+        return CellValue::reconstitute(contents.data(), contents.length(),
+                                       format,
                                        true /* known length */).first;
     }
 }
@@ -652,6 +710,13 @@ FrozenCellValueTable::
 serialize(StructuredSerializer & serializer) const
 {
     blobs.serialize(serializer);
+}
+
+void
+FrozenCellValueTable::
+reconstitute(StructuredReconstituter & reconstituter)
+{
+    blobs.reconstitute(reconstituter);
 }
 
 
@@ -785,6 +850,27 @@ add(CellValue val)
 
     throw AnnotatedException
         (500, "Couldn't add unknown cell to MutableCellValueSet");
+}
+
+
+/*****************************************************************************/
+/* FROZEN CELL VALUE SET                                                     */
+/*****************************************************************************/
+
+void
+FrozenCellValueSet::
+serialize(StructuredSerializer & serializer) const
+{
+    offsets.serialize(serializer);
+    serializer.addRegion(cells, "c");
+}
+
+void
+FrozenCellValueSet::
+reconstitute(StructuredReconstituter & reconstituter)
+{
+    offsets.reconstitute(reconstituter);
+    cells = reconstituter.getRegion("c");
 }
 
 } // namespace MLDB

--- a/plugins/tabular/frozen_tables.cc
+++ b/plugins/tabular/frozen_tables.cc
@@ -483,9 +483,8 @@ freeze(MappedSerializer & serializer)
     if (!forward
         && stats.uniqueLongLengths == 0
         && stats.uniqueShortLengths == 1) {
-
-        //std::tie(forward, reverse)
-        //    = trainIdTransducer(blobs, stats, serializer);
+        std::tie(forward, reverse)
+            = trainIdTransducer(blobs, stats, serializer);
     }
     if (!forward) {
         return freezeUncompressed(serializer);

--- a/plugins/tabular/frozen_tables.h
+++ b/plugins/tabular/frozen_tables.h
@@ -8,11 +8,14 @@
 
 #pragma once
 
+#include "transducer.h"
 #include "frozen_column.h"
 #include "mldb/arch/bitops.h"
 #include "mldb/arch/bit_range_ops.h"
 #include "mldb/arch/endian.h"
 #include "mldb/sql/cell_value.h"
+#include "mldb/compiler/string_view.h"
+
 
 namespace MLDB {
 
@@ -91,6 +94,8 @@ struct FrozenIntegerTable {
     uint64_t get(size_t i) const;
 
     void serialize(StructuredSerializer & serializer) const;
+
+    void reconstitute(StructuredReconstituter & reconstituter);
 };
 
 struct MutableIntegerTable {
@@ -179,52 +184,44 @@ struct MutableDoubleTable {
 /* BLOB TABLES                                                               */
 /*****************************************************************************/
 
-enum FrozenBlobTableFormat {
-    UNCOMPRESSED = 0,
-    ZSTD = 1
-};
-
-struct FrozenBlobTableMetadata {
-    uint8_t /* FrozenBlobTableFormat */ format = UNCOMPRESSED;
-};
-
 struct FrozenBlobTable {
     FrozenBlobTable();
-
-    FrozenBlobTableMetadata md;
-    FrozenMemoryRegion formatData;
-    FrozenMemoryRegion blobData;
-    FrozenIntegerTable offset;
-
+    ~FrozenBlobTable();
+    
     size_t getSize(uint32_t index) const;
     size_t getBufferSize(uint32_t index) const;
     bool needsBuffer(uint32_t index) const;
-    const char * getContents(uint32_t index,
-                             char * tempBuffer,
-                             size_t tempBufferSize) const;
+    std::string_view
+    getContents(uint32_t index,
+                char * tempBuffer,
+                size_t tempBufferSize) const;
     
     size_t memusage() const;
     size_t size() const;
     void serialize(StructuredSerializer & serializer) const;
+    void reconstitute(StructuredReconstituter & reconstituter);
 
+private:
     struct Itl;
     std::shared_ptr<Itl> itl;
+    friend class MutableBlobTable;
 };
-
 
 struct MutableBlobTable {
 
-    size_t add(std::string blob);
+    MutableBlobTable();
+    
+    size_t add(std::string && blob);
+    size_t add(std::string_view blob);
 
     size_t size() const { return blobs.size(); }
 
     MutableIntegerTable offsets;
     std::vector<std::string> blobs;
-    uint64_t totalBytes = 0;
 
+    StringStats stats;
+    
     FrozenBlobTable freeze(MappedSerializer & serializer);
-
-    FrozenBlobTable freezeCompressed(MappedSerializer & serializer);
     FrozenBlobTable freezeUncompressed(MappedSerializer & serializer);
 };
 
@@ -315,6 +312,7 @@ struct FrozenCellValueTable {
     }
 
     void serialize(StructuredSerializer & serializer) const;
+    void reconstitute(StructuredReconstituter & reconstituter);
 
     FrozenBlobTable blobs;
 };
@@ -392,11 +390,9 @@ struct FrozenCellValueSet {
         return true;
     }
 
-    void serialize(StructuredSerializer & serializer) const
-    {
-        offsets.serialize(serializer);
-        serializer.addRegion(cells, "cells");
-    }
+    void serialize(StructuredSerializer & serializer) const;
+
+    void reconstitute(StructuredReconstituter & reconstituter);
 
     FrozenIntegerTable offsets;
     FrozenMemoryRegion cells;

--- a/plugins/tabular/tabular.mk
+++ b/plugins/tabular/tabular.mk
@@ -9,10 +9,12 @@ LIBMLDB_TABULAR_PLUGIN_SOURCES:= \
 	column_types.cc \
 	tabular_dataset_column.cc \
 	tabular_dataset_chunk.cc \
-
+	transducer.cc
 
 LIBMLDB_TABULAR_PLUGIN_LINK := \
 	block zstd sql_expression mldb_engine mldb_core value_description arch types progress base vfs log rest
 
 
 $(eval $(call library,mldb_tabular_plugin,$(LIBMLDB_TABULAR_PLUGIN_SOURCES),$(LIBMLDB_TABULAR_PLUGIN_LINK)))
+
+$(eval $(call include_sub_make,tabular_testing,testing,testing.mk))

--- a/plugins/tabular/tabular_dataset.cc
+++ b/plugins/tabular/tabular_dataset.cc
@@ -331,8 +331,14 @@ struct PathIndexShard: public PathIndexMetadata {
 
     void serialize(StructuredSerializer & serializer) const
     {
-        serializer.newObject<PathIndexMetadata>("md.json", *this);
-        serializer.addRegion(storage, "rowindex");
+        serializer.newObject<PathIndexMetadata>("md", *this);
+        serializer.addRegion(storage, "ri");
+    }
+
+    void reconstitute(StructuredReconstituter & reconstituter)
+    {
+        reconstituter.getObject<PathIndexMetadata>("md", *this);
+        storage = reconstituter.getRegionT<uint32_t>("ri");
     }
 
     // Hash is implicit via position in the entry map (we take the top x bits)
@@ -373,6 +379,16 @@ struct PathIndex {
     {
         for (size_t i = 0;  i < INDEX_SHARDS;  ++i) {
             shards[i].serialize(*serializer.newStructure(i));
+        }
+    }
+
+    void reconstitute(StructuredReconstituter & reconstituter)
+    {
+        // TODO: make it possible to reconstitute a different number of
+        // shards.
+        ExcAssertEqual(reconstituter.getDirectory().size(), INDEX_SHARDS);
+        for (size_t i = 0;  i < INDEX_SHARDS;  ++i) {
+            shards[i].reconstitute(*reconstituter.getStructure(i));
         }
     }
 
@@ -418,6 +434,26 @@ freeze(MappedSerializer & serializer)
 
 
 /*****************************************************************************/
+/* TABULAR DATA STORE METADATA                                               */
+/*****************************************************************************/
+
+struct TabularDataStoreMetadata {
+    std::vector<ColumnPath> columns;
+    Date earliestTs = Date::notADate();
+    Date latestTs = Date::notADate();
+    uint32_t numFixedColumns = 0;
+};
+
+IMPLEMENT_STRUCTURE_DESCRIPTION(TabularDataStoreMetadata)
+{
+    setVersion(1);
+    addField("columns", &TabularDataStoreMetadata::columns, "");
+    addField("earliestTs", &TabularDataStoreMetadata::earliestTs, "");
+    addField("latestTs", &TabularDataStoreMetadata::latestTs, "");
+    addField("numFixedColumns", &TabularDataStoreMetadata::numFixedColumns, "");
+}
+
+/*****************************************************************************/
 /* TABULAR DATA STORE                                                        */
 /*****************************************************************************/
 
@@ -448,18 +484,23 @@ struct TabularDataset::TabularDataStore
                      TabularDatasetConfig config,
                      shared_ptr<spdlog::logger> logger)
         : engine(engine),
+          serializer(new MemorySerializer),
           currentState(std::make_shared<CurrentState>(this, logger)),
           config(std::move(config)),
           backgroundJobsActive(0), logger(std::move(logger))
     {
         ExcAssert(this->logger);
         initRoutes();
+
+        if (!config.dataFileUrl.empty()) {
+            load(config.dataFileUrl);
+        }
     }
 
     MldbEngine * engine = nullptr;
 
     /// This is used to allocate mapped memory when chunks are frozen
-    MemorySerializer serializer;
+    std::unique_ptr<MappedSerializer> serializer;
 
     /// Provides information about a column
     struct ColumnEntry {
@@ -996,15 +1037,204 @@ struct TabularDataset::TabularDataStore
 
             rowIndex.serialize(*serializer.newStructure("ri"));
 
-            {
-                auto colSerializer = serializer.newEntry("cs");
-                
+            TabularDataStoreMetadata md;
+            md.columns.reserve(columns.size());
+            for (auto & c: columns) {
+                md.columns.push_back(c.columnName);
             }
 
-            {
-                auto mdSerializer = serializer.newStream("md");
-                mdSerializer << earliestTs << latestTs;
+            md.earliestTs = earliestTs;
+            md.latestTs = latestTs;
+            md.numFixedColumns = owner->fixedColumns.size();
+            
+            serializer.newObject("md", md);
+        }
+
+        void reconstitute(StructuredReconstituter & reconstituter)
+        {
+            // Read the metadata ahead of everything else, so we can
+            // handle the fixed columns
+            TabularDataStoreMetadata md;
+            reconstituter.getObject("md", md);
+
+            this->earliestTs = md.earliestTs;
+            this->latestTs = md.latestTs;
+
+            ExcAssertGreaterEqual(md.numFixedColumns, 0);
+            ExcAssertLessEqual(md.numFixedColumns, md.columns.size());
+
+            // TODO: ugly reaching into the owner like this; refactor
+            for (size_t i = 0;  i < md.numFixedColumns;  ++i) {
+                owner->fixedColumns.emplace_back(md.columns[i]);
+                owner->fixedColumnIndex[md.columns[i].oldHash()] = i;
             }
+            
+            auto chunkStructure = reconstituter.getStructure("ch");
+            auto entries = chunkStructure->getDirectory();
+                
+            std::vector<std::shared_ptr<TabularDatasetChunk> > newChunks;
+            newChunks.resize(entries.size());
+         
+            for (auto & e: entries) {
+                int chunkNumber = e.name.toIndex();
+                if (chunkNumber < 0 || chunkNumber >= newChunks.size()) {
+                    throw AnnotatedException
+                        (400, "Corrupt Tabular Dataset: chunk index out of range");
+                }
+                if (newChunks[chunkNumber]) {
+                    throw AnnotatedException
+                        (400, "Corrupt Tabular Dataset: duplicate chunk index");
+                }
+
+                newChunks[chunkNumber].reset(new TabularDatasetChunk(*e.getStructure()));
+            }
+
+            // Add these chunks properly...
+            addChunks(newChunks);
+
+            // ... and map the row index in place
+            rowIndex.reconstitute(*reconstituter.getStructure("ri"));
+        }
+
+        void addChunks(std::vector<std::shared_ptr<TabularDatasetChunk> > & inputChunks)
+        {
+            for (auto & c: inputChunks) {
+                rowCount += c->rowCount();
+            }
+
+            size_t numChunksBefore = chunks.size();
+        
+            chunks.reserve(numChunksBefore + inputChunks.size());
+
+            for (auto & c: inputChunks) {
+                chunks.emplace_back(std::move(c));
+            }
+
+            // Make sure they aren't reused
+            inputChunks.clear();
+
+            // This will only happen when this is the first commit
+            if (columns.empty()) {
+                columns.reserve(owner->fixedColumns.size());
+                for (size_t i = 0;  i < owner->fixedColumns.size();  ++i) {
+                    const ColumnPath & c = owner->fixedColumns[i];
+                    ColumnEntry entry;
+                    entry.columnName = c;
+                    columns.emplace_back(entry);
+                    columnIndex[c.oldHash()] = i;
+                    columnHashIndex[c] = i;
+                }
+            }
+
+            // Create the column index.  This should be rapid, as there shouldn't
+            // be too many columns.
+            for (size_t i = numChunksBefore;  i < chunks.size();  ++i) {
+                const TabularDatasetChunk & chunk = *chunks[i];
+                ExcAssertEqual(owner->fixedColumns.size(),
+                               chunk.fixedColumnCount());
+                for (size_t j = 0;  j < chunk.columns.size();  ++j) {
+                    columns[j].chunks.emplace_back(i, chunk.columns[j]);
+                    columns[j].nonNullRowCount
+                        += chunk.columns[j]->nonNullRowCount();
+                }
+                for (auto & c: chunk.sparseColumns) {
+                    auto it = columnIndex
+                        .insert(make_pair(c.first.oldHash(),
+                                          columns.size()))
+                        .first;
+                    if (it->second == columns.size()) {
+                        ColumnEntry entry;
+                        entry.columnName = c.first;
+                        columns.emplace_back(entry);
+                        columnHashIndex[c.first] = it->second;
+                    }
+                    columns[it->second].chunks.emplace_back(i, c.second);
+                    columns[it->second].nonNullRowCount
+                        += c.second->nonNullRowCount();
+                }
+            }
+        
+            ExcAssertEqual(columns.size(), columnIndex.size());
+            ExcAssertEqual(columns.size(),
+                           columnHashIndex.size());
+        }
+
+        void reIndex()
+        {
+            cerr << "indexing " << chunks.size() << " chunks" << endl;
+
+            MutablePathIndex index;
+
+            // We create the row index in multiple chunks
+
+            Timer rowIndexTimer;
+
+            auto indexChunk = [&] (int chunkNum)
+                {
+                    auto recorder = index.getRecorder(chunkNum);
+                    for (unsigned j = 0;
+                         j < chunks[chunkNum]->rowCount();
+                         ++j) {
+                        RowPath rowNameStorage;
+                        const RowPath & rowName
+                            = chunks[chunkNum]
+                            ->getRowPath(j, rowNameStorage);
+                        recorder.record(rowName, j);
+                    }
+                
+                    recorder.commit();
+                };
+        
+            // NOTE: we currently re-index everything from the
+            // previous chunks; this is a big scalability problem.
+            // We should not do that once multiple commits become
+            // an important use case
+            parallelMap(0, chunks.size(), indexChunk);
+
+            std::vector<std::tuple<int, int, int, int> > possibleCollisions;
+            std::tie(rowIndex, possibleCollisions)
+                = index.freeze(*owner->serializer);
+
+            cerr << possibleCollisions.size() << " possible collisions"
+                 << endl;
+
+            std::set<Path> duplicateRowNames;
+            bool extraDuplicates = false;
+            
+            for (auto & c: possibleCollisions) {
+                Path name1 = chunks[std::get<0>(c)]->getRowPath(std::get<1>(c));
+                Path name2 = chunks[std::get<2>(c)]->getRowPath(std::get<3>(c));
+                if (name1 == name2) {
+                    duplicateRowNames.emplace(std::move(name1));
+                }
+                if (duplicateRowNames.size() > 1000) {
+                    extraDuplicates = true;
+                    break;
+                }
+            }
+
+            if (!duplicateRowNames.empty()) {
+                Utf8String duplicateNames;
+                for (auto & n: duplicateRowNames) {
+                    if (!duplicateNames.empty())
+                        duplicateNames += ", ";
+                    duplicateNames += n.toUtf8String();
+                    if (duplicateNames.length() > 100) {
+                        extraDuplicates = true;
+                        break;
+                    }
+                }
+                if (extraDuplicates)
+                    duplicateNames += "...";
+                throw AnnotatedException
+                    (400, "Duplicate row name(s) in tabular dataset: "
+                     + duplicateNames,
+                     "duplicates", duplicateRowNames);
+            }
+            
+            cerr << "rowIndex.memusage() = " << rowIndex.memusage()
+                 << endl;
+            cerr << "row index took " << rowIndexTimer.elapsed();
         }
     };
 
@@ -1415,24 +1645,22 @@ struct TabularDataset::TabularDataStore
 
     /// Create a new current state from the old one plus the extra
     /// chunks.
-    std::shared_ptr<CurrentState>
+    std::shared_ptr<const CurrentState>
     finalize(std::shared_ptr<const CurrentState> oldState,
              std::vector<std::shared_ptr<TabularDatasetChunk> > & inputChunks)
     {
         // NOTE: must be called with the lock held
-
-        size_t totalRows = oldState->rowCount;
+        if (inputChunks.empty()) {
+            return oldState;
+        }
 
         cerr << "commiting " << frozenChunks.size() << " frozen chunks"
              << endl;
 
-        for (auto & c: inputChunks) {
-            totalRows += c->rowCount();
-        }
-
         auto newState = std::make_shared<CurrentState>(*oldState);
 
-        newState->rowCount = totalRows;
+        newState->addChunks(inputChunks);
+        newState->reIndex();
         
         size_t numChunksBefore = newState->chunks.size();
         
@@ -1536,7 +1764,7 @@ struct TabularDataset::TabularDataStore
 
             std::vector<std::tuple<int, int, int, int> > possibleCollisions;
             std::tie(newState->rowIndex, possibleCollisions)
-                = index.freeze(serializer);
+                = index.freeze(*serializer);
 
 #if 0
             // Verify that we find all of our rows
@@ -1653,7 +1881,7 @@ struct TabularDataset::TabularDataStore
 
         PolyConfigT<Dataset> result;
         result.type = "tabular";
-
+        
         PersistentDatasetConfig params;
         params.dataFileUrl = dataFileUrl;
         result.params = params;
@@ -1661,6 +1889,22 @@ struct TabularDataset::TabularDataStore
         return result;
     }
 
+    void reconstitute(StructuredReconstituter & reconstituter)
+    {
+        auto newCurrentState = std::make_shared<CurrentState>
+            (this, this->logger);
+        newCurrentState->reconstitute(reconstituter);
+
+        currentState.store(std::move(newCurrentState));
+    }
+
+    void load(Url dataFileUrl)
+    {
+        ZipStructuredReconstituter reconstituter(dataFileUrl);
+
+        reconstitute(reconstituter);
+    }
+    
     /** This is a recorder that allows parallel records from multiple
         threads. */
     struct BasicRecorder: public Recorder {
@@ -1868,7 +2112,7 @@ struct TabularDataset::TabularDataStore
             if (!chunk || chunk->rowCount() == 0)
                 return;
             ColumnFreezeParameters params;
-            auto frozen = chunk->freeze(store->serializer, params);
+            auto frozen = chunk->freeze(*store->serializer, params);
             store->addFrozenChunk(std::move(frozen));
         }
 
@@ -2044,7 +2288,7 @@ struct TabularDataset::TabularDataStore
         auto job = [=] ()
             {
                 Scope_Exit(--this->backgroundJobsActive);
-                auto frozen = chunk->freeze(serializer, params);
+                auto frozen = chunk->freeze(*serializer, params);
                 addFrozenChunk(std::move(frozen));
             };
         
@@ -2353,12 +2597,6 @@ handleRequest(RestConnection & connection,
 /* TABULAR DATASET                                                           */
 /*****************************************************************************/
 
-TabularDatasetConfig::
-TabularDatasetConfig()
-{
-    unknownColumns = UC_ERROR;
-}
-
 DEFINE_ENUM_DESCRIPTION(UnknownColumnAction);
 
 UnknownColumnActionDescription::
@@ -2376,11 +2614,16 @@ TabularDatasetConfigDescription()
 {
     nullAccepted = true;
 
-    addField("unknownColumns", &TabularDatasetConfig::unknownColumns,
-             "Action to take on unknown columns.  Values are 'ignore', "
+    addAuto("unknownColumns", &TabularDatasetConfig::unknownColumns,
+            "Action to take on unknown columns.  Values are 'ignore', "
              "'error' (default), or 'add' which will allow an unlimited "
-             "number of sparse columns to be added.",
-             UC_ERROR);
+            "number of sparse columns to be added.");
+    addField("dataFileUrl", &TabularDatasetConfig::dataFileUrl,
+             "URL (which must currently be on the local filesystem, ie "
+             "file://...) from which the data will be memory mapped.  In "
+             "the case that the given URL does not exist, it will be "
+             "created and the file used as a memory mapped backing for "
+             "the data file.");
 }
 
 namespace {
@@ -2388,7 +2631,7 @@ namespace {
 RegisterDatasetType<TabularDataset, TabularDatasetConfig>
 regTabular(builtinPackage(),
            "tabular",
-           "Dense dataset which can be recorded to",
+           "Columnar dataset which can be recorded to",
            "datasets/TabularDataset.md.html");
 
 } // file scope

--- a/plugins/tabular/tabular_dataset.h
+++ b/plugins/tabular/tabular_dataset.h
@@ -29,10 +29,8 @@ enum UnknownColumnAction {
 
 DECLARE_ENUM_DESCRIPTION(UnknownColumnAction);
 
-struct TabularDatasetConfig {
-    TabularDatasetConfig();
-
-    UnknownColumnAction unknownColumns;
+struct TabularDatasetConfig: public PersistentDatasetConfig {
+    UnknownColumnAction unknownColumns = UC_ERROR;
 };
 
 DECLARE_STRUCTURE_DESCRIPTION(TabularDatasetConfig);

--- a/plugins/tabular/tabular_dataset_chunk.h
+++ b/plugins/tabular/tabular_dataset_chunk.h
@@ -38,6 +38,8 @@ struct TabularDatasetChunk {
     {
     }
 
+    TabularDatasetChunk(StructuredReconstituter & reconstituter);
+    
     TabularDatasetChunk(TabularDatasetChunk && other) noexcept
     {
         swap(other);

--- a/plugins/tabular/testing/testing.mk
+++ b/plugins/tabular/testing/testing.mk
@@ -1,0 +1,5 @@
+# sql_testing.mk
+# Jeremy Barnes, 10 April 2016
+# This file is part of MLDB. Copyright 2015 mldb.ai inc. All rights reserved.
+
+$(eval $(call test,transducer_test,mldb_tabular_plugin mldb utils block utils base arch value_description,boost))

--- a/plugins/tabular/testing/testing.mk
+++ b/plugins/tabular/testing/testing.mk
@@ -2,4 +2,4 @@
 # Jeremy Barnes, 10 April 2016
 # This file is part of MLDB. Copyright 2015 mldb.ai inc. All rights reserved.
 
-$(eval $(call test,transducer_test,mldb_tabular_plugin mldb utils block utils base arch value_description,boost))
+$(eval $(call test,transducer_test,mldb_tabular_plugin utils block utils base arch value_description types,boost))

--- a/plugins/tabular/testing/transducer_test.cc
+++ b/plugins/tabular/testing/transducer_test.cc
@@ -9,7 +9,10 @@
 
 #include "mldb/plugins/tabular/transducer.h"
 #include "mldb/block/memory_region.h"
+#include "mldb/block/zip_serializer.h"
 #include "mldb/base/hex_dump.h"
+#include "mldb/utils/environment.h"
+#include "mldb/base/scope.h"
 
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
@@ -20,19 +23,18 @@
 using namespace std;
 using namespace MLDB;
 
-BOOST_AUTO_TEST_CASE( test_id_transducer )
+static const std::string TMP = Environment::instance()["TMP"];
+
+std::pair<std::shared_ptr<StringTransducer>, std::shared_ptr<StringTransducer>>
+testTransducer(const std::vector<std::string> & vals)
 {
-    std::vector<std::string> vals;
+    MemorySerializer serializer;
+
     StringStats stats;
 
-    // Check that 16 bits is really represented in 16 bits
-    for (size_t i = 0;  i < 65536;  ++i) {
-        string s = format("%05d", i);
-        stats.add(s);
-        vals.emplace_back(std::move(s));
+    for (auto & v: vals) {
+        stats.add(v);
     }
-
-    MemorySerializer serializer;
     
     std::shared_ptr<StringTransducer> forward, backward;
     std::tie(forward, backward)
@@ -42,16 +44,106 @@ BOOST_AUTO_TEST_CASE( test_id_transducer )
         size_t len = forward->getOutputLength(s);
         char buf[len];
         string_view enc = forward->generateAll(s, buf, len);
-
-        //cerr << "enc length = " << enc.size() << endl;
-
-        //hex_dump(enc);
-        
         char outbuf[s.size()];
         string_view dec = backward->generateAll(enc, outbuf, s.size());
-
-        //hex_dump(dec);
-        
         BOOST_REQUIRE_EQUAL(s, dec);
     }
+
+    string filename = TMP + "/transducer_test.mldbds";
+
+    Scope_Exit(::unlink(filename.c_str()));
+
+    // Test serialization and reconstitution
+    {
+        ZipStructuredSerializer serializer("file://" + filename);
+        forward->serialize(*serializer.newStructure("fwd"));
+        backward->serialize(*serializer.newStructure("bwd"));
+    }
+    
+    ZipStructuredReconstituter reconstitutor(Url("file://" + filename));
+    auto forward2 = StringTransducer::thaw(*reconstitutor.getStructure("fwd"));
+    auto backward2 = StringTransducer::thaw(*reconstitutor.getStructure("bwd"));
+
+    for (auto & s: vals) {
+        size_t len = forward->getOutputLength(s);
+        char buf[len];
+        string_view enc = forward->generateAll(s, buf, len);
+
+        size_t len2 = forward2->getOutputLength(s);
+        char buf2[len2];
+        string_view enc2 = forward2->generateAll(s, buf2, len2);
+
+        BOOST_CHECK_EQUAL(enc, enc2);
+
+        char outbuf[s.size()];
+        string_view dec = backward2->generateAll(enc, outbuf, s.size());
+        BOOST_REQUIRE_EQUAL(s, dec);
+    }
+
+    return { forward, backward };
 }
+
+BOOST_AUTO_TEST_CASE( test_id_transducer_corner_cases )
+{
+    testTransducer({});
+    testTransducer({""});
+    testTransducer({"",""});
+    testTransducer({"hello"});
+
+    // Test that we can use all 256 characters simultaneously
+    std::string s;
+    for (int i = 0;  i < 256;  ++i) {
+        s.push_back(i);
+    }
+
+    testTransducer({s});
+}
+
+#if 1
+BOOST_AUTO_TEST_CASE(id_transducer_difficult_case_1)
+{
+    testTransducer({ "OJozXPBBH999gj0PV", "O+9WCkP/e99epmFZ9", "OueEOKa/e99OMCY0/",
+                     "OT+yjmK/R999YxGJD", "OfXvjta/e999lOVem", "OC8QFwPWK99Yv4zaD",
+                     "OdpGeHtRi99eMDuPV", "ONNyvHPWK99YPXuCV", "O4s126a/e99YpJp/3",
+                     "OgN6sEGRL99ObzaJP" });
+}
+#endif
+
+BOOST_AUTO_TEST_CASE(id_transducer_difficult_case_2)
+{
+    testTransducer({ "000", "011", "012" });
+}
+
+BOOST_AUTO_TEST_CASE(id_transducer_difficult_case_3)
+{
+    testTransducer({ "012", "011", "000", "010" });
+}
+
+BOOST_AUTO_TEST_CASE(id_transducer_difficult_case_4)
+{    std::vector<std::string> strings = {
+        "ORouter Exception: doStartBidding.alreadyInFlight: auction with ID 6c427837-93a6-4bd2-b59e-0c4aacd35c64 already in progress",
+        "ORouter Exception: doStartBidding.alreadyInFlight: auction with ID 6c42ade5-0bc5-4ea4-a4fa-6dab617ce21e already in progress",
+        "ORouter Exception: doStartBidding.alreadyInFlight: auction with ID 6c431bd0-e7ff-4c45-a2c5-bac026743a90 already in progress",
+        "ORouter Exception: doStartBidding.alreadyInFlight: auction with ID 6c4480ee-f226-4de4-9a99-6c665797c0b2 already in progress",
+        "ORouter Exception: doStartBidding.alreadyInFlight: auction with ID 6c44b0fa-340c-4e50-8df6-1effd934ffc8 already in progress",
+        "ORouter Exception: doStartBidding.alreadyInFlight: auction with ID 00000000-0000-0000-0000-PATATE000000 already in progress",
+        "ORouter Exception: doStartBidding.alreadyInFlight: auction with ID 6c469d1d-ce43-4990-9d76-08e83cf85e6f already in progress",
+        "ORouter Exception: doStartBidding.alreadyInFlight: auction with ID 6c486dc3-4707-4c04-967e-2f6b27cd6520 already in progress",
+        "ORouter Exception: doStartBidding.alreadyInFlight: auction with ID 6c4921d8-a3ee-434e-9bef-bb64450af455 already in progress"
+    };
+
+    testTransducer(strings);
+}
+
+BOOST_AUTO_TEST_CASE( test_id_transducer )
+{
+    std::vector<std::string> vals;
+
+    // Check that 16 bits is really represented in 16 bits
+    for (size_t i = 0;  i < 65536;  ++i) {
+        string s = format("%05d", i);
+        vals.emplace_back(std::move(s));
+    }
+
+    testTransducer(vals);
+}    

--- a/plugins/tabular/testing/transducer_test.cc
+++ b/plugins/tabular/testing/transducer_test.cc
@@ -1,0 +1,57 @@
+/** path_test.cc
+    Jeremy Barnes, 10 April 2016
+    Copyright (c) 2015 mldb.ai inc.  All rights reserved.
+
+    This file is part of MLDB. Copyright 2016 mldb.ai inc. All rights reserved.
+
+    Test of coordinate classes.
+*/
+
+#include "mldb/plugins/tabular/transducer.h"
+#include "mldb/block/memory_region.h"
+#include "mldb/base/hex_dump.h"
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "mldb/utils/string_functions.h"
+
+using namespace std;
+using namespace MLDB;
+
+BOOST_AUTO_TEST_CASE( test_id_transducer )
+{
+    std::vector<std::string> vals;
+    StringStats stats;
+
+    // Check that 16 bits is really represented in 16 bits
+    for (size_t i = 0;  i < 65536;  ++i) {
+        string s = format("%05d", i);
+        stats.add(s);
+        vals.emplace_back(std::move(s));
+    }
+
+    MemorySerializer serializer;
+    
+    std::shared_ptr<StringTransducer> forward, backward;
+    std::tie(forward, backward)
+        = trainIdTransducer(vals, stats, serializer);
+
+    for (auto & s: vals) {
+        size_t len = forward->getOutputLength(s);
+        char buf[len];
+        string_view enc = forward->generateAll(s, buf, len);
+
+        //cerr << "enc length = " << enc.size() << endl;
+
+        //hex_dump(enc);
+        
+        char outbuf[s.size()];
+        string_view dec = backward->generateAll(enc, outbuf, s.size());
+
+        //hex_dump(dec);
+        
+        BOOST_REQUIRE_EQUAL(s, dec);
+    }
+}

--- a/plugins/tabular/transducer.cc
+++ b/plugins/tabular/transducer.cc
@@ -1,0 +1,936 @@
+/** transducer.h                                                   -*- C++ -*-
+    Jeremy Barnes, 16 April 2018
+    Copyright (c) 2018 Element AI Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2018 mldb.ai inc. All rights reserved.
+
+    Definitions for transducer classes, used to predictively produce
+    dataset elements.
+*/
+
+#include "transducer.h"
+#include "mldb/ext/zstd/lib/zdict.h"
+#include "mldb/ext/zstd/lib/zstd.h"
+#include "mldb/types/annotated_exception.h"
+
+#include "mldb/block/memory_region.h"
+#include "mldb/base/scope.h"
+#include "mldb/types/basic_value_descriptions.h"
+#include "mldb/utils/possibly_dynamic_buffer.h"
+
+#include "frozen_tables.h"
+
+#include <atomic>
+#include <mutex>
+#include <bitset>
+
+
+using namespace std;
+
+
+namespace MLDB {
+
+
+/*****************************************************************************/
+/* STRING TRANSDUCER                                                         */
+/*****************************************************************************/
+
+namespace {
+
+std::mutex typeRegistryMutex;
+
+std::map<std::string, std::function<std::shared_ptr<StringTransducer> (StructuredReconstituter &)> > & getTypeRegistry()
+{
+    static std::map<std::string, std::function<std::shared_ptr<StringTransducer> (StructuredReconstituter &)> > result;
+    return result;
+}
+
+
+} // file scope
+
+std::shared_ptr<const void>
+StringTransducer::
+registerType(const std::string & type,
+             std::function<std::shared_ptr<StringTransducer>
+                 (StructuredReconstituter &)> create)
+{
+    static auto & registry = getTypeRegistry();
+    
+    std::unique_lock<std::mutex> guard(typeRegistryMutex);
+    if (!registry.emplace(type, std::move(create)).second) {
+        throw Exception("Attempt to double register StringTransducer type "
+                        + type);
+    }
+
+    // Auto-deregister when we lose access to the handle, to enable shared
+    // library unloading etc.
+    auto del = [type] (const void *)
+        {
+            std::unique_lock<std::mutex> guard(typeRegistryMutex);
+            auto & registry = getTypeRegistry();
+            registry.erase(type);
+        };
+
+    return std::shared_ptr<const void>(nullptr, del);
+}
+
+std::shared_ptr<StringTransducer>
+StringTransducer::
+thaw(StructuredReconstituter & reconst)
+{
+    cerr << "reconst is " << reconst.getContext() << endl;
+
+    for (auto & d: reconst.getDirectory()) {
+        cerr << "contains " << d.name << endl;
+    }
+    
+    static const auto & registry = getTypeRegistry();
+
+    // First, get the type
+    string type = reconst.getObject<std::string>("t");
+    
+    std::unique_lock<std::mutex> guard(typeRegistryMutex);
+    auto it = registry.find(type);
+
+    if (it == registry.end()) {
+        throw Exception("Unknown StringTransducer type " + type);
+    }
+
+    // TODO: two-phase that releases lock once first construction is done,
+    // or takes a reference to a shared ptr
+    return it->second(*reconst.getStructure("d"));
+}
+
+void
+StringTransducer::
+serialize(StructuredSerializer & serializer) const
+{
+    serializer.newObject("t", type());
+    serializeParameters(*serializer.newStructure("d"));
+}
+
+
+/*****************************************************************************/
+/* IDENTITY STRING TRANSDUCER                                                */
+/*****************************************************************************/
+
+IdentityStringTransducer::
+IdentityStringTransducer()
+{
+}
+    
+IdentityStringTransducer::
+IdentityStringTransducer(StructuredSerializer & serializer)
+{
+}
+
+std::string_view
+IdentityStringTransducer::
+generateAll(std::string_view input,
+            char * outputBuffer,
+            size_t outputLength) const
+{
+    return input;
+}
+
+size_t
+IdentityStringTransducer::
+getOutputLength(std::string_view input) const
+{
+    return input.length();
+}
+
+size_t
+IdentityStringTransducer::
+getTemporaryBufferSize(std::string_view input,
+                       ssize_t outputLength) const
+{
+    return 0;
+}
+
+bool
+IdentityStringTransducer::
+needsTemporaryBuffer() const
+{
+    return false;
+}
+
+bool
+IdentityStringTransducer::
+canGetOutputLength() const
+{
+    return true;  // can be provided
+}
+
+std::string
+IdentityStringTransducer::
+type() const
+{
+    return "id";
+}
+
+void
+IdentityStringTransducer::
+serializeParameters(StructuredSerializer & serializer) const
+{
+    // Nothing to freeze here
+}
+
+size_t
+IdentityStringTransducer::
+memusage() const
+{
+    return sizeof(*this);
+}
+
+
+/*****************************************************************************/
+/* ZSTD STRING TRANSDUCER                                                    */
+/*****************************************************************************/
+
+struct ZstdStringTransducer::Itl {
+    ~Itl()
+    {
+        {
+            ZSTD_DDict * prev = ddict.exchange(nullptr);
+            if (prev) {
+                ZSTD_freeDDict(prev);
+            }
+        }
+
+        {
+            ZSTD_CDict * prev = cdict.exchange(nullptr);
+            if (prev) {
+                ZSTD_freeCDict(prev);
+            }
+        }
+    }
+
+    FrozenMemoryRegion formatData;
+    
+    // For decompression
+    mutable std::atomic<ZSTD_DDict *> ddict = nullptr;
+    mutable std::mutex dContextPoolLock;
+    mutable std::vector<std::shared_ptr<ZSTD_DCtx> > dContextPool;
+
+    // For compression
+    mutable std::atomic<ZSTD_CDict *> cdict = nullptr;
+    mutable std::mutex cContextPoolLock;
+    mutable std::vector<std::shared_ptr<ZSTD_CCtx> > cContextPool;
+
+    size_t memusage() const
+    {
+        return formatData.memusage();
+        // the other things are caches, so don't count towards permanent
+        // memory usage
+    }
+
+    std::pair<std::shared_ptr<ZSTD_DCtx>, const ZSTD_DDict *>
+    getDecompressionContext()
+    {
+        std::shared_ptr<ZSTD_DCtx> context;
+        {
+            std::unique_lock<std::mutex> guard(dContextPoolLock);
+            if (!dContextPool.empty()) {
+                context = dContextPool.back();
+                dContextPool.pop_back();
+            }
+        }
+        
+        if (!context) {
+            context.reset(ZSTD_createDCtx(),
+                        [] (ZSTD_DCtx * context) { ZSTD_freeDCtx(context); });
+        }
+
+        // Ownership of context is held in this lambda
+        auto freeContext = [this, context] (void *)
+            {
+                if (!context)
+                    return;
+                std::unique_lock<std::mutex> guard(dContextPoolLock);
+                dContextPool.emplace_back(std::move(context));
+            };
+
+        context = std::shared_ptr<ZSTD_DCtx>(context.get(), freeContext);
+
+        if (!ddict.load()) {
+            ZSTD_DDict * dict = ZSTD_createDDict(formatData.data(),
+                                                 formatData.length());
+            ZSTD_DDict * previous = nullptr;
+            if (!this->ddict.compare_exchange_strong(previous, dict)) {
+                ZSTD_freeDDict(dict);
+            }
+        }
+
+        return { std::move(context), ddict.load() };
+    }    
+
+    std::pair<std::shared_ptr<ZSTD_CCtx>, const ZSTD_CDict *>
+    getCompressionContext()
+    {
+        std::shared_ptr<ZSTD_CCtx> context;
+        {
+            std::unique_lock<std::mutex> guard(cContextPoolLock);
+            if (!cContextPool.empty()) {
+                context = cContextPool.back();
+                cContextPool.pop_back();
+            }
+        }
+        
+        if (!context) {
+            context.reset(ZSTD_createCCtx(),
+                        [] (ZSTD_CCtx * context) { ZSTD_freeCCtx(context); });
+        }
+
+        // Ownership of context is held in this lambda
+        auto freeContext = [this, context] (void *)
+            {
+                std::unique_lock<std::mutex> guard(cContextPoolLock);
+                this->cContextPool.emplace_back(std::move(context));
+            };
+
+        context = std::shared_ptr<ZSTD_CCtx>(context.get(), freeContext);
+
+        if (!cdict.load()) {
+            ZSTD_CDict * dict = ZSTD_createCDict(formatData.data(),
+                                                 formatData.length(), 5  /* compression level */);
+            ZSTD_CDict * previous = nullptr;
+            if (!this->cdict.compare_exchange_strong(previous, dict)) {
+                ZSTD_freeCDict(dict);
+            }
+        }
+
+        return { std::move(context), cdict.load() };
+    }    
+
+};
+
+ZstdStringTransducer::
+ZstdStringTransducer(StructuredSerializer & serializer)
+{
+
+}
+
+ZstdStringTransducer::
+ZstdStringTransducer(std::shared_ptr<Itl> itl)
+    : itl(std::move(itl))
+{
+}
+
+ZstdStringTransducer::
+~ZstdStringTransducer()
+{
+}
+
+std::pair<std::shared_ptr<ZstdStringCompressor>,
+          std::shared_ptr<ZstdStringDecompressor> >
+ZstdStringTransducer::
+train(const std::vector<std::string> & blobs,
+      MappedSerializer & serializer)
+{
+    // Let the dictionary size be 5% of the total
+    size_t dictionarySize = 131072;//32768; //info->totalBytes / 20;
+
+    std::string dictionary(dictionarySize, '\0');
+
+    static constexpr size_t TOTAL_SAMPLE_SIZE = 1024 * 1024;
+
+    // Give it the first 1MB to train on
+    std::string sampleBuffer;
+    sampleBuffer.reserve(2 * TOTAL_SAMPLE_SIZE);
+
+    std::vector<size_t> sampleSizes;
+    size_t currentOffset = 0;
+    size_t valNumber = 0;
+
+    // Accumulate the first 1MB of strings in a contiguous buffer
+
+    for (auto & v: blobs) {
+        if (currentOffset > TOTAL_SAMPLE_SIZE)
+            break;
+        size_t sampleSize = v.length();
+        sampleBuffer.append(v);
+        sampleSizes.push_back(sampleSize);
+        currentOffset += sampleSize;
+        valNumber += 1;
+    }
+
+    Date before = Date::now();
+
+    // Perform the dictionary training
+    size_t res = ZDICT_trainFromBuffer(&dictionary[0],
+                                       dictionary.size(),
+                                       sampleBuffer.data(),
+                                       sampleSizes.data(),
+                                       sampleSizes.size());
+    if (ZDICT_isError(res)) {
+        throw AnnotatedException(500, "Error with dictionary: "
+                                  + string(ZDICT_getErrorName(res)));
+    }
+        
+    dictionary.resize(res);
+
+    Date after = Date::now();
+    double elapsed = after.secondsSince(before);
+
+    cerr << "created dictionary of " << res << " bytes from "
+         << currentOffset << " bytes of samples in "
+         << elapsed << " seconds" << endl;
+
+    auto itl = std::make_shared<Itl>();
+    auto dictRegion
+        = serializer.allocateWritable(dictionary.length(), 1);
+    std::memcpy(dictRegion.data(), dictionary.data(), dictionary.length());
+    itl->formatData = dictRegion.freeze();
+
+    return { std::make_shared<ZstdStringCompressor>(itl), std::make_shared<ZstdStringDecompressor>(itl) };
+}
+
+void
+ZstdStringTransducer::
+serializeParameters(StructuredSerializer & serializer) const
+{
+    serializer.newEntry("dict")->copy(itl->formatData);
+}
+
+size_t
+ZstdStringTransducer::
+memusage() const
+{
+    return sizeof(*this)
+        + itl->memusage();
+}
+
+
+/*****************************************************************************/
+/* ZSTD STRING COMPRESSOR                                                    */
+/*****************************************************************************/
+
+std::string_view
+ZstdStringCompressor::
+generateAll(std::string_view input,
+            char * outputBuffer,
+            size_t outputLength) const
+{
+    std::shared_ptr<ZSTD_CCtx> context;
+    const ZSTD_CDict * dict;
+    std::tie(context, dict) = itl->getCompressionContext();
+
+    size_t res
+        = ZSTD_compress_usingCDict(context.get(),
+                                   outputBuffer, outputLength,
+                                   input.data(), input.length(),
+                                   dict);
+
+    if (ZSTD_isError(res)) {
+        throw AnnotatedException(500, "Error with compressing: "
+                                    + string(ZSTD_getErrorName(res)));
+    }
+
+    return { outputBuffer, res };
+}
+
+size_t
+ZstdStringCompressor::
+getTemporaryBufferSize(std::string_view input,
+                       ssize_t outputLength) const
+{
+    return ZSTD_compressBound(input.length());
+}
+
+bool
+ZstdStringCompressor::
+needsTemporaryBuffer() const
+{
+    return true;
+}
+
+bool
+ZstdStringCompressor::
+canGetOutputLength() const
+{
+    return false;
+}
+
+size_t
+ZstdStringCompressor::
+getOutputLength(std::string_view input) const
+{
+    throw MLDB::Exception("canGetOutputLength is false");
+}
+
+std::string
+ZstdStringCompressor::
+type() const
+{
+    return "zsc";
+}
+
+
+/*****************************************************************************/
+/* ZSTD STRING DECOMPRESSOR                                                  */
+/*****************************************************************************/
+
+std::string_view
+ZstdStringDecompressor::
+generateAll(std::string_view input,
+            char * outputBuffer,
+            size_t outputLength) const
+{
+    std::shared_ptr<ZSTD_DCtx> context;
+    const ZSTD_DDict * dict;
+    std::tie(context, dict) = itl->getDecompressionContext();
+
+    size_t storageSize = input.length();
+    const char * data = input.data();
+    
+    auto res = ZSTD_decompress_usingDDict(context.get(),
+                                          outputBuffer,
+                                          outputLength,
+                                          data, storageSize,
+                                          dict);
+    
+    if (ZSTD_isError(res)) {
+        throw AnnotatedException(500, "Error with decompressing: "
+                                  + string(ZSTD_getErrorName(res)));
+    }
+
+    return std::string_view(outputBuffer, res);
+}
+
+size_t
+ZstdStringDecompressor::
+getOutputLength(std::string_view input) const
+{
+    const char * data = input.data();
+    auto res = ZSTD_getDecompressedSize(data, input.length());
+    if (ZSTD_isError(res)) {
+        throw AnnotatedException(500, "Error with decompressing: "
+                                  + string(ZSTD_getErrorName(res)));
+    }
+    return res;
+}
+
+size_t
+ZstdStringDecompressor::
+getTemporaryBufferSize(std::string_view input,
+                       ssize_t outputLength) const
+{
+    auto res = ZSTD_getDecompressedSize(input.data(), input.length());
+    if (ZSTD_isError(res)) {
+        throw AnnotatedException(500, "Error with decompressing: "
+                                  + string(ZSTD_getErrorName(res)));
+    }
+
+    return res;
+}
+
+bool
+ZstdStringDecompressor::
+needsTemporaryBuffer() const
+{
+    return true;
+}
+
+bool
+ZstdStringDecompressor::
+canGetOutputLength() const
+{
+    return true;  // can be provided
+}
+
+std::string
+ZstdStringDecompressor::
+type() const
+{
+    return "zsd";
+}
+
+
+/*****************************************************************************/
+/* ID TRANSDUCER                                                             */
+/*****************************************************************************/
+
+struct TableCharacterTransducer: public CharacterTransducer {
+    TableCharacterTransducer(const std::bitset<256> & table)
+    {
+        // If we have all set, then there is no advantage
+        ExcAssertLess(table.count(), 255);
+
+        for (size_t i = 0;  i < table.size();  ++i) {
+            if (table.test(i)) {
+                this->table.emplace_back(i);
+                this->index[i] = this->table.size();
+            }
+        }
+    }
+
+    virtual ~TableCharacterTransducer()
+    {
+    }
+
+    virtual char decode(uint32_t input) const
+    {
+        return table.at(input);
+    }
+
+    virtual uint32_t encode(unsigned char input) const
+    {
+        if (input[index] == 0)
+            throw Exception(500, "Logic error in char transducer encode");
+        return index[input] - 1;
+    }
+
+    virtual size_t memusage() const
+    {
+        return sizeof(this)
+            + table.capacity();
+    }
+    
+    std::vector<unsigned char> table;
+    unsigned char index[256] = {0};
+};
+
+namespace {
+
+struct PositionInfo {
+    uint32_t counts[256] = {0};
+    uint32_t uniqueCounts = 0;
+    std::bitset<256> bits;
+
+    int intNum = 0;  ///< Which of the integers we encode this in?
+    uint64_t baseMultiplier = 0;  ///< Base multiplier of this bit
+    uint16_t posMultiplier = 0;
+    uint64_t bitWidth = 0;
+    
+    void update(unsigned char c)
+    {
+        uniqueCounts += (counts[c]++ == 0);
+        bits.set(c);
+    }
+
+    std::unique_ptr<CharacterTransducer> train() const
+    {
+        return std::unique_ptr<CharacterTransducer>
+            (new TableCharacterTransducer(bits));
+    }
+};
+
+struct IntInfo {
+    uint32_t bitWidth = 0;   ///< How many bits in this integer
+};
+
+struct IdTransducerInfo {
+    std::vector<PositionInfo> positions;
+    std::vector<std::unique_ptr<CharacterTransducer> > transducers;
+    std::vector<IntInfo> ints;
+    size_t totalOutputBytes = 0;
+
+    void freeze(StructuredSerializer & serializer) const
+    {
+    }
+
+    size_t memusage() const
+    {
+        size_t result
+            = sizeof(*this)
+            + positions.capacity() * sizeof(positions[0])
+            + transducers.capacity() * sizeof(transducers[0])
+            + ints.capacity() * sizeof(ints[0]);
+        for (auto & t: transducers) {
+            result += t->memusage();
+        }
+        return result;
+    }
+
+    static IdTransducerInfo *
+    thaw(StructuredReconstituter & reconstituter)
+    {
+        throw Exception("thaw");
+    }
+};
+
+struct ForwardIdTransducer: public StringTransducer {
+
+    ForwardIdTransducer(std::shared_ptr<IdTransducerInfo> info)
+        : info(std::move(info))
+    {
+    }
+    
+    std::string_view generateAll(std::string_view input,
+                                 char * outputBuffer,
+                                 size_t outputLength) const
+    {
+        ExcAssertEqual(outputLength, info->totalOutputBytes);
+
+        int currentInt = 0;
+        uint64_t current = 0;
+        size_t outputPos = 0;
+        
+        auto doneCurrent = [&] ()
+            {
+                ExcAssertLess(currentInt, info->ints.size());
+                size_t width = info->ints[currentInt].bitWidth;
+                for (size_t i = 0;  i < width;  i += 8) {
+                    //cerr << "writing byte " << (current % 256) << endl;
+                    outputBuffer[outputPos++] = current % 256;
+                    current = current >> 8;
+                }
+
+                ExcAssertEqual(current, 0);
+                
+                current = 0;
+                currentInt += 1;
+            };
+
+        for (size_t i = 0;  i < input.length();  ++i) {
+            uint64_t contrib = info->transducers[i]->encode(input[i]);
+            current += contrib * info->positions[i].baseMultiplier;
+            if (i == input.length() - 1
+                || info->positions[i + 1].intNum != currentInt) {
+                doneCurrent();
+            }
+        }
+
+        return std::string_view(outputBuffer, outputLength);
+    }
+    
+    size_t getOutputLength(std::string_view input) const
+    {
+        return info->totalOutputBytes;
+    }
+
+    size_t getTemporaryBufferSize(std::string_view input,
+                                  ssize_t outputLength) const
+    {
+        return info->totalOutputBytes;
+    }
+
+    bool needsTemporaryBuffer() const
+    {
+        return true;
+    }
+
+    bool canGetOutputLength() const
+    {
+        return false;
+    }
+
+    std::string type() const
+    {
+        return "fid";
+    }
+
+    void serializeParameters(StructuredSerializer & serializer) const
+    {
+        info->freeze(serializer);
+    }
+
+    size_t memusage() const
+    {
+        return sizeof(*this) + info->memusage();
+    }
+
+    std::shared_ptr<IdTransducerInfo> info;
+};
+
+struct BackwardIdTransducer: public StringTransducer {
+
+    BackwardIdTransducer(StructuredReconstituter & reconstituter)
+    {
+    }
+
+    BackwardIdTransducer(std::shared_ptr<IdTransducerInfo> info)
+        : info(std::move(info))
+    {
+    }
+
+    std::string_view
+    generateAll(std::string_view input,
+                char * outputBuffer,
+                size_t outputLength) const
+    {
+        const auto & positions = info->positions;
+        const auto & transducers = info->transducers;
+        
+        if (!info->ints.empty()) {
+            ExcAssertEqual(input.length(),
+                           (info->ints.size() - 1) * 8
+                           + (info->ints.back().bitWidth + 7) / 8);
+        }
+
+        ExcAssertEqual(outputLength, positions.size());
+
+        int intNumber = -1;
+        auto getNewInt = [&] () -> uint64_t
+            {
+                ++intNumber;
+                ExcAssertLess(intNumber, info->ints.size());
+                int numBytes = (info->ints[intNumber].bitWidth + 7) / 8;
+
+                //cerr << "getNewInt with " << numBytes << " bytes"
+                //     << endl;
+
+                uint64_t result = 0;
+                for (size_t i = 0;  i < numBytes;  ++i) {
+                    //cerr << "reading byte " << (unsigned)(unsigned char)input[i] << endl;
+                    result = result | ((unsigned char)input[i] << (i*8));
+                }
+
+
+                
+                return result;
+            };
+        
+        uint64_t current = 0;
+
+        for (size_t i = 0;  i < info->positions.size();  ++i) {
+            if (positions[i].intNum != intNumber) {
+                ExcAssertEqual(current, 0);
+                current = getNewInt();
+            }
+
+            uint64_t nextMultiplier = positions[i].posMultiplier;
+#if 0
+            if (i == positions.size() - 1
+                || positions[i + 1].intNum != positions[i].intNum) {
+                nextMultiplier = -1;
+            }
+            else nextMultiplier = positions[i + 1].posMultiplier;
+#endif
+            
+            //cerr << "i = " << i << " current = " << current
+            //     << " intNum = " << positions[i].intNum << " nextMultiplier = "
+            //     << nextMultiplier << " thisPos = "
+            //     << current % nextMultiplier << endl;
+            
+            uint64_t thisPos = current % nextMultiplier;
+            current = current / nextMultiplier;
+
+            char c = transducers[i]->decode(thisPos);
+            outputBuffer[i] = c;
+        }
+
+        return std::string_view(outputBuffer, outputLength);
+    }
+    
+    size_t getOutputLength(std::string_view input) const
+    {
+        throw AnnotatedException
+            (400, "Transducer does not implement getSize()");
+    }
+
+    size_t getTemporaryBufferSize(std::string_view input,
+                                  ssize_t outputSize) const
+    {
+        return outputSize;
+    }
+
+    bool needsTemporaryBuffer() const
+    {
+        return true;
+    }
+    
+    bool canGetOutputLength() const
+    {
+        return false;
+    }
+
+    std::string type() const
+    {
+        return "bid";
+    }
+
+    void serializeParameters(StructuredSerializer & serializer) const
+    {
+        info->freeze(serializer);
+    }
+    
+    size_t memusage() const
+    {
+        return sizeof(*this) + info->memusage();
+    }
+
+    std::shared_ptr<IdTransducerInfo> info;
+};
+
+static StringTransducer::Register<BackwardIdTransducer> registerId("bid");
+
+
+} // file scope
+
+std::pair<std::shared_ptr<StringTransducer>,
+          std::shared_ptr<StringTransducer> >
+trainIdTransducer(const std::vector<std::string> & blobs,
+                  const StringStats & stats,
+                  MappedSerializer & serializer)
+{
+    std::vector<uint32_t> lengthsFound;
+    // Which is our short length?
+
+    for (int i = 0;  i < 256;  ++i) {
+        if (stats.shortLengthDistribution[i] > 0) {
+            lengthsFound.push_back(i);
+        }
+    }
+
+    ExcAssert(!lengthsFound.empty());
+    
+    size_t maxLength = lengthsFound.back();
+    
+    // Look for a restricted subset of characters per position
+    std::vector<PositionInfo> charsPerPosition(maxLength);
+    std::vector<IntInfo> ints;
+    
+    for (const std::string & b: blobs) {
+        for (size_t i = 0;  i < b.size();  ++i) {
+            charsPerPosition[i].update(b[i]);
+        }
+    }
+
+    double bits = 0;
+    uint64_t total = 1;
+    int intNum = 0;
+    std::vector<std::unique_ptr<CharacterTransducer> > transducers;
+    
+    for (size_t p = 0;  p < maxLength;  ++p) {
+        cerr << p << "=" << charsPerPosition[p].uniqueCounts << " ";
+        bits += log2(charsPerPosition[p].uniqueCounts);
+
+        if (bits > 64 && charsPerPosition[p].uniqueCounts > 1) {
+            ints.push_back({64});
+            total = 1;
+            ++intNum;
+            bits = 0;
+        }
+
+        charsPerPosition[p].posMultiplier = charsPerPosition[p].uniqueCounts;
+        charsPerPosition[p].baseMultiplier = total;
+        charsPerPosition[p].intNum = intNum;
+
+        total *= charsPerPosition[p].uniqueCounts;
+
+        transducers.emplace_back(charsPerPosition[p].train());
+    }
+
+    // There is one extra integer to hold the leftover bits
+    if (bits > 0) {
+        ints.push_back({uint32_t(std::ceil(bits))});
+    }
+    
+    size_t totalOutputBytes = 8 * intNum + (std::ceil(bits) + 7) / 8;
+
+    //cerr << " bits = " << bits << " totalOutputBytes = " << totalOutputBytes
+    //     << " total = " << total << endl;
+    
+    auto info = std::make_shared<IdTransducerInfo>();
+    info->positions = std::move(charsPerPosition);
+    info->totalOutputBytes = totalOutputBytes;
+    info->transducers = std::move(transducers);
+    info->ints = std::move(ints);
+    
+    return { std::make_shared<ForwardIdTransducer>(info),
+             std::make_shared<BackwardIdTransducer>(info) };
+}
+
+
+} // namespace MLDB

--- a/plugins/tabular/transducer.h
+++ b/plugins/tabular/transducer.h
@@ -73,11 +73,9 @@ struct Callable {
 
 
 struct CharacterTransducer: public Transducer {
-    virtual ~CharacterTransducer()
-    {
-    }
+    virtual ~CharacterTransducer() = default;
 
-    virtual char decode(uint32_t input) const = 0;
+    virtual unsigned char decode(uint32_t input) const = 0;
 
     virtual uint32_t encode(unsigned char input) const = 0;
 
@@ -175,8 +173,8 @@ struct IdentityStringTransducer: public StringTransducer {
 
     IdentityStringTransducer();
     
-    IdentityStringTransducer(StructuredSerializer & serializer);
-    
+    IdentityStringTransducer(StructuredReconstituter & reconstituter);
+
     virtual std::string_view
     generateAll(std::string_view input,
                 char * outputBuffer,
@@ -210,7 +208,7 @@ struct ZstdStringTransducer: public StringTransducer {
     struct Itl;
     std::shared_ptr<Itl> itl;
     
-    ZstdStringTransducer(StructuredSerializer & serializer);
+    ZstdStringTransducer(StructuredReconstituter & reconstituter);
     ZstdStringTransducer(std::shared_ptr<Itl> itl);
 
     virtual ~ZstdStringTransducer();

--- a/plugins/tabular/transducer.h
+++ b/plugins/tabular/transducer.h
@@ -1,0 +1,295 @@
+/** transducer.h                                                   -*- C++ -*-
+    Jeremy Barnes, 16 April 2018
+    Copyright (c) 2018 Element AI Inc.  All rights reserved.
+    This file is part of MLDB. Copyright 2018 mldb.ai inc. All rights reserved.
+
+    Definitions for transducer classes, used to predictively produce
+    dataset elements.
+*/
+
+#pragma once
+
+
+#include <memory>
+#include <vector>
+#include <string>
+#include "mldb/utils/lightweight_hash.h"
+#include "mldb/compiler/string_view.h"
+
+
+namespace MLDB {
+
+
+struct MappedSerializer;
+struct StructuredSerializer;
+struct StructuredReconstituter;
+
+
+/*****************************************************************************/
+/* TRANSDUCER                                                                */
+/*****************************************************************************/
+
+/** A transducer encapsulates something that scans a sequence of input
+    tokens, updating a state and producing a set of output tokens.
+
+    It encapsulates many things, including compression and decompression,
+    pseudo-random number generation, predictive coding, etc. 
+
+    This common interface takes care of defining the basic functionality
+    of a transducer that enables it to be constructed, to generate its
+    initial state, to be saved and reconstituted across devices, etc.
+*/
+
+struct Transducer {
+    virtual ~Transducer()
+    {
+    }
+};
+
+
+/*****************************************************************************/
+/* INTERFACE DESCRIPTION                                                     */
+/*****************************************************************************/
+
+struct InterfaceDescription {
+    struct Call {
+        //StructureDescription parameters;
+    };
+};
+
+/*****************************************************************************/
+/* CALLABLE                                                                  */
+/*****************************************************************************/
+
+/** Basic interface for something that exposes a calling contract and is
+    this callable.  These can't be called directly, but can be instantiated
+    into directly callable objects (for a particular device, for example)
+    as the compilation and optimization is device-specific and may take
+    a considerable amount of time.
+*/
+
+struct Callable {
+};
+
+
+struct CharacterTransducer: public Transducer {
+    virtual ~CharacterTransducer()
+    {
+    }
+
+    virtual char decode(uint32_t input) const = 0;
+
+    virtual uint32_t encode(unsigned char input) const = 0;
+
+    virtual size_t memusage() const = 0;
+};
+
+
+/*****************************************************************************/
+/* STRING STATS                                                              */
+/*****************************************************************************/
+
+struct StringStats {
+    uint64_t totalBytes = 0;
+
+    uint32_t shortLengthDistribution[256] = {0};  // for length 0-255
+    LightweightHash<uint32_t, uint32_t> longLengthDistribution;
+    size_t uniqueShortLengths = 0, uniqueLongLengths = 0;
+
+    /* We keep the distribution of bytes in the string to determine if
+       there is an obvious encoding that's much smaller than the current
+       one due to a restricted set of values.
+    */
+    uint32_t byteDistribution[256] = {0};
+    size_t uniqueBytes = 0;
+    
+    void add(std::string_view s);
+};
+
+
+/*****************************************************************************/
+/* STRING TRANSDUCER                                                         */
+/*****************************************************************************/
+
+struct StringTransducer: public Transducer, public Callable {
+    virtual ~StringTransducer()
+    {
+    }
+
+    virtual std::string_view
+    generateAll(std::string_view input,
+                char * outputBuffer,
+                size_t outputLength) const = 0;
+    
+    virtual size_t getOutputLength(std::string_view input) const = 0;
+    
+    virtual size_t getTemporaryBufferSize(std::string_view input,
+                                          ssize_t outputLength) const = 0;
+
+    virtual bool needsTemporaryBuffer() const = 0;
+
+    virtual bool canGetOutputLength() const = 0;
+    
+    virtual std::string type() const = 0;
+
+    virtual void serializeParameters(StructuredSerializer & serializer) const = 0;
+
+    /** Serialize the object including the metadata necessary to know which
+        type it is and invoke a factory function.  This calls
+        serializeParameters under the hood.
+    */
+    void serialize(StructuredSerializer & serializer) const;
+    
+    static std::shared_ptr<const void>
+    registerType
+        (const std::string & type,
+         std::function<std::shared_ptr<StringTransducer>
+                 (StructuredReconstituter &)> create);
+
+    template<typename T>
+    struct Register {
+        Register(const std::string & type)
+        {
+            auto fn = [] (StructuredReconstituter & reconst)
+                {
+                    return std::make_shared<T>(reconst);
+                };
+            handle = registerType(type, std::move(fn));
+        }
+        
+        std::shared_ptr<const void> handle;
+    };
+    
+    static std::shared_ptr<StringTransducer>
+    thaw(StructuredReconstituter & serializer);
+
+    virtual size_t memusage() const = 0;
+};
+
+
+/*****************************************************************************/
+/* IDENTITY STRING TRANSDUCER                                                */
+/*****************************************************************************/
+
+struct IdentityStringTransducer: public StringTransducer {
+
+    IdentityStringTransducer();
+    
+    IdentityStringTransducer(StructuredSerializer & serializer);
+    
+    virtual std::string_view
+    generateAll(std::string_view input,
+                char * outputBuffer,
+                size_t outputLength) const;
+    
+    virtual size_t getOutputLength(std::string_view input) const;
+    
+    virtual size_t getTemporaryBufferSize(std::string_view input,
+                                          ssize_t outputLength) const;
+
+    virtual bool needsTemporaryBuffer() const;
+
+    virtual bool canGetOutputLength() const;
+
+    virtual std::string type() const;
+
+    virtual void serializeParameters(StructuredSerializer & serializer) const;
+
+    virtual size_t memusage() const;
+};
+
+
+/*****************************************************************************/
+/* ZSTD STRING TRANSDUCER                                                    */
+/*****************************************************************************/
+
+struct ZstdStringCompressor;
+struct ZstdStringDecompressor;
+
+struct ZstdStringTransducer: public StringTransducer {
+    struct Itl;
+    std::shared_ptr<Itl> itl;
+    
+    ZstdStringTransducer(StructuredSerializer & serializer);
+    ZstdStringTransducer(std::shared_ptr<Itl> itl);
+
+    virtual ~ZstdStringTransducer();
+
+    static std::pair<std::shared_ptr<ZstdStringCompressor>,
+                     std::shared_ptr<ZstdStringDecompressor> >
+    train(const std::vector<std::string> & strings,
+          MappedSerializer & serializer);
+    
+    virtual void serializeParameters(StructuredSerializer & serializer) const;
+
+    virtual size_t memusage() const;
+};
+
+
+/*****************************************************************************/
+/* ZSTD STRING COMPRESSOR                                                    */
+/*****************************************************************************/
+
+struct ZstdStringCompressor: public ZstdStringTransducer {
+    
+    using ZstdStringTransducer::ZstdStringTransducer;
+
+    virtual std::string_view
+    generateAll(std::string_view input,
+                char * outputBuffer,
+                size_t outputLength) const;
+    
+    
+    virtual bool canGetOutputLength() const;
+
+    virtual size_t getOutputLength(std::string_view input) const;
+    
+    virtual size_t getTemporaryBufferSize(std::string_view input,
+                                          ssize_t outputLength) const;
+
+    virtual bool needsTemporaryBuffer() const;
+
+    virtual std::string type() const;
+};
+
+
+/*****************************************************************************/
+/* ZSTD STRING DECOMPRESSOR                                                  */
+/*****************************************************************************/
+
+struct ZstdStringDecompressor: public ZstdStringTransducer {
+    
+    using ZstdStringTransducer::ZstdStringTransducer;
+
+    virtual std::string_view
+    generateAll(std::string_view input,
+                char * outputBuffer,
+                size_t outputLength) const;
+    
+    virtual bool canGetOutputLength() const;
+
+    virtual size_t getOutputLength(std::string_view input) const;
+    
+    virtual size_t getTemporaryBufferSize(std::string_view input,
+                                          ssize_t outputLength) const;
+
+    virtual bool needsTemporaryBuffer() const;
+
+    virtual std::string type() const;
+};
+
+
+/*****************************************************************************/
+/* ID TRANSDUCER                                                             */
+/*****************************************************************************/
+
+
+
+std::pair<std::shared_ptr<StringTransducer>,
+          std::shared_ptr<StringTransducer> >
+trainIdTransducer(const std::vector<std::string> & strings,
+                  const StringStats & stats,
+                  MappedSerializer & serializer);
+
+} // namespace MLDB
+    


### PR DESCRIPTION
Many fields in datasets have a combination of a fixed format with some non-varying characters (eg, the UUIDs have "-" characters) and a reduced range of characters (eg, hexadecimal).  This patch detects single-length fields and uses modulo-encoding to pack them into fixed-with integers with all of the entropy.  It reduces (for example) the storage required for hexadecimal IDs by a factor of two.

It's a first step, there is much more that can be done.