### PR TITLE
C++20

### DIFF
--- a/arch/wait_on_address.cc
+++ b/arch/wait_on_address.cc
@@ -154,6 +154,7 @@ ulock_wake(uint32_t *uaddr, uint32_t flags)
 	return _dlock_wake(uaddr, flags | UL_COMPARE_AND_WAIT);
 }
 
+#if 0 // not currently used
 static int
 unfair_lock_wait(uint32_t *uaddr, uint32_t val, uint32_t timeout,
 		WaitOnAddressLockOptions flags)
@@ -166,6 +167,7 @@ unfair_lock_wake(uint32_t *uaddr, uint32_t flags)
 {
 	return _dlock_wake(uaddr, flags | UL_UNFAIR_LOCK);
 }
+#endif
 
 } // namespace MLDB
 #endif /* __APPLE__ */

--- a/builtin/joined_dataset.cc
+++ b/builtin/joined_dataset.cc
@@ -1004,7 +1004,7 @@ JoinedDataset(MldbEngine * owner,
        left dataset to right dataset.
     */ 
     ProgressState joinState(100);
-    auto joinedProgress = [&](uint side, const ProgressState & state) {
+    auto joinedProgress = [&](uint32_t side, const ProgressState & state) {
         joinState = state.count / *state.total * 100 + 50 * side;
         return onProgress(joinState);
     };

--- a/core/analytics.cc
+++ b/core/analytics.cc
@@ -418,7 +418,7 @@ queryFromStatementExpr(const SelectStatement & stm,
        left dataset to right dataset.
     */ 
     ProgressState joinState(100);
-    auto joinedProgress = [&](uint side, const ProgressState & state) {
+    auto joinedProgress = [&](uint32_t side, const ProgressState & state) {
         joinState = (50 * state.count / *state.total) + (50 * side);
         //cerr << "joinState.count " << joinState.count << " joinState.total " << *joinState.total << endl;
         return onProgress(joinState);

--- a/ext/s2.mk
+++ b/ext/s2.mk
@@ -135,7 +135,7 @@ ifeq ($(toolchain),gcc10)
 S2_WARNING_OPTIONS:=-Wno-format-contains-nul -Wno-parentheses -Wno-unused-local-typedefs -Wno-attributes -Wno-comment -Wno-bool-compare -Wno-return-type -Wno-class-memaccess
 endif
 ifeq ($(toolchain),clang)
-S2_WARNING_OPTIONS:=-Wno-parentheses -Wno-absolute-value -Wno-unused-local-typedef -Wno-unused-const-variable -Wno-format -Wno-dynamic-class-memaccess -Wno-unused-private-field -Wno-range-loop-analysis
+S2_WARNING_OPTIONS:=-Wno-parentheses -Wno-absolute-value -Wno-unused-local-typedef -Wno-unused-const-variable -Wno-format -Wno-dynamic-class-memaccess -Wno-unused-private-field -Wno-range-loop-analysis -Wno-ambiguous-reversed-operator
 endif
 
 S2_COMPILE_OPTIONS:=-Imldb/ext/s2geometry/src -DS2_USE_EXACTFLOAT $(OPENSSL_INCLUDE_FLAGS)

--- a/ext/spdlog/include/spdlog/details/registry.h
+++ b/ext/spdlog/include/spdlog/details/registry.h
@@ -140,8 +140,8 @@ private:
             throw spdlog_ex("logger with name " + logger_name + " already exists");
         _loggers[logger->name()] = logger;
     }
-    registry_t<Mutex>() {}
-    registry_t<Mutex>(const registry_t<Mutex>&) = delete;
+    registry_t() {}
+    registry_t(const registry_t<Mutex>&) = delete;
     registry_t<Mutex>& operator=(const registry_t<Mutex>&) = delete;
     Mutex _mutex;
     std::unordered_map <std::string, std::shared_ptr<logger>> _loggers;

--- a/ext/sqlite/sqlite.mk
+++ b/ext/sqlite/sqlite.mk
@@ -12,7 +12,7 @@ LIBSQLITE_SOURCES := \
 LIBSQLITE_LINK := 
 	
 # gcc 4.7 and above require this
-$(eval $(call set_compile_option,sqlite3.c,-Wno-array-bounds -Wno-unused-const-variable))
+$(eval $(call set_compile_option,sqlite3.c,-Wno-array-bounds -Wno-unused-const-variable -Wno-misleading-indentation))
 
 $(eval $(call library,sqlite-mldb,$(LIBSQLITE_SOURCES),$(LIBSQLITE_LINK)))
 

--- a/ext/tinyxml2/tinyxml2.h
+++ b/ext/tinyxml2/tinyxml2.h
@@ -162,7 +162,7 @@ template <class T, int INIT>
 class DynArray
 {
 public:
-	DynArray< T, INIT >() 
+	DynArray() 
 	{
 		mem = pool;
 		allocated = INIT;

--- a/jml-build/arch/arm64.mk
+++ b/jml-build/arch/arm64.mk
@@ -1,7 +1,8 @@
 DEFAULTGXX:=arm64-linux-gnu-g++
 DEFAULTGCC:=arm64-linux-gnu-gcc
 toolchain?=clang
-ARCHFLAGS:=-fPIC -fno-omit-frame-pointer -I$(BUILD)/$(ARCH)/osdeps/usr/include --target=arm64-apple-darwin20
+ARM64_TARGET_OPTION:=$(if $(findstring clang,$(toolchain)),--target=arm64-apple-darwin20)
+ARCHFLAGS:=-fPIC -fno-omit-frame-pointer -I$(BUILD)/$(ARCH)/osdeps/usr/include $(ARM64_TARGET_OPTION)
 
 VALGRIND:=
 VALGRINDFLAGS:=

--- a/jml-build/clang.mk
+++ b/jml-build/clang.mk
@@ -24,7 +24,7 @@ NOTHING?=
 SPACE?=$(NOTHING) $(NOTHING)
 SANITIZERS:=$(subst $(COMMA),$(SPACE),$(sanitizers))
 
-CXXFLAGS ?= $(ARCHFLAGS) $(INCLUDE) $(CLANGXXWARNINGFLAGS) -pipe -ggdb $(foreach dir,$(LOCAL_INCLUDE_DIR),-I$(dir)) -std=c++17 $(foreach sanitizer,$(SANITIZERS),$(CLANG_SANITIZER_$(sanitizer)_FLAGS) )
+CXXFLAGS ?= $(ARCHFLAGS) $(INCLUDE) $(CLANGXXWARNINGFLAGS) -pipe -ggdb $(foreach dir,$(LOCAL_INCLUDE_DIR),-I$(dir)) -std=c++20 $(foreach sanitizer,$(SANITIZERS),$(CLANG_SANITIZER_$(sanitizer)_FLAGS) )
 CXXNODEBUGFLAGS := -O3 -DBOOST_DISABLE_ASSERTS -DNDEBUG 
 CXXDEBUGFLAGS := -O0 -g3
 

--- a/jml-build/gcc.mk
+++ b/jml-build/gcc.mk
@@ -12,7 +12,7 @@ BUILDING_WITH_GCC:=1
 
 GXXWARNINGFLAGS?=-Wall -Werror -Wno-sign-compare -Woverloaded-virtual -Wno-deprecated-declarations -Wno-deprecated -Winit-self -Wno-unused-but-set-variable -Wno-psabi -Wno-unknown-pragmas
 
-CXXFLAGS ?= $(ARCHFLAGS) $(INCLUDE) $(GXXWARNINGFLAGS)$(if $(GCC_VERSION_WARNING_FLAGS), $(GCC_VERSION_WARNING_FLAGS),) -pipe -ggdb $(foreach dir,$(LOCAL_INCLUDE_DIR),-I$(dir)) -std=c++1z
+CXXFLAGS ?= $(ARCHFLAGS) $(INCLUDE) $(GXXWARNINGFLAGS)$(if $(GCC_VERSION_WARNING_FLAGS), $(GCC_VERSION_WARNING_FLAGS),) -pipe -ggdb $(foreach dir,$(LOCAL_INCLUDE_DIR),-I$(dir)) $(CXX20_OPTION)
 CXXNODEBUGFLAGS := -O3 -DBOOST_DISABLE_ASSERTS -DNDEBUG 
 CXXDEBUGFLAGS := -O0 -g3
 

--- a/jml-build/gcc10.mk
+++ b/jml-build/gcc10.mk
@@ -2,6 +2,8 @@ GXX_VERSION_MAJOR:=10
 GCC?=gcc-10
 GXX?=g++-10
 
+CXX20_OPTION:=-std=c++20
+
 include $(JML_BUILD)/gcc.mk
 
 GCC_VERSION_WARNING_FLAGS:=-Wno-noexcept-type -Wno-address-of-packed-member -Wno-class-memaccess -flax-vector-conversions

--- a/jml-build/gcc11.mk
+++ b/jml-build/gcc11.mk
@@ -2,6 +2,8 @@ GXX_VERSION_MAJOR:=11
 GCC?=gcc-11
 GXX?=g++-11
 
+CXX20_OPTION:=-std=c++20
+
 include $(JML_BUILD)/gcc.mk
 
-GCC_VERSION_WARNING_FLAGS:=-Wno-noexcept-type
+GCC_VERSION_WARNING_FLAGS:=-Wno-noexcept-type -Wno-overloaded-virtual -Wno-class-memaccess -Wno-array-bounds

--- a/jml-build/gcc9.mk
+++ b/jml-build/gcc9.mk
@@ -2,6 +2,8 @@ GXX_VERSION_MAJOR:=9
 GCC?=gcc-9
 GXX?=g++-9
 
+CXX20_OPTION:=-std=c++2a
+
 include $(JML_BUILD)/gcc.mk
 
 GCC_VERSION_WARNING_FLAGS:=-Wno-noexcept-type -Wno-address-of-packed-member -Wno-class-memaccess -flax-vector-conversions

--- a/plugins/feature_gen/stats_table_procedure.cc
+++ b/plugins/feature_gen/stats_table_procedure.cc
@@ -79,7 +79,7 @@ StatsTable(const std::string & filename)
 
 const StatsTable::BucketCounts &
 StatsTable::
-increment(const CellValue & val, const vector<uint> & outcomes) {
+increment(const CellValue & val, const vector<uint32_t> & outcomes) {
     Utf8String key = val.toUtf8String();
     auto it = counts.find(key);
     if(it == counts.end()) {
@@ -261,7 +261,7 @@ run(const ProcedureRunConfig & run,
                 INFO_MSG(logger) << message;
             }
 
-            vector<uint> encodedLabels;
+            vector<uint32_t> encodedLabels;
             for(int lbl_idx=0; lbl_idx<runProcConf.outcomes.size(); lbl_idx++) {
                 CellValue outcome = extraVals.at(lbl_idx).getAtom();
                 encodedLabels.push_back( !outcome.empty() && outcome.isTrue() );
@@ -701,7 +701,7 @@ run(const ProcedureRunConfig & run,
                 INFO_MSG(logger) << message;
             }
 
-            vector<uint> encodedLabels;
+            vector<uint32_t> encodedLabels;
             for(int lbl_idx=0; lbl_idx < runProcConf.outcomes.size(); lbl_idx++) {
                 CellValue outcome = extraVals.at(lbl_idx).getAtom();
                 encodedLabels.push_back( !outcome.empty() && outcome.isTrue() );

--- a/plugins/feature_gen/stats_table_procedure.h
+++ b/plugins/feature_gen/stats_table_procedure.h
@@ -42,7 +42,7 @@ struct StatsTable {
     // .second : nb of occurence of each outcome
     typedef std::pair<int64_t, std::vector<int64_t>> BucketCounts;
     const BucketCounts & increment(const CellValue & val,
-                                   const std::vector<uint> & outcomes);
+                                   const std::vector<uint32_t> & outcomes);
     const BucketCounts & getCounts(const CellValue & val) const;
 
     void save(const std::string & filename) const;

--- a/plugins/jml/jml/boosted_stumps.cc
+++ b/plugins/jml/jml/boosted_stumps.cc
@@ -501,7 +501,7 @@ output_encoding() const
 void Boosted_Stumps::calc_sum_missing()
 {
     distribution<double> totals(label_count());
-    for (const_iterator it = begin();  it != end();  ++it) {
+    for (const_iterator it = begin(), end = this->end();  it != end;  ++it) {
         distribution<double> this_val(it->action.pred_missing.begin(),
                                       it->action.pred_missing.end());
         totals += this_val;

--- a/sql/builtin_dataset_functions.cc
+++ b/sql/builtin_dataset_functions.cc
@@ -130,12 +130,12 @@ BoundTableExpression merge(const SqlBindingScope & context,
 
     size_t steps = args.size();
     ProgressState joinState(100);
-    auto stepProgress = [&](uint step, const ProgressState & state) {
+    auto stepProgress = [&](uint32_t step, const ProgressState & state) {
         joinState = (100 / steps * state.count / *state.total) + (100 / steps * step);
         return onProgress(joinState);
     };
  
-    for (uint i = 0; i < steps; ++i) {
+    for (uint32_t i = 0; i < steps; ++i) {
         auto & arg = args[i];
         auto & combinedProgress = onProgress ? std::bind(stepProgress, i, _1) : onProgress;
     

--- a/types/string.cc
+++ b/types/string.cc
@@ -123,6 +123,20 @@ Utf8String::Utf8String(const char * in, bool check)
         doCheck();
 }
 
+Utf8String::Utf8String(const char8_t *start, size_t len, bool check)
+    :data_((const char *)start, len)
+{
+    if (check)
+        doCheck();
+}
+
+Utf8String::Utf8String(const char8_t * in, bool check)
+    : data_((const char *)in)
+{
+    if (check)
+        doCheck();
+}
+
 Utf8String::Utf8String(const std::basic_string<char32_t> & str)
 {
     // TODO: less inefficient way of doing it...

--- a/types/string.h
+++ b/types/string.h
@@ -71,6 +71,10 @@ public:
     
     Utf8String(const char *start, size_t len, bool check=true);
 
+    Utf8String(const char8_t * in, bool check=true) ;
+    
+    Utf8String(const char8_t *start, size_t len, bool check=true);
+
     Utf8String(const std::basic_string<char32_t> & str);
 
     Utf8String(const_iterator first, const const_iterator & last);

--- a/types/testing/string_test.cc
+++ b/types/testing/string_test.cc
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE( test_print_format )
 
    	Utf8String utf8(raw);
    	// Now iterate through the utf8 string
-   	for (Utf8String::const_iterator it = utf8.begin(); it != utf8.end(); ++it)
+   	for (Utf8String::const_iterator it = utf8.begin(), end =  utf8.end(); it != end;  ++it)
    	{
    		if (*it ==  L'é' || *it ==  L'ô')
    			numAccentedChars++;
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE( test_print_format )
   	utf8+=raw2;
   	numAccentedChars=0;
   	// Now iterate through the utf8 string
-   	for (Utf8String::const_iterator it = utf8.begin(); it != utf8.end(); ++it)
+   	for (Utf8String::const_iterator it = utf8.begin(), end = utf8.end(); it != end;  ++it)
    	{
    		if (*it ==  L'é' || *it ==  L'ô')
    			numAccentedChars++;

--- a/utils/fixed_point_accum.h
+++ b/utils/fixed_point_accum.h
@@ -10,6 +10,7 @@
 
 #include "mldb/compiler/compiler.h"
 #include "mldb/utils/float_traits.h"
+#include <limits>
 
 namespace ML {
 

--- a/utils/float_traits.h
+++ b/utils/float_traits.h
@@ -11,30 +11,30 @@
 
 #pragma once
 
-#include "mldb/compiler/compiler.h"
+#include <utility>
 
 namespace MLDB {
 
 template<typename F1, typename F2>
 struct float_traits {
-    typedef jml_typeof(F1() + F2()) return_type;
-    typedef jml_typeof(F1() / F2(1)) fraction_type;
+    using return_type = decltype(std::declval<F1>() + std::declval<F2>());
+    using fraction_type = decltype(std::declval<F1>() / std::declval<F2>());
 };
 
 template <typename F>
 struct float_traits<F, F> {
-    typedef F return_type;
-    typedef jml_typeof(F() / F(1)) fraction_type;
+    using return_type = F;
+    using fraction_type = decltype(std::declval<F>() / std::declval<F>());
 };
 
 template<typename F1, typename F2, typename F3>
 struct float_traits3 {
-    typedef jml_typeof(*((F1*)(0)) + (*((F2*)(0))) + (*((F3*)(0)))) return_type;
+    using return_type = decltype(std::declval<F1>() + std::declval<F2>() + std::declval<F3>());
 };
 
 template <typename F>
 struct float_traits3<F, F, F> {
-    typedef F return_type;
+    using return_type = F;
 };
 
 } // namespace MLDB

--- a/utils/interned_string.h
+++ b/utils/interned_string.h
@@ -52,6 +52,10 @@ struct InternedString {
         append(other.data(), other.length());
     }
 
+#pragma GCC diagnostic push
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     template<size_t OtherBytes>
     InternedString(InternedString<OtherBytes, Char> && other) noexcept
         : InternedString()
@@ -109,6 +113,7 @@ struct InternedString {
         }
         return *this;
     }
+#pragma GCC diagnostic pop
 
     ~InternedString() noexcept
     {


### PR DESCRIPTION
Switches MLDB's compilation to happen in C++20.  There are a few minor changes that need to be made, but mostly it just works.

This is to enable previously developed functionality that requires C++20 features like std::range and std::string_view to be incorporated without bringing in the shim libraries in the original branches.
