### PR TITLE
Enable both address and undefined behavior sanitizers in CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,8 +55,9 @@ sanitize:
     - declare -x POSTCFLAGS='-O2 -g' POSTCXXFLAGS='-O2 -g'
     - declare -x PRECXX=./sccache
     - declare -x toolchain=clang
-    - declare -x sanitizers=address
+    - declare -x sanitizers=address,undefined
     - declare -x ASAN_OPTIONS=detect_leaks=0:use_sigaltstack=false
+    - declare -x UBSAN_OPTIONS=use_sigaltstack=false:print_stacktrace=1
     - make -j4 -k dependencies
     - ./sccache --show-stats
     - make -j32 -k compile || make -j32 -k compile

--- a/jml-build/clang.mk
+++ b/jml-build/clang.mk
@@ -19,7 +19,12 @@ CLANG_SANITIZER_memory_FLAGS:=-fsanitize=memory
 CLANG_SANITIZER_thread_FLAGS:=-fsanitize=thread
 CLANG_SANITIZER_undefined_FLAGS:=-fsanitize=undefined -fno-sanitize-recover=undefined -fno-sanitize=vptr -fvisibility=default
 
-CXXFLAGS ?= $(ARCHFLAGS) $(INCLUDE) $(CLANGXXWARNINGFLAGS) -pipe -ggdb $(foreach dir,$(LOCAL_INCLUDE_DIR),-I$(dir)) -std=c++17 $(foreach sanitizer,$(sanitizers),$(CLANG_SANITIZER_$(sanitizer)_FLAGS) )
+COMMA?=,
+NOTHING?=
+SPACE?=$(NOTHING) $(NOTHING)
+SANITIZERS:=$(subst $(COMMA),$(SPACE),$(sanitizers))
+
+CXXFLAGS ?= $(ARCHFLAGS) $(INCLUDE) $(CLANGXXWARNINGFLAGS) -pipe -ggdb $(foreach dir,$(LOCAL_INCLUDE_DIR),-I$(dir)) -std=c++17 $(foreach sanitizer,$(SANITIZERS),$(CLANG_SANITIZER_$(sanitizer)_FLAGS) )
 CXXNODEBUGFLAGS := -O3 -DBOOST_DISABLE_ASSERTS -DNDEBUG 
 CXXDEBUGFLAGS := -O0 -g3
 

--- a/jml-build/functions.mk
+++ b/jml-build/functions.mk
@@ -58,7 +58,7 @@ SEMICOLON:=;
 QUOTE:="
 #"  
 # (previous line is for emacs)
-
+COMMA:=$(NOTHING),$(NOTHING)
 
 
 hash_command2 = $(wordlist 1,1,$(shell echo $(strip $(1)) | $(MD5SUM)))


### PR DESCRIPTION
Ensures that we won't accidentally introduce regressions.